### PR TITLE
Phase 4: validate normal-response/cancel race

### DIFF
--- a/.github/workflows/rpc-cancel-race-tests.yml
+++ b/.github/workflows/rpc-cancel-race-tests.yml
@@ -1,0 +1,104 @@
+name: rpc-cancel-race-tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pdu-rpc-cancel-race-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu x64
+            os: ubuntu-latest
+          - name: Ubuntu ARM64
+            os: ubuntu-24.04-arm
+          - name: macOS
+            os: macos-15
+          - name: Windows x64
+            os: windows-2025
+
+    steps:
+      - name: Checkout with Registry submodule
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libboost-dev
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: brew install cmake boost
+
+      - name: Install Windows dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install boost-asio:x64-windows boost-beast:x64-windows
+
+      - name: Build and install Core-free Endpoint package
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF \
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --target hakoniwa_pdu_endpoint --parallel
+          cmake --install endpoint/build --config Release --prefix "${GITHUB_WORKSPACE}/endpoint-install"
+          echo "HAKO_PDU_ENDPOINT_ROOT=${GITHUB_WORKSPACE}/endpoint-install" >> "$GITHUB_ENV"
+
+      - name: Build and install Core-free Endpoint package on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build -A x64 `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows `
+            -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/endpoint-install" `
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF `
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --target hakoniwa_pdu_endpoint --parallel
+          cmake --install endpoint/build --config Release --prefix "$env:GITHUB_WORKSPACE/endpoint-install"
+          "HAKO_PDU_ENDPOINT_ROOT=$env:GITHUB_WORKSPACE/endpoint-install" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Doctor
+        run: python tools/hako.py doctor
+
+      - name: Phase 4 cancel-race RPC test
+        run: python tools/hako.py test-cancel-race

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,22 @@ set_tests_properties(hakoniwa_pdu_rpc_timeout_cancel_test PROPERTIES
   TIMEOUT 30
 )
 
+# Phase 4: after explicit cancellation, a normal response may still win before
+# the server processes the CANCEL. A late CANCEL must be harmless.
+add_executable(hakoniwa_pdu_rpc_cancel_race_test
+  rpc_cancel_race_contract_test.cpp
+)
+target_link_libraries(hakoniwa_pdu_rpc_cancel_race_test
+  PRIVATE
+    hakoniwa_pdu_rpc::rpc
+    GTest::gtest_main
+)
+add_test(NAME hakoniwa_pdu_rpc_cancel_race_test COMMAND hakoniwa_pdu_rpc_cancel_race_test)
+set_tests_properties(hakoniwa_pdu_rpc_cancel_race_test PROPERTIES
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  TIMEOUT 30
+)
+
 # Legacy aggregate tests are intentionally preserved unchanged for audit.
 # They are not part of the phased cross-platform gates.
 add_executable(hakoniwa_pdu_rpc_test

--- a/test/rpc_cancel_race_contract_test.cpp
+++ b/test/rpc_cancel_race_contract_test.cpp
@@ -1,0 +1,209 @@
+#include <gtest/gtest.h>
+
+#include "hakoniwa/pdu/endpoint_container.hpp"
+#include "hakoniwa/pdu/rpc/rpc_service_helper.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_client.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_server.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsRequestPacket.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsResponsePacket.hpp"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace {
+
+using namespace std::chrono_literals;
+using hakoniwa::pdu::rpc::ClientEventType;
+using hakoniwa::pdu::rpc::RpcRequest;
+using hakoniwa::pdu::rpc::RpcResponse;
+using hakoniwa::pdu::rpc::RpcServicesClient;
+using hakoniwa::pdu::rpc::RpcServicesServer;
+using hakoniwa::pdu::rpc::ServerEventType;
+
+constexpr const char* kConfigPath = "configs/service_config.json";
+constexpr const char* kEndpointConfigPath = "configs/endpoints.json";
+constexpr const char* kServerNodeId = "server_node";
+constexpr const char* kClientNodeId = "client_node";
+constexpr const char* kClientName = "TestClient";
+constexpr const char* kServiceName = "Service/Add";
+
+class RpcRuntime {
+public:
+    RpcRuntime()
+        : server_endpoint_(std::make_shared<hakoniwa::pdu::EndpointContainer>(
+              kServerNodeId, kEndpointConfigPath))
+        , client_endpoint_(std::make_shared<hakoniwa::pdu::EndpointContainer>(
+              kClientNodeId, kEndpointConfigPath))
+        , server_(kServerNodeId, "RpcServerEndpointImpl", kConfigPath, 1000)
+        , client_(kClientNodeId, kClientName, kConfigPath, "RpcClientEndpointImpl", 1000)
+    {
+    }
+
+    ~RpcRuntime()
+    {
+        stop();
+    }
+
+    bool start()
+    {
+        if (server_endpoint_->initialize() != HAKO_PDU_ERR_OK ||
+            client_endpoint_->initialize() != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        if (!server_.initialize_services(server_endpoint_) ||
+            !client_.initialize_services(client_endpoint_)) {
+            return false;
+        }
+        if (server_endpoint_->start_all() != HAKO_PDU_ERR_OK ||
+            client_endpoint_->start_all() != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        if (!server_.start_all_services() || !client_.start_all_services()) {
+            return false;
+        }
+
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        while (!server_endpoint_->is_running_all() || !client_endpoint_->is_running_all()) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return false;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+        started_ = true;
+        return true;
+    }
+
+    void stop()
+    {
+        if (!started_) {
+            return;
+        }
+        server_endpoint_->stop_all();
+        client_endpoint_->stop_all();
+        server_.stop_all_services();
+        client_.stop_all_services();
+        server_.clear_all_instances();
+        client_.clear_all_instances();
+        started_ = false;
+    }
+
+    ServerEventType wait_server_event(RpcRequest& request, std::chrono::milliseconds timeout = 2s)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        for (;;) {
+            const auto event = server_.poll(request);
+            if (event != ServerEventType::NONE) {
+                return event;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return ServerEventType::NONE;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    ClientEventType wait_client_event(
+        std::string& service_name,
+        RpcResponse& response,
+        std::chrono::milliseconds timeout = 2s)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        for (;;) {
+            const auto event = client_.poll(service_name, response);
+            if (event != ClientEventType::NONE) {
+                return event;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return ClientEventType::NONE;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    RpcServicesServer& server() { return server_; }
+    RpcServicesClient& client() { return client_; }
+
+private:
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> server_endpoint_;
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> client_endpoint_;
+    RpcServicesServer server_;
+    RpcServicesClient client_;
+    bool started_ = false;
+};
+
+TEST(RpcCancelRaceContractTest, NormalResponseMayWinAfterExplicitCancel)
+{
+    RpcRuntime runtime;
+    ASSERT_TRUE(runtime.start());
+
+    HakoRpcServiceServerTemplateType(AddTwoInts) service;
+    HakoCpp_AddTwoIntsRequest request_body{};
+    request_body.a = 3;
+    request_body.b = 4;
+    ASSERT_TRUE(service.call(runtime.client(), kServiceName, request_body, 50'000));
+
+    RpcRequest original_request;
+    ASSERT_EQ(runtime.wait_server_event(original_request), ServerEventType::REQUEST_IN);
+
+    std::string service_name;
+    RpcResponse response;
+    ASSERT_EQ(runtime.wait_client_event(service_name, response), ClientEventType::RESPONSE_TIMEOUT);
+    ASSERT_EQ(service_name, kServiceName);
+
+    ASSERT_TRUE(runtime.client().send_cancel_request(kServiceName));
+
+    // Do not poll the server for CANCEL yet. The original request is already
+    // RUNNING on the server, so complete that work first. This models the
+    // production race where normal completion wins after the caller has sent
+    // cancellation but before the server has processed that cancellation.
+    HakoCpp_AddTwoIntsResponse response_body{};
+    response_body.sum = 7;
+    ASSERT_TRUE(service.reply(
+        runtime.server(),
+        original_request,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_OK,
+        response_body));
+
+    service_name.clear();
+    response = {};
+    ASSERT_EQ(runtime.wait_client_event(service_name, response), ClientEventType::RESPONSE_IN);
+    ASSERT_EQ(service_name, kServiceName);
+
+    HakoCpp_AddTwoIntsResponse parsed_response{};
+    ASSERT_TRUE(service.get_response_body(response, parsed_response));
+    ASSERT_EQ(parsed_response.sum, 7);
+
+    // The queued CANCEL is now late. The invariant is that it is harmless: it
+    // must not poison the next request or prevent the endpoint from being reused.
+    HakoCpp_AddTwoIntsRequest next_request_body{};
+    next_request_body.a = 8;
+    next_request_body.b = 9;
+    ASSERT_TRUE(service.call(runtime.client(), kServiceName, next_request_body, 1'000'000));
+
+    RpcRequest next_request;
+    ASSERT_EQ(runtime.wait_server_event(next_request), ServerEventType::REQUEST_IN);
+    ASSERT_NE(next_request.header.request_id, original_request.header.request_id);
+
+    HakoCpp_AddTwoIntsResponse next_response_body{};
+    next_response_body.sum = 17;
+    ASSERT_TRUE(service.reply(
+        runtime.server(),
+        next_request,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_OK,
+        next_response_body));
+
+    service_name.clear();
+    response = {};
+    ASSERT_EQ(runtime.wait_client_event(service_name, response), ClientEventType::RESPONSE_IN);
+    ASSERT_EQ(service_name, kServiceName);
+
+    parsed_response = {};
+    ASSERT_TRUE(service.get_response_body(response, parsed_response));
+    EXPECT_EQ(parsed_response.sum, 17);
+}
+
+} // namespace

--- a/tools/hako.py
+++ b/tools/hako.py
@@ -241,6 +241,10 @@ def test_timeout_cancel(ctx: Context) -> None:
     run_test_target(ctx, "hakoniwa_pdu_rpc_timeout_cancel_test", "hakoniwa_pdu_rpc_timeout_cancel_test")
 
 
+def test_cancel_race(ctx: Context) -> None:
+    run_test_target(ctx, "hakoniwa_pdu_rpc_cancel_race_test", "hakoniwa_pdu_rpc_cancel_race_test")
+
+
 def test(ctx: Context) -> None:
     # Legacy aggregate tests remain available for audit but are not the phased
     # cross-platform gates.
@@ -294,6 +298,7 @@ def main() -> int:
             "test-basic",
             "test-infinite-wait",
             "test-timeout-cancel",
+            "test-cancel-race",
             "test",
             "install",
             "package-test",
@@ -325,6 +330,8 @@ def main() -> int:
         test_infinite_wait(ctx)
     elif args.command == "test-timeout-cancel":
         test_timeout_cancel(ctx)
+    elif args.command == "test-cancel-race":
+        test_cancel_race(ctx)
     elif args.command == "test":
         test(ctx)
     elif args.command == "install":


### PR DESCRIPTION
## Phase 4 scope

Validate the race where a normal response wins after timeout and explicit cancellation, but before the server processes the CANCEL.

The contract is:

```text
REQUEST
  -> RESPONSE_TIMEOUT
  -> caller explicitly sends CANCEL
  -> client enters CANCELLING
  -> original server work completes normally first
  -> client receives RESPONSE_IN
  -> late CANCEL is harmless
  -> endpoint/server remain reusable
