### PR TITLE
Refresh README for current build and RPC contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,439 +1,416 @@
 # Hakoniwa PDU-RPC
 
-`hakoniwa-pdu-rpc` is a C++ RPC layer for Hakoniwa built on the PDU communication model.
-It provides request/response semantics that align with Hakoniwa endpoint configuration and PDU definitions.
-It is intentionally narrow in scope: deterministic integration and explicit topology are prioritized over general-purpose RPC features.
-If you are building Hakoniwa-native control-plane RPC in C++, this is the intended layer.
+`hakoniwa-pdu-rpc` is a C++ request/response layer built on `hakoniwa-pdu-endpoint`.
 
-## Positioning (What This Is / Isn't)
+It is designed for Hakoniwa-native control-plane communication where explicit lifecycle, endpoint topology, and deterministic/tick-driven integration are more important than general-purpose RPC features.
 
-**This is:**
-- A PDU-native request/response layer for Hakoniwa execution and endpoint semantics.
-- A config-driven RPC integration model that reuses Hakoniwa endpoint topology.
-- A thin abstraction over `hakoniwa-pdu-endpoint` with explicit call/poll behavior.
+## What This Library Provides
 
-**This is not:**
-- A general-purpose RPC framework (for example, gRPC).
-- A dynamic service mesh with runtime discovery, auth, tracing, and streaming semantics.
+- PDU-native request/response RPC.
+- Multiple named services and clients.
+- JSON-driven service and endpoint topology.
+- Typed request/response helpers for generated PDU service types.
+- Explicit polling, timeout, and cancellation semantics.
+- An installable CMake package for downstream consumers.
+- Cross-platform build and contract-test coverage on Linux x64, Linux ARM64, macOS, and Windows x64.
 
-Design intent:
-- **Explicit semantics:** Request IDs, channels, and timeout behavior are visible in config/API.
-- **Config-driven topology:** RPC wiring follows Hakoniwa node/endpoint definitions.
-- **Minimal hidden assumptions:** No hidden scheduler/threading policy is imposed by default.
-- **API consistency:** Service/client APIs align with existing Endpoint/Bridge usage patterns.
+This library intentionally does **not** provide dynamic service discovery, authentication, tracing, streaming RPC, or a hidden scheduling/threading model.
 
-## Links
+## Architecture
 
-- Examples: `examples/README.md`
-- Tutorial: `docs/tutorials/rpc.md`
-- Minimal config set: `config/sample/minimal/README.md`
-- JSON schema: `config/schema/service-schema.json`
-- Config validator: `PYTHONPATH=python:$PYTHONPATH python -m hakoniwa_pdu_rpc.validate_configs config/sample/simple-service.json --skip-endpoint-validation`
+```text
+User application
+    |
+    v
+RpcServicesClient / RpcServicesServer
+    |
+    v
+IRpcClientEndpoint / IRpcServerEndpoint
+    |
+    v
+RpcClientEndpointImpl / RpcServerEndpointImpl
+    |
+    v
+hakoniwa-pdu-endpoint
+    |
+    v
+configured PDU transport
+```
 
-## When To Use / Not Use
+`hakoniwa-pdu-rpc` depends on the public CMake target provided by `hakoniwa-pdu-endpoint`:
 
-| Use when | Not for |
-|---|---|
-| Hakoniwa ecosystem integration is primary | Polyglot public APIs across many languages |
-| Request/response control-plane communication | Web-service style APIs |
-| PDU-native data model and transport reuse are required | Streaming RPC workloads |
-| Deterministic or tick-driven integration loops are required | Full auth/observability stack requirements |
-| C++ applications with existing Hakoniwa config assets | Dynamic service discovery-centric architectures |
+```text
+hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint
+```
 
-## Features
+The RPC package itself does not require a direct dependency on Hakoniwa Core. Whether a particular endpoint configuration needs additional runtime components is an Endpoint concern.
 
-- **Service-Oriented RPC:** Define and manage multiple RPC services within a single server.
-- **Multi-Client Support:** A single service can be called by multiple uniquely named clients.
-- **Configuration-Driven:** Define services in a JSON file.
-- **Typed Helper API:** `HakoRpcServiceServerTemplateType` handles PDU pack/unpack for ROS service types.
-- **Transport Agnostic at RPC Layer:** Reuses `hakoniwa-pdu-endpoint` transports (TCP/UDP/Shared Memory) without changing RPC user code.
+## RPC Lifecycle Contract
 
