### PR TITLE
Phase 3: validate timeout and explicit cancel contract

### DIFF
--- a/.github/workflows/rpc-timeout-cancel-tests.yml
+++ b/.github/workflows/rpc-timeout-cancel-tests.yml
@@ -1,0 +1,104 @@
+name: rpc-timeout-cancel-tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pdu-rpc-timeout-cancel-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu x64
+            os: ubuntu-latest
+          - name: Ubuntu ARM64
+            os: ubuntu-24.04-arm
+          - name: macOS
+            os: macos-15
+          - name: Windows x64
+            os: windows-2025
+
+    steps:
+      - name: Checkout with Registry submodule
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libboost-dev
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: brew install cmake boost
+
+      - name: Install Windows dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install boost-asio:x64-windows boost-beast:x64-windows
+
+      - name: Build and install Core-free Endpoint package
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF \
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --target hakoniwa_pdu_endpoint --parallel
+          cmake --install endpoint/build --config Release --prefix "${GITHUB_WORKSPACE}/endpoint-install"
+          echo "HAKO_PDU_ENDPOINT_ROOT=${GITHUB_WORKSPACE}/endpoint-install" >> "$GITHUB_ENV"
+
+      - name: Build and install Core-free Endpoint package on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build -A x64 `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows `
+            -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/endpoint-install" `
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF `
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --target hakoniwa_pdu_endpoint --parallel
+          cmake --install endpoint/build --config Release --prefix "$env:GITHUB_WORKSPACE/endpoint-install"
+          "HAKO_PDU_ENDPOINT_ROOT=$env:GITHUB_WORKSPACE/endpoint-install" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Doctor
+        run: python tools/hako.py doctor
+
+      - name: Phase 3 timeout-cancel RPC test
+        run: python tools/hako.py test-timeout-cancel

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,7 +29,6 @@ set_tests_properties(hakoniwa_pdu_rpc_basic_test PROPERTIES
 )
 
 # Phase 2: timeout == 0 means the in-flight RPC has no timeout deadline.
-# Keep this separate from timeout/cancel semantics so failures have one meaning.
 add_executable(hakoniwa_pdu_rpc_infinite_wait_test
   rpc_infinite_wait_contract_test.cpp
 )
@@ -40,6 +39,22 @@ target_link_libraries(hakoniwa_pdu_rpc_infinite_wait_test
 )
 add_test(NAME hakoniwa_pdu_rpc_infinite_wait_test COMMAND hakoniwa_pdu_rpc_infinite_wait_test)
 set_tests_properties(hakoniwa_pdu_rpc_infinite_wait_test PROPERTIES
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  TIMEOUT 30
+)
+
+# Phase 3: timeout is a notification; cancellation is explicit; only a terminal
+# cancel response returns the endpoint to a reusable state.
+add_executable(hakoniwa_pdu_rpc_timeout_cancel_test
+  rpc_timeout_cancel_contract_test.cpp
+)
+target_link_libraries(hakoniwa_pdu_rpc_timeout_cancel_test
+  PRIVATE
+    hakoniwa_pdu_rpc::rpc
+    GTest::gtest_main
+)
+add_test(NAME hakoniwa_pdu_rpc_timeout_cancel_test COMMAND hakoniwa_pdu_rpc_timeout_cancel_test)
+set_tests_properties(hakoniwa_pdu_rpc_timeout_cancel_test PROPERTIES
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   TIMEOUT 30
 )

--- a/test/rpc_timeout_cancel_contract_test.cpp
+++ b/test/rpc_timeout_cancel_contract_test.cpp
@@ -1,0 +1,207 @@
+#include <gtest/gtest.h>
+
+#include "hakoniwa/pdu/endpoint_container.hpp"
+#include "hakoniwa/pdu/rpc/rpc_service_helper.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_client.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_server.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsRequestPacket.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsResponsePacket.hpp"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace {
+
+using namespace std::chrono_literals;
+using hakoniwa::pdu::rpc::ClientEventType;
+using hakoniwa::pdu::rpc::RpcRequest;
+using hakoniwa::pdu::rpc::RpcResponse;
+using hakoniwa::pdu::rpc::RpcServicesClient;
+using hakoniwa::pdu::rpc::RpcServicesServer;
+using hakoniwa::pdu::rpc::ServerEventType;
+
+constexpr const char* kConfigPath = "configs/service_config.json";
+constexpr const char* kEndpointConfigPath = "configs/endpoints.json";
+constexpr const char* kServerNodeId = "server_node";
+constexpr const char* kClientNodeId = "client_node";
+constexpr const char* kClientName = "TestClient";
+constexpr const char* kServiceName = "Service/Add";
+
+class RpcRuntime {
+public:
+    RpcRuntime()
+        : server_endpoint_(std::make_shared<hakoniwa::pdu::EndpointContainer>(
+              kServerNodeId, kEndpointConfigPath))
+        , client_endpoint_(std::make_shared<hakoniwa::pdu::EndpointContainer>(
+              kClientNodeId, kEndpointConfigPath))
+        , server_(kServerNodeId, "RpcServerEndpointImpl", kConfigPath, 1000)
+        , client_(kClientNodeId, kClientName, kConfigPath, "RpcClientEndpointImpl", 1000)
+    {
+    }
+
+    ~RpcRuntime()
+    {
+        stop();
+    }
+
+    bool start()
+    {
+        if (server_endpoint_->initialize() != HAKO_PDU_ERR_OK ||
+            client_endpoint_->initialize() != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        if (!server_.initialize_services(server_endpoint_) ||
+            !client_.initialize_services(client_endpoint_)) {
+            return false;
+        }
+        if (server_endpoint_->start_all() != HAKO_PDU_ERR_OK ||
+            client_endpoint_->start_all() != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        if (!server_.start_all_services() || !client_.start_all_services()) {
+            return false;
+        }
+
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        while (!server_endpoint_->is_running_all() || !client_endpoint_->is_running_all()) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return false;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+        started_ = true;
+        return true;
+    }
+
+    void stop()
+    {
+        if (!started_) {
+            return;
+        }
+        server_endpoint_->stop_all();
+        client_endpoint_->stop_all();
+        server_.stop_all_services();
+        client_.stop_all_services();
+        server_.clear_all_instances();
+        client_.clear_all_instances();
+        started_ = false;
+    }
+
+    ServerEventType wait_server_event(RpcRequest& request, std::chrono::milliseconds timeout = 2s)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        for (;;) {
+            const auto event = server_.poll(request);
+            if (event != ServerEventType::NONE) {
+                return event;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return ServerEventType::NONE;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    ClientEventType wait_client_event(
+        std::string& service_name,
+        RpcResponse& response,
+        std::chrono::milliseconds timeout = 2s)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        for (;;) {
+            const auto event = client_.poll(service_name, response);
+            if (event != ClientEventType::NONE) {
+                return event;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return ClientEventType::NONE;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    RpcServicesServer& server() { return server_; }
+    RpcServicesClient& client() { return client_; }
+
+private:
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> server_endpoint_;
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> client_endpoint_;
+    RpcServicesServer server_;
+    RpcServicesClient client_;
+    bool started_ = false;
+};
+
+TEST(RpcTimeoutCancelContractTest, TimeoutRequiresExplicitCancelAndTerminalCancelCompletion)
+{
+    RpcRuntime runtime;
+    ASSERT_TRUE(runtime.start());
+
+    HakoRpcServiceServerTemplateType(AddTwoInts) service;
+    HakoCpp_AddTwoIntsRequest request_body{};
+    request_body.a = 10;
+    request_body.b = 20;
+
+    ASSERT_TRUE(service.call(runtime.client(), kServiceName, request_body, 50'000));
+
+    RpcRequest original_request;
+    ASSERT_EQ(runtime.wait_server_event(original_request), ServerEventType::REQUEST_IN);
+
+    // The server intentionally does not reply. The client should emit a timeout
+    // notification while the request remains in flight.
+    std::string service_name;
+    RpcResponse response;
+    ASSERT_EQ(runtime.wait_client_event(service_name, response), ClientEventType::RESPONSE_TIMEOUT);
+    ASSERT_EQ(service_name, kServiceName);
+
+    // Timeout itself is not cancellation. The caller explicitly transitions
+    // the same in-flight request to cancellation.
+    ASSERT_TRUE(runtime.client().send_cancel_request(kServiceName));
+
+    RpcRequest cancel_request;
+    ASSERT_EQ(runtime.wait_server_event(cancel_request), ServerEventType::REQUEST_CANCEL);
+    ASSERT_EQ(cancel_request.header.request_id, original_request.header.request_id);
+
+    hakoniwa::pdu::rpc::PduData cancel_response;
+    runtime.server().create_reply_buffer(
+        cancel_request.header,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_CANCELED,
+        cancel_response);
+    ASSERT_TRUE(runtime.server().send_cancel_reply(cancel_request.header, cancel_response));
+
+    service_name.clear();
+    response = {};
+    ASSERT_EQ(runtime.wait_client_event(service_name, response), ClientEventType::RESPONSE_CANCEL);
+    ASSERT_EQ(service_name, kServiceName);
+
+    // A terminal cancel response must return the endpoint to a reusable state.
+    HakoCpp_AddTwoIntsRequest next_request_body{};
+    next_request_body.a = 7;
+    next_request_body.b = 8;
+    ASSERT_TRUE(service.call(runtime.client(), kServiceName, next_request_body, 1'000'000));
+
+    RpcRequest next_request;
+    ASSERT_EQ(runtime.wait_server_event(next_request), ServerEventType::REQUEST_IN);
+
+    HakoCpp_AddTwoIntsResponse next_response_body{};
+    next_response_body.sum = 15;
+    ASSERT_TRUE(service.reply(
+        runtime.server(),
+        next_request,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_OK,
+        next_response_body));
+
+    service_name.clear();
+    response = {};
+    ASSERT_EQ(runtime.wait_client_event(service_name, response), ClientEventType::RESPONSE_IN);
+    ASSERT_EQ(service_name, kServiceName);
+
+    HakoCpp_AddTwoIntsResponse parsed_response{};
+    ASSERT_TRUE(service.get_response_body(response, parsed_response));
+    EXPECT_EQ(parsed_response.sum, 15);
+}
+
+} // namespace

--- a/test/rpc_timeout_cancel_contract_test.cpp
+++ b/test/rpc_timeout_cancel_contract_test.cpp
@@ -169,7 +169,7 @@ TEST(RpcTimeoutCancelContractTest, TimeoutRequiresExplicitCancelAndTerminalCance
         hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE,
         hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_CANCELED,
         cancel_response);
-    ASSERT_TRUE(runtime.server().send_cancel_reply(cancel_request.header, cancel_response));
+    runtime.server().send_cancel_reply(cancel_request.header, cancel_response);
 
     service_name.clear();
     response = {};

--- a/tools/hako.py
+++ b/tools/hako.py
@@ -237,6 +237,10 @@ def test_infinite_wait(ctx: Context) -> None:
     run_test_target(ctx, "hakoniwa_pdu_rpc_infinite_wait_test", "hakoniwa_pdu_rpc_infinite_wait_test")
 
 
+def test_timeout_cancel(ctx: Context) -> None:
+    run_test_target(ctx, "hakoniwa_pdu_rpc_timeout_cancel_test", "hakoniwa_pdu_rpc_timeout_cancel_test")
+
+
 def test(ctx: Context) -> None:
     # Legacy aggregate tests remain available for audit but are not the phased
     # cross-platform gates.
@@ -289,6 +293,7 @@ def main() -> int:
             "build",
             "test-basic",
             "test-infinite-wait",
+            "test-timeout-cancel",
             "test",
             "install",
             "package-test",
@@ -318,6 +323,8 @@ def main() -> int:
         test_basic(ctx)
     elif args.command == "test-infinite-wait":
         test_infinite_wait(ctx)
+    elif args.command == "test-timeout-cancel":
+        test_timeout_cancel(ctx)
     elif args.command == "test":
         test(ctx)
     elif args.command == "install":


### PR DESCRIPTION
## Phase 3 scope

Validate the core timeout/cancel lifecycle as a focused PDU-RPC contract test.

The requirement is:

```text
REQUEST
  -> RESPONSE_TIMEOUT
  -> caller explicitly sends CANCEL
  -> server receives REQUEST_CANCEL for the same request_id
  -> server sends terminal canceled response
  -> client receives RESPONSE_CANCEL
  -> endpoint returns to a reusable state
  -> next RPC completes normally
