### PR TITLE
Phase 2: validate infinite-wait RPC contract

### DIFF
--- a/.github/workflows/rpc-infinite-wait-tests.yml
+++ b/.github/workflows/rpc-infinite-wait-tests.yml
@@ -1,0 +1,104 @@
+name: rpc-infinite-wait-tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pdu-rpc-infinite-wait-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu x64
+            os: ubuntu-latest
+          - name: Ubuntu ARM64
+            os: ubuntu-24.04-arm
+          - name: macOS
+            os: macos-15
+          - name: Windows x64
+            os: windows-2025
+
+    steps:
+      - name: Checkout with Registry submodule
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libboost-dev
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: brew install cmake boost
+
+      - name: Install Windows dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install boost-asio:x64-windows boost-beast:x64-windows
+
+      - name: Build and install Core-free Endpoint package
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF \
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --target hakoniwa_pdu_endpoint --parallel
+          cmake --install endpoint/build --config Release --prefix "${GITHUB_WORKSPACE}/endpoint-install"
+          echo "HAKO_PDU_ENDPOINT_ROOT=${GITHUB_WORKSPACE}/endpoint-install" >> "$GITHUB_ENV"
+
+      - name: Build and install Core-free Endpoint package on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build -A x64 `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows `
+            -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/endpoint-install" `
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF `
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --target hakoniwa_pdu_endpoint --parallel
+          cmake --install endpoint/build --config Release --prefix "$env:GITHUB_WORKSPACE/endpoint-install"
+          "HAKO_PDU_ENDPOINT_ROOT=$env:GITHUB_WORKSPACE/endpoint-install" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Doctor
+        run: python tools/hako.py doctor
+
+      - name: Phase 2 infinite-wait RPC test
+        run: python tools/hako.py test-infinite-wait

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,9 +14,6 @@ if(NOT TARGET GTest::gtest_main)
 endif()
 
 # Phase 1: focused, cross-platform-safe RPC contract tests.
-# These cover only basic round-trip and endpoint reuse. Timeout/cancel and
-# timing-sensitive scenarios remain in the legacy target until their contracts
-# are reviewed in later phases.
 add_executable(hakoniwa_pdu_rpc_basic_test
   rpc_basic_contract_test.cpp
 )
@@ -31,8 +28,24 @@ set_tests_properties(hakoniwa_pdu_rpc_basic_test PROPERTIES
   TIMEOUT 30
 )
 
+# Phase 2: timeout == 0 means the in-flight RPC has no timeout deadline.
+# Keep this separate from timeout/cancel semantics so failures have one meaning.
+add_executable(hakoniwa_pdu_rpc_infinite_wait_test
+  rpc_infinite_wait_contract_test.cpp
+)
+target_link_libraries(hakoniwa_pdu_rpc_infinite_wait_test
+  PRIVATE
+    hakoniwa_pdu_rpc::rpc
+    GTest::gtest_main
+)
+add_test(NAME hakoniwa_pdu_rpc_infinite_wait_test COMMAND hakoniwa_pdu_rpc_infinite_wait_test)
+set_tests_properties(hakoniwa_pdu_rpc_infinite_wait_test PROPERTIES
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  TIMEOUT 30
+)
+
 # Legacy aggregate tests are intentionally preserved unchanged for audit.
-# They are not part of the phase-1 cross-platform gate.
+# They are not part of the phased cross-platform gates.
 add_executable(hakoniwa_pdu_rpc_test
     hakoniwa_pdu_rpc_test.cpp
     rpc_timeout_cancel_semantics_test.cpp

--- a/test/rpc_infinite_wait_contract_test.cpp
+++ b/test/rpc_infinite_wait_contract_test.cpp
@@ -1,0 +1,186 @@
+#include <gtest/gtest.h>
+
+#include "hakoniwa/pdu/endpoint_container.hpp"
+#include "hakoniwa/pdu/rpc/rpc_service_helper.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_client.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_server.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsRequestPacket.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsResponsePacket.hpp"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace {
+
+using namespace std::chrono_literals;
+using hakoniwa::pdu::rpc::ClientEventType;
+using hakoniwa::pdu::rpc::RpcRequest;
+using hakoniwa::pdu::rpc::RpcResponse;
+using hakoniwa::pdu::rpc::RpcServicesClient;
+using hakoniwa::pdu::rpc::RpcServicesServer;
+using hakoniwa::pdu::rpc::ServerEventType;
+
+constexpr const char* kConfigPath = "configs/service_config.json";
+constexpr const char* kEndpointConfigPath = "configs/endpoints.json";
+constexpr const char* kServerNodeId = "server_node";
+constexpr const char* kClientNodeId = "client_node";
+constexpr const char* kClientName = "TestClient";
+constexpr const char* kServiceName = "Service/Add";
+
+class RpcRuntime {
+public:
+    RpcRuntime()
+        : server_endpoint_(std::make_shared<hakoniwa::pdu::EndpointContainer>(
+              kServerNodeId, kEndpointConfigPath))
+        , client_endpoint_(std::make_shared<hakoniwa::pdu::EndpointContainer>(
+              kClientNodeId, kEndpointConfigPath))
+        , server_(kServerNodeId, "RpcServerEndpointImpl", kConfigPath, 1000)
+        , client_(kClientNodeId, kClientName, kConfigPath, "RpcClientEndpointImpl", 1000)
+    {
+    }
+
+    ~RpcRuntime()
+    {
+        stop();
+    }
+
+    bool start()
+    {
+        if (server_endpoint_->initialize() != HAKO_PDU_ERR_OK ||
+            client_endpoint_->initialize() != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        if (!server_.initialize_services(server_endpoint_) ||
+            !client_.initialize_services(client_endpoint_)) {
+            return false;
+        }
+        if (server_endpoint_->start_all() != HAKO_PDU_ERR_OK ||
+            client_endpoint_->start_all() != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        if (!server_.start_all_services() || !client_.start_all_services()) {
+            return false;
+        }
+
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        while (!server_endpoint_->is_running_all() || !client_endpoint_->is_running_all()) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return false;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+        started_ = true;
+        return true;
+    }
+
+    void stop()
+    {
+        if (!started_) {
+            return;
+        }
+        server_endpoint_->stop_all();
+        client_endpoint_->stop_all();
+        server_.stop_all_services();
+        client_.stop_all_services();
+        server_.clear_all_instances();
+        client_.clear_all_instances();
+        started_ = false;
+    }
+
+    ServerEventType wait_server_event(RpcRequest& request, std::chrono::milliseconds timeout = 2s)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        for (;;) {
+            const auto event = server_.poll(request);
+            if (event != ServerEventType::NONE) {
+                return event;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return ServerEventType::NONE;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    ClientEventType wait_client_event(
+        std::string& service_name,
+        RpcResponse& response,
+        std::chrono::milliseconds timeout = 2s)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        for (;;) {
+            const auto event = client_.poll(service_name, response);
+            if (event != ClientEventType::NONE) {
+                return event;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return ClientEventType::NONE;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    RpcServicesServer& server() { return server_; }
+    RpcServicesClient& client() { return client_; }
+
+private:
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> server_endpoint_;
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> client_endpoint_;
+    RpcServicesServer server_;
+    RpcServicesClient client_;
+    bool started_ = false;
+};
+
+TEST(RpcInfiniteWaitContractTest, TimeoutZeroDoesNotEmitTimeoutBeforeReply)
+{
+    RpcRuntime runtime;
+    ASSERT_TRUE(runtime.start());
+
+    HakoRpcServiceServerTemplateType(AddTwoInts) service;
+    HakoCpp_AddTwoIntsRequest request_body{};
+    request_body.a = 99;
+    request_body.b = 1;
+
+    // Contract under test: timeout == 0 means no RPC timeout deadline.
+    ASSERT_TRUE(service.call(runtime.client(), kServiceName, request_body, 0));
+
+    RpcRequest request;
+    ASSERT_EQ(runtime.wait_server_event(request), ServerEventType::REQUEST_IN);
+
+    // Keep the request deliberately unresolved and poll repeatedly. We are not
+    // testing a 200 ms wall-clock threshold; we are testing that timeout == 0
+    // never produces RESPONSE_TIMEOUT while the request remains in flight.
+    for (int i = 0; i < 100; ++i) {
+        std::string service_name;
+        RpcResponse response;
+        EXPECT_EQ(runtime.client().poll(service_name, response), ClientEventType::NONE);
+        std::this_thread::sleep_for(1ms);
+    }
+
+    HakoCpp_AddTwoIntsRequest parsed_request{};
+    ASSERT_TRUE(service.get_request_body(request, parsed_request));
+    ASSERT_EQ(parsed_request.a, 99);
+    ASSERT_EQ(parsed_request.b, 1);
+
+    HakoCpp_AddTwoIntsResponse response_body{};
+    response_body.sum = parsed_request.a + parsed_request.b;
+    ASSERT_TRUE(service.reply(
+        runtime.server(),
+        request,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_OK,
+        response_body));
+
+    std::string service_name;
+    RpcResponse response;
+    ASSERT_EQ(runtime.wait_client_event(service_name, response), ClientEventType::RESPONSE_IN);
+    ASSERT_EQ(service_name, kServiceName);
+
+    HakoCpp_AddTwoIntsResponse parsed_response{};
+    ASSERT_TRUE(service.get_response_body(response, parsed_response));
+    EXPECT_EQ(parsed_response.sum, 100);
+}
+
+} // namespace

--- a/tools/hako.py
+++ b/tools/hako.py
@@ -199,7 +199,7 @@ def install(ctx: Context) -> None:
     )
 
 
-def test_basic(ctx: Context) -> None:
+def run_test_target(ctx: Context, target: str, ctest_name: str) -> None:
     configure(ctx, tests=True)
     run(
         [
@@ -209,7 +209,7 @@ def test_basic(ctx: Context) -> None:
             "--config",
             ctx.build_type,
             "--target",
-            "hakoniwa_pdu_rpc_basic_test",
+            target,
             "--parallel",
         ],
         cwd=ctx.repo_root,
@@ -223,24 +223,24 @@ def test_basic(ctx: Context) -> None:
             ctx.build_type,
             "--output-on-failure",
             "-R",
-            "^hakoniwa_pdu_rpc_basic_test$",
+            f"^{ctest_name}$",
         ],
         cwd=ctx.repo_root,
     )
 
 
+def test_basic(ctx: Context) -> None:
+    run_test_target(ctx, "hakoniwa_pdu_rpc_basic_test", "hakoniwa_pdu_rpc_basic_test")
+
+
+def test_infinite_wait(ctx: Context) -> None:
+    run_test_target(ctx, "hakoniwa_pdu_rpc_infinite_wait_test", "hakoniwa_pdu_rpc_infinite_wait_test")
+
+
 def test(ctx: Context) -> None:
-    # Legacy aggregate tests remain available for audit but are not the phase-1
-    # cross-platform gate.
-    configure(ctx, tests=True)
-    run(
-        ["cmake", "--build", str(ctx.build_dir), "--config", ctx.build_type, "--target", "hakoniwa_pdu_rpc_test", "--parallel"],
-        cwd=ctx.repo_root,
-    )
-    run(
-        ["ctest", "--test-dir", str(ctx.build_dir), "-C", ctx.build_type, "--output-on-failure", "-R", "^hakoniwa_pdu_rpc_test$"],
-        cwd=ctx.repo_root,
-    )
+    # Legacy aggregate tests remain available for audit but are not the phased
+    # cross-platform gates.
+    run_test_target(ctx, "hakoniwa_pdu_rpc_test", "hakoniwa_pdu_rpc_test")
 
 
 def package_test(ctx: Context) -> None:
@@ -283,7 +283,16 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Hakoniwa PDU RPC cross-platform build driver")
     parser.add_argument(
         "command",
-        choices=["doctor", "configure", "build", "test-basic", "test", "install", "package-test"],
+        choices=[
+            "doctor",
+            "configure",
+            "build",
+            "test-basic",
+            "test-infinite-wait",
+            "test",
+            "install",
+            "package-test",
+        ],
     )
     parser.add_argument("--build-dir", default="build")
     parser.add_argument("--install-dir", default=".hako/install")
@@ -307,6 +316,8 @@ def main() -> int:
         build(ctx)
     elif args.command == "test-basic":
         test_basic(ctx)
+    elif args.command == "test-infinite-wait":
+        test_infinite_wait(ctx)
     elif args.command == "test":
         test(ctx)
     elif args.command == "install":


### PR DESCRIPTION
## Phase 2 scope

Validate the `timeout == 0` contract independently from timeout/cancel behavior.

The requirement is intentionally narrow:

```text
RPC call(timeout = 0)
  -> request remains in flight without RESPONSE_TIMEOUT
  -> server eventually replies
  -> client receives RESPONSE_IN