-## Quick Start (5 min)
+The client lifecycle is intentionally explicit.
 
-If you want one working RPC pair first, use the bundled samples.
+Normal request:
+
+```text
+IDLE
+  -> call()
+RUNNING
+  -> RESPONSE_IN
+IDLE
+```
+
+A finite timeout is a **notification**, not automatic cancellation:
+
+```text
+RUNNING
+  -> RESPONSE_TIMEOUT
+RUNNING
+  -> caller send_cancel_request()
+CANCELLING
+  -> RESPONSE_CANCEL
+IDLE
+```
+
+`timeout == 0` means no RPC timeout deadline. The request remains in flight until a response is received.
+
+A normal response may also win after cancellation has been requested:
+
+```text
+RUNNING
+  -> RESPONSE_TIMEOUT
+  -> send_cancel_request()
+CANCELLING
+  -> normal RESPONSE_IN wins before cancel completion
+IDLE
+```
+
+A late server-side CANCEL must be harmless. This race is part of the reviewed RPC contract and is covered by the contract-test suite.
+
+Server loss is not treated as a separate RPC recovery protocol here. Applications that require server-death detection or high-availability recovery should provide that policy above this layer.
+
+See `docs/test-contract.md` for the detailed test ownership and lifecycle rationale.
+
+## Repository Setup
+
+Clone the repository including the generated PDU registry submodule:
 
 ```bash
-# 1) Build examples
+git clone --recursive https://github.com/hakoniwalab/hakoniwa-pdu-rpc.git
+cd hakoniwa-pdu-rpc
+```
+
+For an existing checkout:
+
+```bash
+git submodule update --init --recursive
+```
+
+## Dependencies
+
+Required:
+
+- C++20 compiler.
+- CMake 3.16 or newer.
+- Installed `hakoniwa-pdu-endpoint` CMake package.
+- `hakoniwa-pdu-registry` submodule from this repository.
+
+`nlohmann_json` is resolved by the project and is included in the installed package contract.
+
+On Windows, the build driver uses vcpkg when required by Endpoint dependencies.
+
+## Recommended Build Interface: `tools/hako.py`
+
+The repository provides one cross-platform build driver so callers do not need to reproduce platform-specific CMake details.
+
+```bash
+python tools/hako.py doctor --endpoint-root /path/to/endpoint/install
+python tools/hako.py build --endpoint-root /path/to/endpoint/install
+```
+
+`doctor` checks the host platform, CMake/Git availability, Registry submodule, Endpoint installation, and Windows vcpkg prerequisites.
+
+The Endpoint prefix can also be supplied through:
+
+```bash
+export HAKO_PDU_ENDPOINT_ROOT=/path/to/endpoint/install
+# or
+export HAKO_PDU_ENDPOINT_PREFIX=/path/to/endpoint/install
+```
+
+Then the common workflow is:
+
+```bash
+python tools/hako.py doctor
+python tools/hako.py build
+python tools/hako.py test
+python tools/hako.py install
+python tools/hako.py package-test
+```
+
+By default:
+
+- build directory: `build/`
+- local install directory used by `hako.py`: `.hako/install/`
+- build type: `Release`
+
+Override them when needed:
+
+```bash
+python tools/hako.py build \
+  --build-dir out/build \
+  --install-dir out/install \
+  --build-type Debug
+```
+
+### Inspect the generated CMake command
+
+```bash
+python tools/hako.py configure --dry-run
+```
+
+This is useful when integrating the package into another build environment without duplicating the repository's platform policy.
+
+## Direct CMake Usage
+
+Direct CMake is also supported.
+
+```bash
 cmake -S . -B build \
-  -DHAKO_PDU_ENDPOINT_PREFIX=/usr/local/hakoniwa \
+  -DHAKO_PDU_ENDPOINT_PREFIX=/path/to/endpoint/install \
+  -DHAKO_PDU_RPC_BUILD_TESTS=ON \
   -DHAKO_PDU_RPC_BUILD_EXAMPLES=ON
-cmake --build build
 
-# 2) Validate config first (recommended)
-PYTHONPATH=python:$PYTHONPATH \
-python -m hakoniwa_pdu_rpc.validate_configs config/sample/simple-service.json --skip-endpoint-validation
+cmake --build build --parallel
 ```
 