```

This PR does **not** change production RPC code and does **not** modify the legacy timeout/cancel tests.

## Why this is a separate phase

Phase 1 established normal round-trip and endpoint reuse. Phase 2 established `timeout == 0` infinite-wait behavior. Phase 3 now isolates the non-racy timeout/cancel state machine before Phase 4 introduces the normal-response/cancel race.

The test deliberately keeps the server alive and simply withholds the original normal reply until the client observes `RESPONSE_TIMEOUT`. The client then explicitly calls `send_cancel_request()`, and the test verifies the same request ID flows through `REQUEST_CANCEL` to `RESPONSE_CANCEL`.

Only after the terminal cancel response do we issue another RPC and verify normal completion. This makes endpoint reusability part of the terminal-state contract rather than an assumption at timeout time.

## Changes

- add `rpc_timeout_cancel_contract_test.cpp`;
- add dedicated `hakoniwa_pdu_rpc_timeout_cancel_test` target;
- add `python tools/hako.py test-timeout-cancel`;
- add a separate four-platform CI matrix:
  - Ubuntu x64
  - Ubuntu ARM64
  - macOS
  - Windows x64

## Deliberately deferred

- normal-response/cancel race after timeout;
- legacy `RpcCallTimeoutTest` cleanup/removal;
- legacy `NormalResponseMayWinRaceAfterTimeout` correction/removal;
- final convergence of the default `hako.py test` command.

Those remain Phase 4–5 work under `docs/test-contract.md`.