```

This PR does **not** change production RPC code and does **not** modify the legacy timeout/cancel tests.

## Why this test pattern differs from the legacy test

The legacy `RpcCallInfiniteWaitTest` uses a server thread with a fixed 200 ms processing delay and a 400 ms polling window. The requirement itself is valid, but those numbers are incidental timing assumptions.

The new focused test instead:

1. sends a request with `timeout == 0`;
2. confirms the server received it;
3. deliberately leaves the request unresolved while polling the client repeatedly;
4. asserts every pre-reply poll remains `NONE` rather than `RESPONSE_TIMEOUT`;
5. sends the normal reply;
6. verifies `RESPONSE_IN` and the response body.

The small sleep between polls is only pacing; correctness does not depend on a specific 200/400 ms threshold.

## Changes

- add `rpc_infinite_wait_contract_test.cpp`;
- add dedicated `hakoniwa_pdu_rpc_infinite_wait_test` target;
- add `python tools/hako.py test-infinite-wait`;
- factor the hako.py test-target runner so phase commands share the same build/CTest path;
- add a separate four-platform CI matrix:
  - Ubuntu x64
  - Ubuntu ARM64
  - macOS
  - Windows x64

## Deliberately deferred

- timeout notification cleanup;
- explicit cancel lifecycle;
- normal-response/cancel race;
- legacy test removal/renaming.

Those remain Phase 3–5 work under `docs/test-contract.md`.