-Validation catches schema and RPC consistency errors early (for example: required fields, duplicate names, channel collisions). If endpoint validation is enabled, referenced endpoint config issues are also checked.
+The preferred dependency is an installed Endpoint CMake package. `HAKO_PDU_ENDPOINT_PREFIX` is retained as a hint/compatibility path for Endpoint installations.
 
-Run in two terminals:
+On Unix-like systems, the historical direct-CMake install default remains `/usr/local/hakoniwa`. `tools/hako.py install` uses an explicit repository-local prefix instead.
+
+## Install and Downstream CMake Usage
+
+Install with the build driver:
 
 ```bash
-# terminal A
-build/examples/hakoniwa_pdu_rpc_server
+python tools/hako.py install
 ```
 
-```bash
-# terminal B
-build/examples/hakoniwa_pdu_rpc_client 1000000
-# then type: 5 7
-# expected: sum=12
-```
-
-If it fails, check these first:
-- Server is started before client.
-- `nodeId`/client name in config matches what server/client constructors use.
-- `endpointId` values match endpoint config mappings.
-- Both sides use the same TCP port (`54001`) and reachable addresses.
-- Runtime library path includes Hakoniwa libs (`LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH` as needed).
-
-Reference files used by this path:
-- `examples/rpc_server.cpp`
-- `examples/rpc_client.cpp`
-- `examples/README.md`
-- `config/sample/simple-service.json`
-- `config/sample/endpoints.json`
-- `config/sample/minimal/` (compact equivalent config set)
-
-## Why Config Is Explicit (and Validated)
-
-"Static JSON is brittle" is a valid concern when IDs drift. This repository uses explicit config plus validation to make those failures visible before runtime.
-
-What is validated:
-- Service config schema (`config/schema/service-schema.json`).
-- RPC-level consistency checks (for example: duplicate service/client names, channel collisions, `maxClients` bounds).
-- Optional endpoint validation through `hakoniwa-pdu-endpoint` validator (when installed/available).
-
-Common pitfalls:
-- `nodeId` or client name mismatch between code and service config.
-- `endpointId` mismatch with endpoint mapping (`endpoints.json`).
-- `pduSize` mismatch (base/heap) against generated registry definitions.
-- Request/response channel ID collisions.
-
-Explicit config keeps timing, routing, and delivery assumptions reviewable in code review and reproducible in CI.
-
-## Build
-
-### Dependencies
-
-- C++20 compiler (GCC/Clang)
-- CMake 3.16+
-- Hakoniwa core library (typically under `/usr/local/hakoniwa`)
-- Installed `hakoniwa-pdu-endpoint` library and headers
-
-### `hakoniwa-pdu-endpoint` install layout
-
-This project expects:
+The installed package exports:
 
 ```text
-<prefix>/
-  include/hakoniwa/pdu/endpoint.hpp
-  lib/libhakoniwa_pdu_endpoint.(a|so|dylib)
+hakoniwa_pdu_rpc::rpc
 ```
 
-Default prefix is `/usr/local/hakoniwa`. Override if needed:
-
-```bash
-cmake -S . -B build -DHAKO_PDU_ENDPOINT_PREFIX=/path/to/prefix
-```
-
-If layout is non-standard, set explicitly:
-
-```bash
-cmake -S . -B build \
-  -DHAKO_PDU_ENDPOINT_INCLUDE_DIR=/path/to/include \
-  -DHAKO_PDU_ENDPOINT_LIBRARY=/path/to/libhakoniwa_pdu_endpoint.so
-```
-
-Note: `hakoniwa-pdu-endpoint` depends on Hakoniwa core libs (`assets`, `shakoc`). Ensure library path includes:
-
-```text
-/usr/local/hakoniwa/lib
-```
-
-### Build steps
-
-```bash
-# 1. Configure
-cmake -S . -B build \
-  -DHAKO_PDU_ENDPOINT_PREFIX=/usr/local/hakoniwa
-
-# 2. Build
-cmake --build build
-```
-
-Generated library:
-- `build/src/libhakoniwa_pdu_rpc.(a|so|dylib)`
-
-### Install
-
-Install headers/libraries/CMake package:
-
-```bash
-./build.bash
-./install.bash
-```
-
-Default install locations:
-- Headers: `/usr/local/hakoniwa/include`
-- Libraries: `/usr/local/hakoniwa/lib`
-
-Uninstall:
-
-```bash
-./uninstall.bash
-```
-
-Override install prefix:
-
-```bash
-PREFIX=/path/to/prefix ./install.bash
-```
-
-### Downstream CMake usage
+Downstream CMake:
 
 ```cmake
 find_package(hakoniwa_pdu_rpc REQUIRED)
 
 add_executable(my_app main.cpp)
-target_link_libraries(my_app PRIVATE hakoniwa_pdu_rpc::hakoniwa_pdu_rpc)
+target_link_libraries(my_app PRIVATE hakoniwa_pdu_rpc::rpc)
 ```
 