```

This is deliberately different from the legacy `NormalResponseMayWinRaceAfterTimeout` pattern, which expected a normal response after timeout without first issuing explicit cancellation. The current RPC contract requires the caller to send CANCEL after timeout; once the client is in `CANCELLING`, either normal completion or cancel completion may win.

## Test pattern

1. send request with finite timeout;
2. let the server receive the original request but withhold its reply;
3. wait for client `RESPONSE_TIMEOUT`;
4. explicitly call `send_cancel_request()`;
5. intentionally do **not** poll the server for CANCEL yet;
6. complete the already-running original request normally;
7. verify client receives `RESPONSE_IN`;
8. issue a fresh RPC and verify it completes normally, proving the queued late CANCEL did not poison server/client state.

This mirrors the same invariant already exercised by Conductor Light, while keeping the PDU-RPC regression focused on its own state-machine contract.

## Changes

- add `rpc_cancel_race_contract_test.cpp`;
- add dedicated `hakoniwa_pdu_rpc_cancel_race_test` target;
- add `python tools/hako.py test-cancel-race`;
- add four-platform CI:
  - Ubuntu x64
  - Ubuntu ARM64
  - macOS
  - Windows x64

## Safety

Production RPC code is unchanged. The branch differs from `main` only in the focused test, test CMake wiring, hako.py command, and CI workflow.

## Follow-up

Phase 5 will audit and retire/rename redundant legacy tests, then converge the default `hako.py test` path onto the reviewed contract tests.