### PR TITLE
Add cross-platform CMake package contract

### DIFF
--- a/.github/workflows/package-contract.yml
+++ b/.github/workflows/package-contract.yml
@@ -1,0 +1,124 @@
+name: package-contract
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE*"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pdu-rpc-package-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu x64
+            os: ubuntu-latest
+          - name: Ubuntu ARM64
+            os: ubuntu-24.04-arm
+          - name: macOS
+            os: macos-15
+          - name: Windows x64
+            os: windows-2025
+
+    steps:
+      - name: Checkout with Registry submodule
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libboost-dev
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: brew install cmake boost
+
+      - name: Install Windows dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install boost-asio:x64-windows boost-beast:x64-windows
+
+      - name: Build and install Core-free Endpoint package
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF \
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --target hakoniwa_pdu_endpoint --parallel
+          cmake --install endpoint/build --config Release --prefix "${GITHUB_WORKSPACE}/endpoint-install"
+          echo "HAKO_PDU_ENDPOINT_ROOT=${GITHUB_WORKSPACE}/endpoint-install" >> "$GITHUB_ENV"
+
+      - name: Build and install Core-free Endpoint package on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build -A x64 `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows `
+            -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/endpoint-install" `
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF `
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --target hakoniwa_pdu_endpoint --parallel
+          cmake --install endpoint/build --config Release --prefix "$env:GITHUB_WORKSPACE/endpoint-install"
+          "HAKO_PDU_ENDPOINT_ROOT=$env:GITHUB_WORKSPACE/endpoint-install" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Doctor
+        run: python tools/hako.py doctor
+
+      - name: Configure dry-run
+        run: python tools/hako.py configure --dry-run
+
+      - name: Build
+        run: python tools/hako.py build
+
+      - name: Install
+        run: python tools/hako.py install
+
+      - name: Installed package consumer
+        run: python tools/hako.py package-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,62 @@
 cmake_minimum_required(VERSION 3.16)
 project(hakoniwa-pdu-rpc VERSION 0.1.0 LANGUAGES CXX)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-# Default install prefix for this project
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+# Preserve the historical Unix default while allowing native CMake defaults on
+# Windows. tools/hako.py always uses an explicit local install prefix.
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND NOT WIN32)
   set(CMAKE_INSTALL_PREFIX "/usr/local/hakoniwa" CACHE PATH "Install prefix" FORCE)
 endif()
 
-# Default install prefix for hakoniwa-pdu-endpoint (compatible with hakoniwa-pdu-bridge)
-set(HAKO_PDU_ENDPOINT_PREFIX "/usr/local/hakoniwa" CACHE PATH "Install prefix for hakoniwa-pdu-endpoint")
+# Prefer the installed Endpoint CMake package. A compatibility Find module is
+# retained for older Endpoint installations, but the public dependency target
+# is always normalized to hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint.
+set(HAKO_PDU_ENDPOINT_PREFIX "" CACHE PATH "Optional install prefix for hakoniwa-pdu-endpoint")
+if(HAKO_PDU_ENDPOINT_PREFIX STREQUAL "" AND DEFINED ENV{HAKO_PDU_ENDPOINT_PREFIX})
+  set(HAKO_PDU_ENDPOINT_PREFIX "$ENV{HAKO_PDU_ENDPOINT_PREFIX}" CACHE PATH
+      "Optional install prefix for hakoniwa-pdu-endpoint" FORCE)
+elseif(HAKO_PDU_ENDPOINT_PREFIX STREQUAL "" AND DEFINED ENV{HAKO_PDU_ENDPOINT_ROOT})
+  set(HAKO_PDU_ENDPOINT_PREFIX "$ENV{HAKO_PDU_ENDPOINT_ROOT}" CACHE PATH
+      "Optional install prefix for hakoniwa-pdu-endpoint" FORCE)
+endif()
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+set(_hako_endpoint_hints "")
+if(NOT HAKO_PDU_ENDPOINT_PREFIX STREQUAL "")
+  list(APPEND _hako_endpoint_hints
+    "${HAKO_PDU_ENDPOINT_PREFIX}"
+    "${HAKO_PDU_ENDPOINT_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/hakoniwa_pdu_endpoint"
+  )
+endif()
 
-# Option to build tests, ON by default
+find_package(hakoniwa_pdu_endpoint CONFIG QUIET HINTS ${_hako_endpoint_hints})
+if(NOT TARGET hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+  find_package(HakoniwaPduEndpoint REQUIRED)
+endif()
+if(NOT TARGET hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint)
+  message(FATAL_ERROR
+    "hakoniwa-pdu-endpoint dependency did not provide "
+    "hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint")
+endif()
+
 option(HAKO_PDU_RPC_BUILD_TESTS "Build tests for hakoniwa-pdu-rpc" ON)
 option(HAKO_PDU_RPC_BUILD_EXAMPLES "Build examples for hakoniwa-pdu-rpc" OFF)
 
-set(HAKONIWA_PDU_REGISTRY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/hakoniwa-pdu-registry")
-message(STATUS "HAKONIWA_PDU_REGISTRY_DIR: ${HAKONIWA_PDU_REGISTRY_DIR}"
-)
-# Add src subdirectory
+set(HAKONIWA_PDU_REGISTRY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/hakoniwa-pdu-registry" CACHE PATH
+    "Source checkout of hakoniwa-pdu-registry used for generated public PDU headers")
+if(NOT EXISTS "${HAKONIWA_PDU_REGISTRY_DIR}/pdu/types")
+  message(FATAL_ERROR
+    "hakoniwa-pdu-registry generated types were not found at "
+    "${HAKONIWA_PDU_REGISTRY_DIR}/pdu/types. Run: git submodule update --init --recursive")
+endif()
+
 add_subdirectory(src)
 
-# Enable and add test subdirectory if the option is ON
 if(HAKO_PDU_RPC_BUILD_TESTS)
   enable_testing()
   add_subdirectory(test)

--- a/cmake/FindHakoniwaPduEndpoint.cmake
+++ b/cmake/FindHakoniwaPduEndpoint.cmake
@@ -1,17 +1,29 @@
+# Compatibility finder for Endpoint installations that predate the exported
+# hakoniwa_pdu_endpoint CMake package. Modern builds should resolve the package
+# config first and never enter this module.
+
+set(_HAKO_ENDPOINT_PREFIX_HINTS "")
+foreach(_value
+    "${HAKO_PDU_ENDPOINT_PREFIX}"
+    "${HAKONIWA_PDU_ENDPOINT_ROOT}"
+    "${HAKONIWA_PDU_ENDPOINT_DIR}"
+    "$ENV{HAKO_PDU_ENDPOINT_PREFIX}"
+    "$ENV{HAKO_PDU_ENDPOINT_ROOT}")
+  if(NOT "${_value}" STREQUAL "")
+    list(APPEND _HAKO_ENDPOINT_PREFIX_HINTS "${_value}")
+  endif()
+endforeach()
+if(NOT WIN32)
+  list(APPEND _HAKO_ENDPOINT_PREFIX_HINTS /usr/local/hakoniwa /usr/local /usr /opt/homebrew)
+endif()
+
 if(HAKO_PDU_ENDPOINT_INCLUDE_DIR)
   set(HAKONIWA_PDU_ENDPOINT_INCLUDE_DIR "${HAKO_PDU_ENDPOINT_INCLUDE_DIR}")
 else()
   find_path(HAKONIWA_PDU_ENDPOINT_INCLUDE_DIR
     NAMES hakoniwa/pdu/endpoint.hpp
-    PATHS
-      ${HAKO_PDU_ENDPOINT_PREFIX}
-      ${HAKONIWA_PDU_ENDPOINT_ROOT}
-      ${HAKONIWA_PDU_ENDPOINT_DIR}
-      /usr/local
-      /usr
-      /opt/homebrew
-    PATH_SUFFIXES
-      include
+    HINTS ${_HAKO_ENDPOINT_PREFIX_HINTS}
+    PATH_SUFFIXES include
   )
 endif()
 
@@ -20,16 +32,8 @@ if(HAKO_PDU_ENDPOINT_LIBRARY)
 else()
   find_library(HAKONIWA_PDU_ENDPOINT_LIBRARY
     NAMES hakoniwa_pdu_endpoint
-    PATHS
-      ${HAKO_PDU_ENDPOINT_PREFIX}
-      ${HAKONIWA_PDU_ENDPOINT_ROOT}
-      ${HAKONIWA_PDU_ENDPOINT_DIR}
-      /usr/local
-      /usr
-      /opt/homebrew
-    PATH_SUFFIXES
-      lib
-      lib64
+    HINTS ${_HAKO_ENDPOINT_PREFIX_HINTS}
+    PATH_SUFFIXES lib lib64 bin
   )
 endif()
 
@@ -38,19 +42,16 @@ find_package_handle_standard_args(HakoniwaPduEndpoint
   REQUIRED_VARS HAKONIWA_PDU_ENDPOINT_INCLUDE_DIR HAKONIWA_PDU_ENDPOINT_LIBRARY
 )
 
-if(HakoniwaPduEndpoint_FOUND AND NOT TARGET hakoniwa_pdu_endpoint)
-  add_library(hakoniwa_pdu_endpoint UNKNOWN IMPORTED)
-  set(_hako_pdu_endpoint_include_dirs "${HAKONIWA_PDU_ENDPOINT_INCLUDE_DIR}")
-  if(HAKO_PDU_ENDPOINT_PREFIX)
-    list(APPEND _hako_pdu_endpoint_include_dirs
-      "${HAKO_PDU_ENDPOINT_PREFIX}/include"
-      "${HAKO_PDU_ENDPOINT_PREFIX}/include/hakoniwa"
-    )
-  endif()
-  set_target_properties(hakoniwa_pdu_endpoint PROPERTIES
+if(HakoniwaPduEndpoint_FOUND
+   AND NOT TARGET hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint)
+  add_library(hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint UNKNOWN IMPORTED)
+  set_target_properties(hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint PROPERTIES
     IMPORTED_LOCATION "${HAKONIWA_PDU_ENDPOINT_LIBRARY}"
-    INTERFACE_INCLUDE_DIRECTORIES "${_hako_pdu_endpoint_include_dirs}"
+    INTERFACE_INCLUDE_DIRECTORIES "${HAKONIWA_PDU_ENDPOINT_INCLUDE_DIR}"
   )
 endif()
 
-mark_as_advanced(HAKONIWA_PDU_ENDPOINT_INCLUDE_DIR HAKONIWA_PDU_ENDPOINT_LIBRARY)
+mark_as_advanced(
+  HAKONIWA_PDU_ENDPOINT_INCLUDE_DIR
+  HAKONIWA_PDU_ENDPOINT_LIBRARY
+)

--- a/cmake/hakoniwa_pdu_rpcConfig.cmake.in
+++ b/cmake/hakoniwa_pdu_rpcConfig.cmake.in
@@ -2,14 +2,23 @@
 
 include(CMakeFindDependencyMacro)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-
-find_package(hakoniwa_pdu_endpoint QUIET)
-if(NOT hakoniwa_pdu_endpoint_FOUND)
-  find_package(HakoniwaPduEndpoint REQUIRED)
+find_package(hakoniwa_pdu_endpoint CONFIG QUIET)
+if(NOT TARGET hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+  find_dependency(HakoniwaPduEndpoint)
 endif()
-find_dependency(nlohmann_json)
+
+if(NOT TARGET nlohmann_json::nlohmann_json)
+  find_dependency(nlohmann_json)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/hakoniwa_pdu_rpcTargets.cmake")
+
+if(TARGET hakoniwa_pdu_rpc::rpc
+   AND NOT TARGET hakoniwa_pdu_rpc::hakoniwa_pdu_rpc)
+  add_library(hakoniwa_pdu_rpc::hakoniwa_pdu_rpc INTERFACE IMPORTED)
+  set_property(TARGET hakoniwa_pdu_rpc::hakoniwa_pdu_rpc PROPERTY
+    INTERFACE_LINK_LIBRARIES hakoniwa_pdu_rpc::rpc)
+endif()
 
 check_required_components(hakoniwa_pdu_rpc)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,46 +1,44 @@
 include(FetchContent)
 
-option(HAKO_PDU_RPC_INSTALL_NLOHMANN_JSON "Install bundled nlohmann_json when installing hakoniwa-pdu-rpc" ON)
-if(HAKO_PDU_RPC_INSTALL_NLOHMANN_JSON)
-  set(JSON_Install ON CACHE INTERNAL "")
+if(NOT TARGET nlohmann_json::nlohmann_json)
+  option(HAKO_PDU_RPC_INSTALL_NLOHMANN_JSON "Install bundled nlohmann_json when installing hakoniwa-pdu-rpc" ON)
+  if(HAKO_PDU_RPC_INSTALL_NLOHMANN_JSON)
+    set(JSON_Install ON CACHE INTERNAL "")
+  endif()
+
+  FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.3
+  )
+  FetchContent_MakeAvailable(nlohmann_json)
 endif()
 
-FetchContent_Declare(
-  nlohmann_json
-  GIT_REPOSITORY https://github.com/nlohmann/json.git
-  GIT_TAG v3.11.3
-)
-
-FetchContent_MakeAvailable(nlohmann_json)
-
 add_library(hakoniwa_pdu_rpc
-    rpc_server_endpoint_impl.cpp
-    rpc_services_server.cpp
-    rpc_client_endpoint_impl.cpp
-    rpc_services_client.cpp
+  rpc_server_endpoint_impl.cpp
+  rpc_services_server.cpp
+  rpc_client_endpoint_impl.cpp
+  rpc_services_client.cpp
 )
 
+add_library(hakoniwa_pdu_rpc::rpc ALIAS hakoniwa_pdu_rpc)
 add_library(hakoniwa_pdu_rpc::hakoniwa_pdu_rpc ALIAS hakoniwa_pdu_rpc)
 
+target_compile_features(hakoniwa_pdu_rpc PUBLIC cxx_std_20)
 target_include_directories(hakoniwa_pdu_rpc
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     $<BUILD_INTERFACE:${HAKONIWA_PDU_REGISTRY_DIR}/pdu/types>
-    $<BUILD_INTERFACE:/usr/local/hakoniwa/include>
-    $<BUILD_INTERFACE:/usr/local/hakoniwa/include/hakoniwa>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-find_package(hakoniwa_pdu_endpoint REQUIRED)
-
-# Link our library against the endpoint library (installed)
 target_link_libraries(hakoniwa_pdu_rpc
   PUBLIC
-    hakoniwa_pdu_endpoint
+    hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint
     nlohmann_json::nlohmann_json
 )
 
-set_target_properties(hakoniwa_pdu_rpc PROPERTIES EXPORT_NAME hakoniwa_pdu_rpc)
+set_target_properties(hakoniwa_pdu_rpc PROPERTIES EXPORT_NAME rpc)
 
 install(
   TARGETS hakoniwa_pdu_rpc
@@ -54,4 +52,12 @@ install(
 install(
   DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../include/"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+install(
+  DIRECTORY "${HAKONIWA_PDU_REGISTRY_DIR}/pdu/types/"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp"
 )

--- a/test/package_consumer/CMakeLists.txt
+++ b/test/package_consumer/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+project(hakoniwa_pdu_rpc_package_consumer LANGUAGES CXX)
+
+find_package(hakoniwa_pdu_rpc CONFIG REQUIRED)
+
+add_executable(rpc_package_consumer main.cpp)
+target_compile_features(rpc_package_consumer PRIVATE cxx_std_20)
+target_link_libraries(rpc_package_consumer PRIVATE hakoniwa_pdu_rpc::rpc)
+
+add_executable(rpc_package_consumer_compat main.cpp)
+target_compile_features(rpc_package_consumer_compat PRIVATE cxx_std_20)
+target_link_libraries(rpc_package_consumer_compat PRIVATE hakoniwa_pdu_rpc::hakoniwa_pdu_rpc)

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -1,0 +1,10 @@
+#include "hakoniwa/pdu/rpc/rpc_services_client.hpp"
+
+int main()
+{
+    hakoniwa::pdu::rpc::RpcServicesClient client(
+        "package-consumer-node",
+        "PackageConsumer",
+        "unused-service-config.json");
+    return client.start_all_services() ? 1 : 0;
+}

--- a/tools/hako.py
+++ b/tools/hako.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+class HakoError(RuntimeError):
+    pass
+
+
+def host_platform() -> tuple[str, str]:
+    if sys.platform == "win32":
+        os_name = "windows"
+    elif sys.platform == "darwin":
+        os_name = "macos"
+    elif sys.platform.startswith("linux"):
+        os_name = "linux"
+    else:
+        os_name = sys.platform
+
+    machine = platform.machine().lower()
+    arch = {
+        "amd64": "x64",
+        "x86_64": "x64",
+        "arm64": "arm64",
+        "aarch64": "arm64",
+    }.get(machine, machine or "unknown")
+    return os_name, arch
+
+
+def endpoint_package_exists(root: Path) -> bool:
+    return any(
+        path.is_file()
+        for path in (
+            root / "lib" / "cmake" / "hakoniwa_pdu_endpoint" / "hakoniwa_pdu_endpointConfig.cmake",
+            root / "lib64" / "cmake" / "hakoniwa_pdu_endpoint" / "hakoniwa_pdu_endpointConfig.cmake",
+        )
+    )
+
+
+def find_endpoint_root(explicit: str, repo_root: Path) -> Path | None:
+    candidates = [
+        explicit,
+        os.environ.get("HAKO_PDU_ENDPOINT_ROOT", ""),
+        os.environ.get("HAKO_PDU_ENDPOINT_PREFIX", ""),
+        str(repo_root.parent / "hakoniwa-pdu-endpoint" / ".hako" / "install"),
+        str(repo_root.parent / "hakoniwa-pdu-endpoint" / "install"),
+        "/usr/local/hakoniwa",
+    ]
+    for value in candidates:
+        if not value:
+            continue
+        root = Path(value).expanduser().resolve()
+        if endpoint_package_exists(root):
+            return root
+    return None
+
+
+def find_vcpkg_root(explicit: str, repo_root: Path) -> Path | None:
+    candidates = [
+        explicit,
+        os.environ.get("VCPKG_ROOT", ""),
+        os.environ.get("VCPKG_INSTALLATION_ROOT", ""),
+        str(repo_root.parent / "vcpkg"),
+    ]
+    for value in candidates:
+        if not value:
+            continue
+        root = Path(value).expanduser().resolve()
+        if (root / "scripts" / "buildsystems" / "vcpkg.cmake").is_file():
+            return root
+    return None
+
+
+def run(command: Sequence[str], *, cwd: Path) -> None:
+    print(">", subprocess.list2cmdline(list(command)) if sys.platform == "win32" else " ".join(command))
+    subprocess.run(list(command), cwd=cwd, check=True)
+
+
+class Context:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.repo_root = Path(__file__).resolve().parents[1]
+        self.build_dir = (self.repo_root / args.build_dir).resolve()
+        self.install_dir = (self.repo_root / args.install_dir).resolve()
+        self.build_type = args.build_type
+        self.platform_name, self.arch = host_platform()
+        self.endpoint_root = find_endpoint_root(args.endpoint_root, self.repo_root)
+        self.vcpkg_root = find_vcpkg_root(args.vcpkg_root, self.repo_root)
+
+    @property
+    def vcpkg_triplet(self) -> str:
+        return f"{self.arch}-windows"
+
+    def common_cmake_args(self) -> list[str]:
+        args = [f"-DCMAKE_BUILD_TYPE={self.build_type}"]
+        if self.endpoint_root:
+            args.extend(
+                [
+                    f"-DHAKO_PDU_ENDPOINT_PREFIX={self.endpoint_root}",
+                    f"-DCMAKE_PREFIX_PATH={self.endpoint_root}",
+                ]
+            )
+        if self.platform_name == "windows" and self.vcpkg_root:
+            args.extend(
+                [
+                    f"-DCMAKE_TOOLCHAIN_FILE={self.vcpkg_root / 'scripts' / 'buildsystems' / 'vcpkg.cmake'}",
+                    f"-DVCPKG_TARGET_TRIPLET={self.vcpkg_triplet}",
+                ]
+            )
+        return args
+
+
+def doctor(ctx: Context) -> list[str]:
+    errors: list[str] = []
+    if not shutil.which("cmake"):
+        errors.append("CMake was not found on PATH")
+    if not shutil.which("git"):
+        errors.append("Git was not found on PATH")
+    if not (ctx.repo_root / "hakoniwa-pdu-registry" / "pdu" / "types").is_dir():
+        errors.append("Registry submodule is missing; run: git submodule update --init --recursive")
+    if not ctx.endpoint_root:
+        errors.append(
+            "installed hakoniwa-pdu-endpoint package was not found; set --endpoint-root or HAKO_PDU_ENDPOINT_ROOT"
+        )
+    if ctx.platform_name == "windows" and not ctx.vcpkg_root:
+        errors.append("vcpkg was not found; set --vcpkg-root or VCPKG_ROOT")
+    return errors
+
+
+def print_summary(ctx: Context, errors: list[str]) -> None:
+    print("Hakoniwa PDU RPC build configuration")
+    print(f"  Platform       : {ctx.platform_name}-{ctx.arch}")
+    print(f"  Build type     : {ctx.build_type}")
+    print(f"  Build directory: {ctx.build_dir}")
+    print(f"  Install prefix : {ctx.install_dir}")
+    print(f"  Endpoint root  : {ctx.endpoint_root or 'not resolved'}")
+    print("  Examples       : ON")
+    print("  Tests in build : OFF")
+    if ctx.platform_name == "windows":
+        print(f"  vcpkg          : {ctx.vcpkg_root or 'not resolved'}")
+    if errors:
+        print("\nDoctor errors:")
+        for error in errors:
+            print(f"  - {error}")
+
+
+def configure_command(ctx: Context, *, tests: bool) -> list[str]:
+    command = ["cmake", "-S", str(ctx.repo_root), "-B", str(ctx.build_dir)]
+    if ctx.platform_name == "windows" and not os.environ.get("CMAKE_GENERATOR"):
+        command.extend(["-A", "ARM64" if ctx.arch == "arm64" else "x64"])
+    command.extend(ctx.common_cmake_args())
+    command.extend(
+        [
+            f"-DHAKO_PDU_RPC_BUILD_TESTS={'ON' if tests else 'OFF'}",
+            "-DHAKO_PDU_RPC_BUILD_EXAMPLES=ON",
+        ]
+    )
+    return command
+
+
+def configure(ctx: Context, *, dry_run: bool = False, tests: bool = False) -> None:
+    command = configure_command(ctx, tests=tests)
+    if dry_run:
+        print(">", subprocess.list2cmdline(command) if sys.platform == "win32" else " ".join(command))
+        return
+    ctx.build_dir.mkdir(parents=True, exist_ok=True)
+    run(command, cwd=ctx.repo_root)
+
+
+def build(ctx: Context) -> None:
+    configure(ctx, tests=False)
+    run(
+        ["cmake", "--build", str(ctx.build_dir), "--config", ctx.build_type, "--parallel"],
+        cwd=ctx.repo_root,
+    )
+
+
+def install(ctx: Context) -> None:
+    if not (ctx.build_dir / "CMakeCache.txt").is_file():
+        build(ctx)
+    ctx.install_dir.mkdir(parents=True, exist_ok=True)
+    run(
+        [
+            "cmake",
+            "--install",
+            str(ctx.build_dir),
+            "--config",
+            ctx.build_type,
+            "--prefix",
+            str(ctx.install_dir),
+        ],
+        cwd=ctx.repo_root,
+    )
+
+
+def test(ctx: Context) -> None:
+    # Legacy RPC tests are intentionally a separate concern from the package
+    # contract. Reconfigure explicitly with tests enabled when this command is
+    # requested; cross-platform CI does not gate package-contract work on it.
+    configure(ctx, tests=True)
+    run(
+        ["cmake", "--build", str(ctx.build_dir), "--config", ctx.build_type, "--target", "hakoniwa_pdu_rpc_test", "--parallel"],
+        cwd=ctx.repo_root,
+    )
+    run(
+        ["ctest", "--test-dir", str(ctx.build_dir), "-C", ctx.build_type, "--output-on-failure"],
+        cwd=ctx.repo_root,
+    )
+
+
+def package_test(ctx: Context) -> None:
+    if not ctx.endpoint_root:
+        raise HakoError("Endpoint package root is required for package-test")
+    build(ctx)
+    install(ctx)
+
+    source_dir = ctx.repo_root / "test" / "package_consumer"
+    build_dir = ctx.repo_root / ".hako" / "package-consumer-build"
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+
+    command = [
+        "cmake",
+        "-S",
+        str(source_dir),
+        "-B",
+        str(build_dir),
+        f"-DCMAKE_BUILD_TYPE={ctx.build_type}",
+        f"-DCMAKE_PREFIX_PATH={ctx.install_dir};{ctx.endpoint_root}",
+    ]
+    if ctx.platform_name == "windows" and not os.environ.get("CMAKE_GENERATOR"):
+        command.extend(["-A", "ARM64" if ctx.arch == "arm64" else "x64"])
+    if ctx.platform_name == "windows" and ctx.vcpkg_root:
+        command.extend(
+            [
+                f"-DCMAKE_TOOLCHAIN_FILE={ctx.vcpkg_root / 'scripts' / 'buildsystems' / 'vcpkg.cmake'}",
+                f"-DVCPKG_TARGET_TRIPLET={ctx.vcpkg_triplet}",
+            ]
+        )
+    run(command, cwd=ctx.repo_root)
+    run(
+        ["cmake", "--build", str(build_dir), "--config", ctx.build_type, "--parallel"],
+        cwd=ctx.repo_root,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Hakoniwa PDU RPC cross-platform build driver")
+    parser.add_argument("command", choices=["doctor", "configure", "build", "test", "install", "package-test"])
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--install-dir", default=".hako/install")
+    parser.add_argument("--build-type", default="Release")
+    parser.add_argument("--endpoint-root", default="")
+    parser.add_argument("--vcpkg-root", default="")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    ctx = Context(args)
+    errors = doctor(ctx)
+    print_summary(ctx, errors)
+    if args.command == "doctor":
+        return 1 if errors else 0
+    if errors:
+        raise HakoError("doctor found blocking prerequisites")
+
+    if args.command == "configure":
+        configure(ctx, dry_run=args.dry_run, tests=False)
+    elif args.command == "build":
+        build(ctx)
+    elif args.command == "test":
+        test(ctx)
+    elif args.command == "install":
+        install(ctx)
+    elif args.command == "package-test":
+        package_test(ctx)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except HakoError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: command failed with exit code {exc.returncode}", file=sys.stderr)
+        raise SystemExit(exc.returncode or 1)


### PR DESCRIPTION
## Scope

This PR intentionally focuses on the build/package boundary only.

The RPC production implementation is unchanged from `main` (`b72db0db...`), which is the revision already validated by `hakoniwa-conductor-light` across Ubuntu x64, Ubuntu ARM64, macOS, and Windows x64 with build/test/smoke CI.

Legacy PDU-RPC tests are **not** a gate for this PR. They will be reviewed separately for test intent, timing assumptions, and compatibility with the current timeout/cancel contract.

## What this PR validates

- `python tools/hako.py doctor`
- `python tools/hako.py configure --dry-run`
- `python tools/hako.py build`
- local install/export
- external `find_package(hakoniwa_pdu_rpc CONFIG REQUIRED)` consumer
- Ubuntu x64
- Ubuntu ARM64
- macOS
- Windows x64

The managed build explicitly uses `HAKO_PDU_RPC_BUILD_TESTS=OFF`; `python tools/hako.py test` remains available as a separate diagnostic path but is not executed by package-contract CI.

## CMake contract

- prefer the installed `hakoniwa-pdu-endpoint` package target
- normalize the legacy Endpoint finder to `hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint`
- remove hard-coded `/usr/local/hakoniwa/include*` build-interface paths
- export `hakoniwa_pdu_rpc::rpc`
- retain `hakoniwa_pdu_rpc::hakoniwa_pdu_rpc` compatibility target
- install generated Registry headers needed by the public RPC headers
- validate the installed package from a separate downstream CMake project

## Follow-up

After this package-contract PR is green, audit the existing RPC tests separately:

1. confirm each test still represents a valid requirement;
2. fix or remove tests whose assumptions are obsolete;
3. when a valid test still fails because of timing/platform behavior, open a focused issue and address it independently rather than changing production RPC semantics inside this CMake PR.