-Note: `hakoniwa-pdu-registry` must be installed and visible on include path because `hakoniwa-pdu-rpc` headers include registry headers.
+The compatibility target below is also provided:
 
-If installed to non-standard prefix:
+```cmake
+hakoniwa_pdu_rpc::hakoniwa_pdu_rpc
+```
+
+For a non-standard install prefix:
 
 ```bash
-cmake -S . -B build -DCMAKE_PREFIX_PATH=/path/to/prefix
-# or
-export CMAKE_PREFIX_PATH=/path/to/prefix
+cmake -S . -B build \
+  -DCMAKE_PREFIX_PATH="/path/to/rpc/install;/path/to/endpoint/install"
 ```
 
-Build examples:
+### Package contract verification
+
+`package-test` verifies the installed package from a separate consumer project rather than relying on the in-tree build:
 
 ```bash
-cmake -S . -B build -DHAKO_PDU_RPC_BUILD_EXAMPLES=ON
-cmake --build build
+python tools/hako.py package-test
 ```
 
-### Hakoniwa core install notes
+This checks the exported CMake package and downstream link contract.
 
-- Headers: `/usr/local/hakoniwa/include/hakoniwa`
-- Libraries: `/usr/local/hakoniwa/lib`
-- `hakoniwa-pdu-endpoint` default search prefix: `/usr/local/hakoniwa`
-  - Header target: `hakoniwa/pdu/endpoint.hpp`
-  - Library target: `libhakoniwa_pdu_endpoint.*`
+## Contract Tests
 
-If shared libraries are not found at runtime, add `LD_LIBRARY_PATH` (Linux) or `DYLD_LIBRARY_PATH` (macOS).
-
-## How To Test
-
-This project uses GoogleTest. After build:
+The default test command runs the reviewed RPC contract suite:
 
 ```bash
-cd build
-make test
-# or
-ctest
+python tools/hako.py test
 ```
 
-## Config Validation Commands
+The suite is intentionally split by contract so a failure identifies which lifecycle guarantee changed.
 
-From repository root:
+| Contract | Command | Main guarantee |
+|---|---|---|
+| Basic | `test-basic` | round trip and endpoint reuse |
+| Infinite wait | `test-infinite-wait` | `timeout == 0` never emits RPC timeout |
+| Timeout/cancel | `test-timeout-cancel` | timeout -> explicit cancel -> terminal cancel -> reuse |
+| Cancel race | `test-cancel-race` | normal response may win while client is cancelling |
+
+Examples:
+
+```bash
+python tools/hako.py test-basic
+python tools/hako.py test-infinite-wait
+python tools/hako.py test-timeout-cancel
+python tools/hako.py test-cancel-race
+```
+
+The contract tests are also exercised in CI on:
+
+- Ubuntu x64
+- Ubuntu ARM64
+- macOS
+- Windows x64
+
+A test failure is not automatically a production bug. Before changing RPC implementation, verify that the failing test still represents the documented lifecycle contract. See `docs/test-contract.md`.
+
+## Quick Example
+
+The build driver enables examples during normal builds:
+
+```bash
+python tools/hako.py build
+```
+
+Run server and client in separate terminals.
+
+Terminal A:
+
+```bash
+build/examples/hakoniwa_pdu_rpc_server
+```
+
+Terminal B:
+
+```bash
+build/examples/hakoniwa_pdu_rpc_client 1000000
+```
+
+Then enter:
+
+```text
+5 7
+```
+
+Expected result:
+
+```text
+sum=12
+```
+
+Reference files:
+
+- `examples/rpc_server.cpp`
+- `examples/rpc_client.cpp`
+- `examples/README.md`
+- `config/sample/simple-service.json`
+- `config/sample/endpoints.json`
+- `config/sample/minimal/`
+
+## Configuration Validation
+
+Service topology is defined in JSON and can be validated before runtime.
+
+From the repository root:
 
 ```bash
 export PYTHONPATH="python:$PYTHONPATH"
-python -m hakoniwa_pdu_rpc.validate_configs config/sample/simple-service.json --skip-endpoint-validation
-python -m hakoniwa_pdu_rpc.validate_configs test/configs/service_config.json --skip-endpoint-validation
+python -m hakoniwa_pdu_rpc.validate_configs \
+  config/sample/simple-service.json \
+  --skip-endpoint-validation
 ```
 
