### PR TITLE
Phase 1: add basic RPC contract tests

### DIFF
--- a/.github/workflows/rpc-basic-tests.yml
+++ b/.github/workflows/rpc-basic-tests.yml
@@ -1,0 +1,104 @@
+name: rpc-basic-tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pdu-rpc-basic-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu x64
+            os: ubuntu-latest
+          - name: Ubuntu ARM64
+            os: ubuntu-24.04-arm
+          - name: macOS
+            os: macos-15
+          - name: Windows x64
+            os: windows-2025
+
+    steps:
+      - name: Checkout with Registry submodule
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libboost-dev
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: brew install cmake boost
+
+      - name: Install Windows dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install boost-asio:x64-windows boost-beast:x64-windows
+
+      - name: Build and install Core-free Endpoint package
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF \
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --target hakoniwa_pdu_endpoint --parallel
+          cmake --install endpoint/build --config Release --prefix "${GITHUB_WORKSPACE}/endpoint-install"
+          echo "HAKO_PDU_ENDPOINT_ROOT=${GITHUB_WORKSPACE}/endpoint-install" >> "$GITHUB_ENV"
+
+      - name: Build and install Core-free Endpoint package on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build -A x64 `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows `
+            -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/endpoint-install" `
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF `
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --target hakoniwa_pdu_endpoint --parallel
+          cmake --install endpoint/build --config Release --prefix "$env:GITHUB_WORKSPACE/endpoint-install"
+          "HAKO_PDU_ENDPOINT_ROOT=$env:GITHUB_WORKSPACE/endpoint-install" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Doctor
+        run: python tools/hako.py doctor
+
+      - name: Phase 1 basic RPC tests
+        run: python tools/hako.py test-basic

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,38 @@
-find_package(GTest REQUIRED)
+include(FetchContent)
 
+find_package(GTest CONFIG QUIET)
+if(NOT TARGET GTest::gtest_main)
+  if(WIN32)
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  endif()
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.15.2
+  )
+  FetchContent_MakeAvailable(googletest)
+endif()
+
+# Phase 1: focused, cross-platform-safe RPC contract tests.
+# These cover only basic round-trip and endpoint reuse. Timeout/cancel and
+# timing-sensitive scenarios remain in the legacy target until their contracts
+# are reviewed in later phases.
+add_executable(hakoniwa_pdu_rpc_basic_test
+  rpc_basic_contract_test.cpp
+)
+target_link_libraries(hakoniwa_pdu_rpc_basic_test
+  PRIVATE
+    hakoniwa_pdu_rpc::rpc
+    GTest::gtest_main
+)
+add_test(NAME hakoniwa_pdu_rpc_basic_test COMMAND hakoniwa_pdu_rpc_basic_test)
+set_tests_properties(hakoniwa_pdu_rpc_basic_test PROPERTIES
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  TIMEOUT 30
+)
+
+# Legacy aggregate tests are intentionally preserved unchanged for audit.
+# They are not part of the phase-1 cross-platform gate.
 add_executable(hakoniwa_pdu_rpc_test
     hakoniwa_pdu_rpc_test.cpp
     rpc_timeout_cancel_semantics_test.cpp

--- a/test/rpc_basic_contract_test.cpp
+++ b/test/rpc_basic_contract_test.cpp
@@ -1,0 +1,202 @@
+#include <gtest/gtest.h>
+
+#include "hakoniwa/pdu/endpoint_container.hpp"
+#include "hakoniwa/pdu/rpc/rpc_service_helper.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_client.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_server.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsRequestPacket.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsResponsePacket.hpp"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace {
+
+using namespace std::chrono_literals;
+using hakoniwa::pdu::rpc::ClientEventType;
+using hakoniwa::pdu::rpc::RpcRequest;
+using hakoniwa::pdu::rpc::RpcResponse;
+using hakoniwa::pdu::rpc::RpcServicesClient;
+using hakoniwa::pdu::rpc::RpcServicesServer;
+using hakoniwa::pdu::rpc::ServerEventType;
+
+constexpr const char* kConfigPath = "configs/service_config.json";
+constexpr const char* kEndpointConfigPath = "configs/endpoints.json";
+constexpr const char* kServerNodeId = "server_node";
+constexpr const char* kClientNodeId = "client_node";
+constexpr const char* kClientName = "TestClient";
+constexpr const char* kServiceName = "Service/Add";
+
+class RpcRuntime {
+public:
+    RpcRuntime()
+        : server_endpoint_(std::make_shared<hakoniwa::pdu::EndpointContainer>(
+              kServerNodeId, kEndpointConfigPath))
+        , client_endpoint_(std::make_shared<hakoniwa::pdu::EndpointContainer>(
+              kClientNodeId, kEndpointConfigPath))
+        , server_(kServerNodeId, "RpcServerEndpointImpl", kConfigPath, 1000)
+        , client_(kClientNodeId, kClientName, kConfigPath, "RpcClientEndpointImpl", 1000)
+    {
+    }
+
+    ~RpcRuntime()
+    {
+        stop();
+    }
+
+    bool start()
+    {
+        if (server_endpoint_->initialize() != HAKO_PDU_ERR_OK ||
+            client_endpoint_->initialize() != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        if (!server_.initialize_services(server_endpoint_) ||
+            !client_.initialize_services(client_endpoint_)) {
+            return false;
+        }
+        if (server_endpoint_->start_all() != HAKO_PDU_ERR_OK ||
+            client_endpoint_->start_all() != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        if (!server_.start_all_services() || !client_.start_all_services()) {
+            return false;
+        }
+
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        while (!server_endpoint_->is_running_all() || !client_endpoint_->is_running_all()) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return false;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+        started_ = true;
+        return true;
+    }
+
+    void stop()
+    {
+        if (!started_) {
+            return;
+        }
+        server_endpoint_->stop_all();
+        client_endpoint_->stop_all();
+        server_.stop_all_services();
+        client_.stop_all_services();
+        server_.clear_all_instances();
+        client_.clear_all_instances();
+        started_ = false;
+    }
+
+    ServerEventType wait_server_event(RpcRequest& request, std::chrono::milliseconds timeout = 2s)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        for (;;) {
+            const auto event = server_.poll(request);
+            if (event != ServerEventType::NONE) {
+                return event;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return ServerEventType::NONE;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    ClientEventType wait_client_event(
+        std::string& service_name,
+        RpcResponse& response,
+        std::chrono::milliseconds timeout = 2s)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        for (;;) {
+            const auto event = client_.poll(service_name, response);
+            if (event != ClientEventType::NONE) {
+                return event;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return ClientEventType::NONE;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    RpcServicesServer& server() { return server_; }
+    RpcServicesClient& client() { return client_; }
+
+private:
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> server_endpoint_;
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> client_endpoint_;
+    RpcServicesServer server_;
+    RpcServicesClient client_;
+    bool started_ = false;
+};
+
+bool execute_add(RpcRuntime& runtime, long long a, long long b, long long expected)
+{
+    HakoRpcServiceServerTemplateType(AddTwoInts) service;
+
+    HakoCpp_AddTwoIntsRequest request_body{};
+    request_body.a = a;
+    request_body.b = b;
+    if (!service.call(runtime.client(), kServiceName, request_body, 1'000'000)) {
+        return false;
+    }
+
+    RpcRequest request;
+    if (runtime.wait_server_event(request) != ServerEventType::REQUEST_IN) {
+        return false;
+    }
+
+    HakoCpp_AddTwoIntsRequest parsed_request{};
+    if (!service.get_request_body(request, parsed_request)) {
+        return false;
+    }
+    if (parsed_request.a != a || parsed_request.b != b) {
+        return false;
+    }
+
+    HakoCpp_AddTwoIntsResponse response_body{};
+    response_body.sum = parsed_request.a + parsed_request.b;
+    if (!service.reply(
+            runtime.server(),
+            request,
+            hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE,
+            hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_OK,
+            response_body)) {
+        return false;
+    }
+
+    std::string service_name;
+    RpcResponse response;
+    if (runtime.wait_client_event(service_name, response) != ClientEventType::RESPONSE_IN) {
+        return false;
+    }
+    if (service_name != kServiceName) {
+        return false;
+    }
+
+    HakoCpp_AddTwoIntsResponse parsed_response{};
+    if (!service.get_response_body(response, parsed_response)) {
+        return false;
+    }
+    return parsed_response.sum == expected;
+}
+
+TEST(RpcBasicContractTest, BasicRoundTrip)
+{
+    RpcRuntime runtime;
+    ASSERT_TRUE(runtime.start());
+    EXPECT_TRUE(execute_add(runtime, 5, 7, 12));
+}
+
+TEST(RpcBasicContractTest, ConsecutiveCallsReuseEndpoint)
+{
+    RpcRuntime runtime;
+    ASSERT_TRUE(runtime.start());
+    ASSERT_TRUE(execute_add(runtime, 10, 20, 30));
+    EXPECT_TRUE(execute_add(runtime, 15, 25, 40));
+}
+
+} // namespace

--- a/tools/hako.py
+++ b/tools/hako.py
@@ -142,7 +142,6 @@ def print_summary(ctx: Context, errors: list[str]) -> None:
     print(f"  Install prefix : {ctx.install_dir}")
     print(f"  Endpoint root  : {ctx.endpoint_root or 'not resolved'}")
     print("  Examples       : ON")
-    print("  Tests in build : OFF")
     if ctx.platform_name == "windows":
         print(f"  vcpkg          : {ctx.vcpkg_root or 'not resolved'}")
     if errors:
@@ -200,17 +199,46 @@ def install(ctx: Context) -> None:
     )
 
 
+def test_basic(ctx: Context) -> None:
+    configure(ctx, tests=True)
+    run(
+        [
+            "cmake",
+            "--build",
+            str(ctx.build_dir),
+            "--config",
+            ctx.build_type,
+            "--target",
+            "hakoniwa_pdu_rpc_basic_test",
+            "--parallel",
+        ],
+        cwd=ctx.repo_root,
+    )
+    run(
+        [
+            "ctest",
+            "--test-dir",
+            str(ctx.build_dir),
+            "-C",
+            ctx.build_type,
+            "--output-on-failure",
+            "-R",
+            "^hakoniwa_pdu_rpc_basic_test$",
+        ],
+        cwd=ctx.repo_root,
+    )
+
+
 def test(ctx: Context) -> None:
-    # Legacy RPC tests are intentionally a separate concern from the package
-    # contract. Reconfigure explicitly with tests enabled when this command is
-    # requested; cross-platform CI does not gate package-contract work on it.
+    # Legacy aggregate tests remain available for audit but are not the phase-1
+    # cross-platform gate.
     configure(ctx, tests=True)
     run(
         ["cmake", "--build", str(ctx.build_dir), "--config", ctx.build_type, "--target", "hakoniwa_pdu_rpc_test", "--parallel"],
         cwd=ctx.repo_root,
     )
     run(
-        ["ctest", "--test-dir", str(ctx.build_dir), "-C", ctx.build_type, "--output-on-failure"],
+        ["ctest", "--test-dir", str(ctx.build_dir), "-C", ctx.build_type, "--output-on-failure", "-R", "^hakoniwa_pdu_rpc_test$"],
         cwd=ctx.repo_root,
     )
 
@@ -253,7 +281,10 @@ def package_test(ctx: Context) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Hakoniwa PDU RPC cross-platform build driver")
-    parser.add_argument("command", choices=["doctor", "configure", "build", "test", "install", "package-test"])
+    parser.add_argument(
+        "command",
+        choices=["doctor", "configure", "build", "test-basic", "test", "install", "package-test"],
+    )
     parser.add_argument("--build-dir", default="build")
     parser.add_argument("--install-dir", default=".hako/install")
     parser.add_argument("--build-type", default="Release")
@@ -274,6 +305,8 @@ def main() -> int:
         configure(ctx, dry_run=args.dry_run, tests=False)
     elif args.command == "build":
         build(ctx)
+    elif args.command == "test-basic":
+        test_basic(ctx)
     elif args.command == "test":
         test(ctx)
     elif args.command == "install":


### PR DESCRIPTION
## Phase 1 scope

Start the RPC test cleanup in the smallest safe slice described by `docs/test-contract.md`.

This PR adds only the two already-approved basic invariants:

1. basic request/response round trip;
2. endpoint reuse across consecutive completed calls.

It does **not** change production RPC code and does **not** modify the legacy timeout/cancel tests.

## Changes

- add `rpc_basic_contract_test.cpp` with:
  - `BasicRoundTrip`
  - `ConsecutiveCallsReuseEndpoint`
- add a dedicated `hakoniwa_pdu_rpc_basic_test` CMake target;
- keep the legacy aggregate test target unchanged for later audit;
- add `python tools/hako.py test-basic` so this phase can be run independently;
- add a separate 4-platform CI matrix for only this basic test target:
  - Ubuntu x64
  - Ubuntu ARM64
  - macOS
  - Windows x64

## Deliberately deferred

- infinite-wait timing behavior;
- timeout notification cleanup;
- explicit cancel lifecycle;
- normal-response/cancel race;
- legacy test removal/renaming.

Those will be separate PRs after each requirement/test pattern is reviewed.

## Proposed follow-up phases

- Phase 2: infinite-wait contract and timing assumptions
- Phase 3: timeout + explicit cancel lifecycle
- Phase 4: normal-response/cancel race using the Conductor Light pattern
- Phase 5: retire/rename redundant legacy tests and converge the default `hako.py test` command

The rule remains: test failures are reviewed against the documented contract before production RPC behavior is changed.