-If installed under `/usr/local/hakoniwa`, this also works:
+The validator checks RPC schema and consistency, including required fields, duplicate names, channel collisions, and `maxClients` constraints.
 
-```bash
-export PYTHONPATH="/usr/local/hakoniwa/share/hakoniwa-pdu-rpc/python:$PYTHONPATH"
-python -m hakoniwa_pdu_rpc.validate_configs config/sample/simple-service.json
-python -m hakoniwa_pdu_rpc.validate_configs test/configs/service_config.json
+Endpoint-side validation can also be used when the Endpoint validator/schema is available.
+
+Common configuration mistakes include:
+
+- `nodeId` mismatch between code and service configuration.
+- client-name mismatch.
+- `endpointId` mismatch with Endpoint configuration.
+- request/response channel collisions.
+- incorrect generated PDU sizes.
+
+Schema:
+
+```text
+config/schema/service-schema.json
 ```
 
-Notes:
-- Requires `jsonschema` (`pip install jsonschema`).
-- Endpoint validator is provided by `hakoniwa-pdu-endpoint`.
-- If endpoint schema is not found, set `HAKO_PDU_ENDPOINT_SCHEMA`.
-- Use `--skip-endpoint-validation` to skip endpoint-side checks.
+## Core API
 
-## Tutorials and Examples
+Primary application entry points:
 
-- `docs/tutorials/rpc.md`: End-to-end RPC setup using sample configs.
-- `examples/README.md`: Fastest path to run bundled server/client examples.
-- `config/sample/minimal/README.md`: Compact JSON set with field notes.
+### `RpcServicesClient`
 
-## Core Concepts
+```text
+RpcServicesClient(node_id, client_name, config_path, ...)
+initialize_services(endpoint_container)
+start_all_services()
+call(service_name, request_pdu, timeout_usec)
+poll(service_name, response_out)
+send_cancel_request(service_name)
+```
 
-### Services
-A service is a remote procedure (for example, `Service/Add`) with request/response PDU definitions and allowed clients.
+### `RpcServicesServer`
 
-### Configuration
-RPC topology is defined in a service configuration JSON file (`services`).
-Endpoint configs are managed separately via `EndpointContainer`; service config references endpoint IDs (`server_endpoints`, `client_endpoint`).
+```text
+RpcServicesServer(node_id, impl_type, config_path, ...)
+initialize_services(endpoint_container, ...)
+start_all_services()
+poll(request_out)
+send_reply(...)
+```
 
-### RPC Service Helper
-`HakoRpcServiceServerTemplateType` (for example `HakoRpcServiceServerTemplateType(AddTwoInts)`) provides typed helpers:
+### Typed service helper
+
+`HakoRpcServiceServerTemplateType(...)` provides typed conversion helpers such as:
+
 - `call()`
 - `get_request_body()`
 - `reply()`
 - `get_response_body()`
 
-This avoids manual byte-level PDU handling in application code.
+Most users should work through `RpcServicesClient`, `RpcServicesServer`, and the typed helper. `IRpcClientEndpoint` / `IRpcServerEndpoint` are extension interfaces for custom endpoint behavior.
 
-## API Reference
+## Why Explicit Polling?
 
-Primary entry points are `RpcServicesServer` and `RpcServicesClient`.
+The RPC API intentionally uses `poll()` instead of imposing worker threads or a scheduler.
 
-### `RpcServicesClient`
+This lets the caller choose:
 
-- `RpcServicesClient(node_id, client_name, config_path, ...)`
-  - `node_id`: node ID for this client (must match config)
-  - `client_name`: unique client name (must match config)
-  - `config_path`: service config path
-- `bool initialize_services(endpoint_container)`
-- `bool start_all_services()`
-- `bool call(service_name, request_pdu, timeout_usec)`
-- `ClientEventType poll(service_name, response_out)`
+- simulation tick alignment,
+- sleep/backoff policy,
+- scheduling order,
+- integration with an existing deterministic main loop.
 
-### `RpcServicesServer`
-
-- `RpcServicesServer(node_id, impl_type, config_path, ...)`
-  - `node_id`: node ID for this server
-- `bool initialize_services(endpoint_container, client_node_id = std::nullopt)`
-- `bool start_all_services()`
-- `ServerEventType poll(request_out)`
-- `void send_reply(header, pdu)`
-
-## Why Polling?
-
-The API uses explicit `poll()` loops by design:
-- Integration-friendly for deterministic/tick-driven main loops.
-- Avoids hidden threads and timer behavior in the RPC layer.
-- Lets applications choose scheduling policy (tight loop, sleep interval, frame/tick alignment).
-- Q: Is polling inefficient? A: Polling is explicit for deterministic/tick-driven integration; callers choose their loop and sleep/backoff policy (no hidden threads).
-
-## Most Users Only Need These Entry Points
-
-- `RpcServicesServer` and `RpcServicesClient` for server/client lifecycle and call flow.
-- `HakoRpcServiceServerTemplateType` for typed request/response conversion.
-- `config/sample/minimal/` as the baseline wiring model.
-
-Endpoint interface layer usage (`IRpcServerEndpoint` / `IRpcClientEndpoint`) is an extension point for custom behavior. Most users can ignore it.
+The library owns RPC state transitions; the application owns scheduling policy.
 
 ## Why Not gRPC?
 
-This library is not a gRPC replacement; it is a Hakoniwa-native control-plane RPC layer.
+This project is not intended to replace gRPC.
 
-- Hakoniwa deployments can face build/versioning constraints across platforms; keeping stack depth lower is operationally simpler.
-- PDU-native semantics are first-class here, and transport abstraction is already provided by `hakoniwa-pdu-endpoint`.
-- Control-plane RPC and PDU data paths are explicitly separable for deterministic simulation integration concerns.
-- Existing ROS IDL + PDU registry assets are reused directly; no additional IDL/runtime stack is required.
-- API shape remains consistent with existing Hakoniwa Endpoint/Bridge usage patterns.
+Use PDU-RPC when Hakoniwa-native topology, generated PDU assets, deterministic integration, and a small middleware surface are the important constraints.
 
-If you need polyglot clients, streaming, auth, or tracing, gRPC is a better fit.
-A hybrid approach is also valid: use gRPC for the control-plane and keep Hakoniwa PDU for the data-plane.
-Trade-off of the hybrid:
-- Two independent middleware stacks (build, dependencies, lifecycle).
-- Two debugging toolchains and mental models.
-- Integration drift between RPC semantics and Hakoniwa-native topology/config.
-This is a deliberate trade-off: broader RPC features are traded for reproducibility and tight Hakoniwa-native integration.
+Use a general-purpose RPC framework when you need capabilities such as:
 
-## Configuration File Schema
+- broad polyglot client support,
+- streaming,
+- authentication/authorization,
+- tracing and service observability,
+- dynamic service infrastructure.
 
-Service configuration example:
+A hybrid architecture is also possible, but it intentionally introduces two middleware stacks and two lifecycle/debugging models.
 
-```json
-{
-  "pduMetaDataSize": 24,
-  "services": [
-    {
-      "name": "Service/Add",
-      "type": "hako_srv_msgs/AddTwoInts",
-      "maxClients": 1,
-      "pduSize": {
-        "server": { "heapSize": 0, "baseSize": 296 },
-        "client": { "heapSize": 0, "baseSize": 288 }
-      },
-      "server_endpoints": [
-        {
-          "nodeId": "server_node",
-          "endpointId": "server_ep_id"
-        }
-      ],
-      "clients": [
-        {
-          "name": "TestClient",
-          "requestChannelId": 1,
-          "responseChannelId": 2,
-          "client_endpoint": {
-            "nodeId": "client_node",
-            "endpointId": "client_ep_id"
-          }
-        }
-      ]
-    }
-  ]
-}
-```
+## Documentation
 
-Key fields:
-- `pduMetaDataSize`: metadata header size.
-- `services`: service definitions.
-  - `name`: unique service name.
-  - `type`: ROS service type (for example `hako_srv_msgs/AddTwoInts`).
-  - `pduSize`: base/heap PDU sizes for server/client.
-  - `server_endpoints`: server endpoint mappings.
-  - `clients`: allowed clients and channel mappings.
-
-## Architecture
-
-```mermaid
-flowchart TB
-    subgraph UserApplication["User Application"]
-        direction LR
-        AppClient["Client App"]
-        AppServer["Server App"]
-    end
-
-    subgraph RpcServiceLayer["RPC Service Layer (This Library)"]
-        RpcServicesClient["RpcServicesClient"]
-        RpcServicesServer["RpcServicesServer"]
-    end
-
-    subgraph RpcEndpointLayer["RPC Endpoint Layer (This Library)"]
-        RpcClientEndpoint["IRpcClientEndpoint"]
-        RpcServerEndpoint["IRpcServerEndpoint"]
-    end
-
-    subgraph EndpointImplLayer["Endpoint Implementation"]
-        RpcClientEndpointImpl["RpcClientEndpointImpl"]
-        RpcServerEndpointImpl["RpcServerEndpointImpl"]
-    end
-
-    subgraph PduLayer["Hakoniwa PDU Layer"]
-        PduEndpoint["hakoniwa::pdu::Endpoint"]
-    end
-
-    AppClient --> RpcServicesClient
-    AppServer --> RpcServicesServer
-
-    RpcServicesClient --> RpcClientEndpoint
-    RpcServicesServer --> RpcServerEndpoint
-
-    RpcClientEndpoint <--- RpcClientEndpointImpl
-    RpcServerEndpoint <--- RpcServerEndpointImpl
-
-    RpcClientEndpointImpl --> PduEndpoint
-    RpcServerEndpointImpl --> PduEndpoint
-```
-
-Layer responsibilities:
-- `RpcServicesServer` / `RpcServicesClient`: primary application entry points.
-- `IRpcServerEndpoint` / `IRpcClientEndpoint`: extension interfaces.
-- `RpcServerEndpointImpl` / `RpcClientEndpointImpl`: default endpoint implementations.
-- `hakoniwa::pdu::Endpoint`: underlying transport/data-plane interface.
+- Test contract and audit policy: `docs/test-contract.md`
+- RPC tutorial: `docs/tutorials/rpc.md`
+- Examples: `examples/README.md`
+- Minimal configuration: `config/sample/minimal/README.md`
+- Service schema: `config/schema/service-schema.json`


### PR DESCRIPTION
## Summary

Refresh the README so it matches the repository after the CMake/package modernization and Phase 1–5 test cleanup.

## Main corrections

- describe PDU-RPC as depending on the installed `hakoniwa-pdu-endpoint` CMake package rather than directly requiring Hakoniwa Core;
- document `tools/hako.py` as the recommended cross-platform build interface;
- document `doctor`, `build`, `test`, `install`, and `package-test`;
- use the preferred downstream target `hakoniwa_pdu_rpc::rpc` while retaining the compatibility target note;
- explain the install/package contract and separate package-consumer verification;
- replace the historical `make test` guidance with the reviewed contract-test suite;
- document the four RPC contracts: basic, infinite-wait, timeout/cancel, and cancel/normal-response race;
- state the timeout semantics explicitly: timeout is a notification, cancellation is caller-driven, and `timeout == 0` means no deadline;
- document the supported CI matrix: Ubuntu x64, Ubuntu ARM64, macOS, Windows x64;
- remove stale build/install guidance and duplicate sections.

## Safety

Documentation only. No production, build, or test code changes.