### PR TITLE
feat: validate basic RPC through C API

### DIFF
--- a/.github/workflows/rpc-basic-tests.yml
+++ b/.github/workflows/rpc-basic-tests.yml
@@ -100,5 +100,11 @@ jobs:
       - name: Doctor
         run: python tools/hako.py doctor
 
-      - name: Phase 1 basic RPC tests
+      - name: Existing C++ basic contracts
         run: python tools/hako.py test-basic
+
+      - name: Build C API basic contract
+        run: cmake --build build --config Release --target hakoniwa_pdu_rpc_c_api_basic_test --parallel
+
+      - name: C API basic contracts
+        run: ctest --test-dir build -C Release --output-on-failure -R "^hakoniwa_pdu_rpc_c_api_basic_test$"

--- a/include/hakoniwa/pdu/rpc/c_rpc.h
+++ b/include/hakoniwa/pdu/rpc/c_rpc.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef HAKO_PDU_RPC_NAME_MAX
+#define HAKO_PDU_RPC_NAME_MAX 128
+#endif
+
+typedef struct hako_pdu_rpc_client_handle hako_pdu_rpc_client_handle_t;
+typedef struct hako_pdu_rpc_server_handle hako_pdu_rpc_server_handle_t;
+
+typedef enum {
+    HAKO_PDU_RPC_OK = 0,
+    HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT = 1,
+    HAKO_PDU_RPC_ERROR_INITIALIZE = 2,
+    HAKO_PDU_RPC_ERROR_START = 3,
+    HAKO_PDU_RPC_ERROR_NOT_RUNNING = 4,
+    HAKO_PDU_RPC_ERROR_CALL = 5,
+    HAKO_PDU_RPC_ERROR_BUFFER_TOO_SMALL = 6,
+    HAKO_PDU_RPC_ERROR_NOT_FOUND = 7,
+    HAKO_PDU_RPC_ERROR_INTERNAL = 8
+} hako_pdu_rpc_error_t;
+
+typedef enum {
+    HAKO_PDU_RPC_CLIENT_EVENT_NONE = 0,
+    HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_IN = 1,
+    HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_CANCEL = 2,
+    HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_TIMEOUT = 3
+} hako_pdu_rpc_client_event_t;
+
+typedef enum {
+    HAKO_PDU_RPC_SERVER_EVENT_NONE = 0,
+    HAKO_PDU_RPC_SERVER_EVENT_REQUEST_IN = 1,
+    HAKO_PDU_RPC_SERVER_EVENT_REQUEST_CANCEL = 2
+} hako_pdu_rpc_server_event_t;
+
+typedef struct {
+    char service_name[HAKO_PDU_RPC_NAME_MAX];
+    size_t pdu_size;
+} hako_pdu_rpc_response_info_t;
+
+typedef struct {
+    uint64_t request_token;
+    char service_name[HAKO_PDU_RPC_NAME_MAX];
+    char client_name[HAKO_PDU_RPC_NAME_MAX];
+    size_t pdu_size;
+} hako_pdu_rpc_request_info_t;
+
+hako_pdu_rpc_client_handle_t* hako_pdu_rpc_client_create(const char* node_id, const char* client_name, const char* service_config_path, const char* endpoint_config_path, uint64_t delta_time_usec, const char* time_source_type);
+void hako_pdu_rpc_client_destroy(hako_pdu_rpc_client_handle_t* handle);
+hako_pdu_rpc_error_t hako_pdu_rpc_client_start(hako_pdu_rpc_client_handle_t* handle);
+hako_pdu_rpc_error_t hako_pdu_rpc_client_stop(hako_pdu_rpc_client_handle_t* handle);
+hako_pdu_rpc_error_t hako_pdu_rpc_client_create_request_buffer(hako_pdu_rpc_client_handle_t* handle, const char* service_name, uint8_t* buffer, size_t capacity, size_t* out_size);
+hako_pdu_rpc_error_t hako_pdu_rpc_client_call(hako_pdu_rpc_client_handle_t* handle, const char* service_name, const uint8_t* pdu, size_t pdu_size, uint64_t timeout_usec);
+hako_pdu_rpc_client_event_t hako_pdu_rpc_client_poll(hako_pdu_rpc_client_handle_t* handle, hako_pdu_rpc_response_info_t* out_info, uint8_t* buffer, size_t capacity, size_t* out_size, hako_pdu_rpc_error_t* out_error);
+
+hako_pdu_rpc_server_handle_t* hako_pdu_rpc_server_create(const char* node_id, const char* service_config_path, const char* endpoint_config_path, uint64_t delta_time_usec, const char* time_source_type);
+void hako_pdu_rpc_server_destroy(hako_pdu_rpc_server_handle_t* handle);
+hako_pdu_rpc_error_t hako_pdu_rpc_server_start(hako_pdu_rpc_server_handle_t* handle);
+hako_pdu_rpc_error_t hako_pdu_rpc_server_stop(hako_pdu_rpc_server_handle_t* handle);
+hako_pdu_rpc_server_event_t hako_pdu_rpc_server_poll(hako_pdu_rpc_server_handle_t* handle, hako_pdu_rpc_request_info_t* out_info, uint8_t* buffer, size_t capacity, size_t* out_size, hako_pdu_rpc_error_t* out_error);
+hako_pdu_rpc_error_t hako_pdu_rpc_server_create_reply_buffer(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, uint8_t status, int32_t result_code, uint8_t* buffer, size_t capacity, size_t* out_size);
+hako_pdu_rpc_error_t hako_pdu_rpc_server_send_reply(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, const uint8_t* pdu, size_t pdu_size);
+
+/* Co-located test/application shutdown order: server Endpoint, client Endpoint, server RPC, client RPC. */
+hako_pdu_rpc_error_t hako_pdu_rpc_stop_pair(hako_pdu_rpc_server_handle_t* server, hako_pdu_rpc_client_handle_t* client);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(hakoniwa_pdu_rpc
   rpc_services_server.cpp
   rpc_client_endpoint_impl.cpp
   rpc_services_client.cpp
+  c_rpc.cpp
 )
 
 add_library(hakoniwa_pdu_rpc::rpc ALIAS hakoniwa_pdu_rpc)

--- a/src/c_rpc.cpp
+++ b/src/c_rpc.cpp
@@ -1,0 +1,271 @@
+#include "hakoniwa/pdu/rpc/c_rpc.h"
+
+#include "hakoniwa/pdu/endpoint_container.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_client.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_server.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+using hakoniwa::pdu::EndpointContainer;
+using hakoniwa::pdu::rpc::ClientEventType;
+using hakoniwa::pdu::rpc::PduData;
+using hakoniwa::pdu::rpc::RpcRequest;
+using hakoniwa::pdu::rpc::RpcResponse;
+using hakoniwa::pdu::rpc::RpcServicesClient;
+using hakoniwa::pdu::rpc::RpcServicesServer;
+using hakoniwa::pdu::rpc::ServerEventType;
+
+namespace {
+constexpr const char* kClientImpl = "RpcClientEndpointImpl";
+constexpr const char* kServerImpl = "RpcServerEndpointImpl";
+constexpr const char* kDefaultTimeSource = "real";
+
+bool valid_text(const char* value) { return value != nullptr && value[0] != '\0'; }
+
+void copy_name(char* dst, size_t capacity, const std::string& src)
+{
+    if (dst == nullptr || capacity == 0) return;
+    const size_t count = std::min(capacity - 1, src.size());
+    std::memcpy(dst, src.data(), count);
+    dst[count] = '\0';
+}
+
+hako_pdu_rpc_error_t copy_pdu(const PduData& src, uint8_t* dst, size_t capacity, size_t* out_size)
+{
+    if (out_size == nullptr) return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    *out_size = src.size();
+    if (src.size() > capacity || (!src.empty() && dst == nullptr)) return HAKO_PDU_RPC_ERROR_BUFFER_TOO_SMALL;
+    if (!src.empty()) std::memcpy(dst, src.data(), src.size());
+    return HAKO_PDU_RPC_OK;
+}
+
+PduData make_pdu(const uint8_t* data, size_t size)
+{
+    return size == 0 ? PduData{} : PduData(data, data + size);
+}
+
+hako_pdu_rpc_client_event_t map_client_event(ClientEventType event)
+{
+    switch (event) {
+    case ClientEventType::RESPONSE_IN: return HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_IN;
+    case ClientEventType::RESPONSE_CANCEL: return HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_CANCEL;
+    case ClientEventType::RESPONSE_TIMEOUT: return HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_TIMEOUT;
+    default: return HAKO_PDU_RPC_CLIENT_EVENT_NONE;
+    }
+}
+
+hako_pdu_rpc_server_event_t map_server_event(ServerEventType event)
+{
+    switch (event) {
+    case ServerEventType::REQUEST_IN: return HAKO_PDU_RPC_SERVER_EVENT_REQUEST_IN;
+    case ServerEventType::REQUEST_CANCEL: return HAKO_PDU_RPC_SERVER_EVENT_REQUEST_CANCEL;
+    default: return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+}
+} // namespace
+
+struct hako_pdu_rpc_client_handle {
+    std::shared_ptr<EndpointContainer> endpoints;
+    std::unique_ptr<RpcServicesClient> rpc;
+    bool started{false};
+};
+
+struct hako_pdu_rpc_server_handle {
+    std::shared_ptr<EndpointContainer> endpoints;
+    std::unique_ptr<RpcServicesServer> rpc;
+    std::mutex pending_mutex;
+    uint64_t next_token{1};
+    std::map<uint64_t, RpcRequest> pending_requests;
+    bool started{false};
+};
+
+namespace {
+void stop_client_endpoint(hako_pdu_rpc_client_handle_t* h) { if (h && h->endpoints) (void)h->endpoints->stop_all(); }
+void stop_server_endpoint(hako_pdu_rpc_server_handle_t* h) { if (h && h->endpoints) (void)h->endpoints->stop_all(); }
+void stop_client_rpc(hako_pdu_rpc_client_handle_t* h) { if (h && h->rpc) { h->rpc->stop_all_services(); h->rpc->clear_all_instances(); } }
+void stop_server_rpc(hako_pdu_rpc_server_handle_t* h) { if (h && h->rpc) { h->rpc->stop_all_services(); h->rpc->clear_all_instances(); } }
+void release_client(hako_pdu_rpc_client_handle_t* h) { if (h) { h->rpc.reset(); h->endpoints.reset(); h->started = false; } }
+void release_server(hako_pdu_rpc_server_handle_t* h) {
+    if (!h) return;
+    { std::lock_guard<std::mutex> lock(h->pending_mutex); h->pending_requests.clear(); }
+    h->rpc.reset(); h->endpoints.reset(); h->started = false;
+}
+} // namespace
+
+extern "C" {
+
+hako_pdu_rpc_client_handle_t* hako_pdu_rpc_client_create(const char* node_id, const char* client_name, const char* service_config_path, const char* endpoint_config_path, uint64_t delta_time_usec, const char* time_source_type)
+{
+    if (!valid_text(node_id) || !valid_text(client_name) || !valid_text(service_config_path) || !valid_text(endpoint_config_path)) return nullptr;
+    try {
+        auto h = std::make_unique<hako_pdu_rpc_client_handle_t>();
+        h->endpoints = std::make_shared<EndpointContainer>(node_id, endpoint_config_path);
+        if (h->endpoints->initialize() != HAKO_PDU_ERR_OK) return nullptr;
+        h->rpc = std::make_unique<RpcServicesClient>(node_id, client_name, service_config_path, kClientImpl, delta_time_usec, valid_text(time_source_type) ? time_source_type : kDefaultTimeSource);
+        if (!h->rpc->initialize_services(h->endpoints)) return nullptr;
+        return h.release();
+    } catch (...) { return nullptr; }
+}
+
+void hako_pdu_rpc_client_destroy(hako_pdu_rpc_client_handle_t* h)
+{
+    if (!h) return;
+    (void)hako_pdu_rpc_client_stop(h);
+    delete h;
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_client_start(hako_pdu_rpc_client_handle_t* h)
+{
+    if (!h) return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    if (h->started) return HAKO_PDU_RPC_OK;
+    if (!h->endpoints || !h->rpc) return HAKO_PDU_RPC_ERROR_INITIALIZE;
+    try {
+        if (h->endpoints->start_all() != HAKO_PDU_ERR_OK) return HAKO_PDU_RPC_ERROR_START;
+        if (!h->rpc->start_all_services()) { stop_client_endpoint(h); return HAKO_PDU_RPC_ERROR_START; }
+        h->started = true;
+        return HAKO_PDU_RPC_OK;
+    } catch (...) { stop_client_endpoint(h); return HAKO_PDU_RPC_ERROR_INTERNAL; }
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_client_stop(hako_pdu_rpc_client_handle_t* h)
+{
+    if (!h) return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    stop_client_endpoint(h);
+    stop_client_rpc(h);
+    release_client(h);
+    return HAKO_PDU_RPC_OK;
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_client_create_request_buffer(hako_pdu_rpc_client_handle_t* h, const char* service_name, uint8_t* buffer, size_t capacity, size_t* out_size)
+{
+    if (!h || !valid_text(service_name) || !out_size) return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    if (!h->started || !h->rpc) return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    PduData pdu;
+    if (!h->rpc->create_request_buffer(service_name, pdu)) return HAKO_PDU_RPC_ERROR_NOT_FOUND;
+    return copy_pdu(pdu, buffer, capacity, out_size);
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_client_call(hako_pdu_rpc_client_handle_t* h, const char* service_name, const uint8_t* pdu, size_t pdu_size, uint64_t timeout_usec)
+{
+    if (!h || !valid_text(service_name) || (pdu_size > 0 && !pdu)) return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    if (!h->started || !h->rpc) return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    return h->rpc->call(service_name, make_pdu(pdu, pdu_size), timeout_usec) ? HAKO_PDU_RPC_OK : HAKO_PDU_RPC_ERROR_CALL;
+}
+
+hako_pdu_rpc_client_event_t hako_pdu_rpc_client_poll(hako_pdu_rpc_client_handle_t* h, hako_pdu_rpc_response_info_t* info, uint8_t* buffer, size_t capacity, size_t* out_size, hako_pdu_rpc_error_t* out_error)
+{
+    if (out_error) *out_error = HAKO_PDU_RPC_OK;
+    if (!h || !info || !out_size) { if (out_error) *out_error = HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT; return HAKO_PDU_RPC_CLIENT_EVENT_NONE; }
+    if (!h->started || !h->rpc) { if (out_error) *out_error = HAKO_PDU_RPC_ERROR_NOT_RUNNING; return HAKO_PDU_RPC_CLIENT_EVENT_NONE; }
+    std::string service_name;
+    RpcResponse response;
+    const auto event = h->rpc->poll(service_name, response);
+    if (event == ClientEventType::NONE) { *out_size = 0; return HAKO_PDU_RPC_CLIENT_EVENT_NONE; }
+    const auto result = copy_pdu(response.pdu, buffer, capacity, out_size);
+    if (result != HAKO_PDU_RPC_OK) { if (out_error) *out_error = result; return HAKO_PDU_RPC_CLIENT_EVENT_NONE; }
+    copy_name(info->service_name, sizeof(info->service_name), service_name);
+    info->pdu_size = response.pdu.size();
+    return map_client_event(event);
+}
+
+hako_pdu_rpc_server_handle_t* hako_pdu_rpc_server_create(const char* node_id, const char* service_config_path, const char* endpoint_config_path, uint64_t delta_time_usec, const char* time_source_type)
+{
+    if (!valid_text(node_id) || !valid_text(service_config_path) || !valid_text(endpoint_config_path)) return nullptr;
+    try {
+        auto h = std::make_unique<hako_pdu_rpc_server_handle_t>();
+        h->endpoints = std::make_shared<EndpointContainer>(node_id, endpoint_config_path);
+        if (h->endpoints->initialize() != HAKO_PDU_ERR_OK) return nullptr;
+        h->rpc = std::make_unique<RpcServicesServer>(node_id, kServerImpl, service_config_path, delta_time_usec, valid_text(time_source_type) ? time_source_type : kDefaultTimeSource);
+        if (!h->rpc->initialize_services(h->endpoints)) return nullptr;
+        return h.release();
+    } catch (...) { return nullptr; }
+}
+
+void hako_pdu_rpc_server_destroy(hako_pdu_rpc_server_handle_t* h)
+{
+    if (!h) return;
+    (void)hako_pdu_rpc_server_stop(h);
+    delete h;
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_server_start(hako_pdu_rpc_server_handle_t* h)
+{
+    if (!h) return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    if (h->started) return HAKO_PDU_RPC_OK;
+    if (!h->endpoints || !h->rpc) return HAKO_PDU_RPC_ERROR_INITIALIZE;
+    try {
+        if (h->endpoints->start_all() != HAKO_PDU_ERR_OK) return HAKO_PDU_RPC_ERROR_START;
+        if (!h->rpc->start_all_services()) { stop_server_endpoint(h); return HAKO_PDU_RPC_ERROR_START; }
+        h->started = true;
+        return HAKO_PDU_RPC_OK;
+    } catch (...) { stop_server_endpoint(h); return HAKO_PDU_RPC_ERROR_INTERNAL; }
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_server_stop(hako_pdu_rpc_server_handle_t* h)
+{
+    if (!h) return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    stop_server_endpoint(h);
+    stop_server_rpc(h);
+    release_server(h);
+    return HAKO_PDU_RPC_OK;
+}
+
+hako_pdu_rpc_server_event_t hako_pdu_rpc_server_poll(hako_pdu_rpc_server_handle_t* h, hako_pdu_rpc_request_info_t* info, uint8_t* buffer, size_t capacity, size_t* out_size, hako_pdu_rpc_error_t* out_error)
+{
+    if (out_error) *out_error = HAKO_PDU_RPC_OK;
+    if (!h || !info || !out_size) { if (out_error) *out_error = HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT; return HAKO_PDU_RPC_SERVER_EVENT_NONE; }
+    if (!h->started || !h->rpc) { if (out_error) *out_error = HAKO_PDU_RPC_ERROR_NOT_RUNNING; return HAKO_PDU_RPC_SERVER_EVENT_NONE; }
+    RpcRequest request;
+    const auto event = h->rpc->poll(request);
+    if (event == ServerEventType::NONE) { *out_size = 0; return HAKO_PDU_RPC_SERVER_EVENT_NONE; }
+    const auto result = copy_pdu(request.pdu, buffer, capacity, out_size);
+    if (result != HAKO_PDU_RPC_OK) { if (out_error) *out_error = result; return HAKO_PDU_RPC_SERVER_EVENT_NONE; }
+    uint64_t token;
+    { std::lock_guard<std::mutex> lock(h->pending_mutex); token = h->next_token++; h->pending_requests.emplace(token, request); }
+    info->request_token = token;
+    copy_name(info->service_name, sizeof(info->service_name), request.header.service_name);
+    copy_name(info->client_name, sizeof(info->client_name), request.client_name);
+    info->pdu_size = request.pdu.size();
+    return map_server_event(event);
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_server_create_reply_buffer(hako_pdu_rpc_server_handle_t* h, uint64_t token, uint8_t status, int32_t result_code, uint8_t* buffer, size_t capacity, size_t* out_size)
+{
+    if (!h || !out_size) return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    if (!h->started || !h->rpc) return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    RpcRequest request;
+    { std::lock_guard<std::mutex> lock(h->pending_mutex); const auto it = h->pending_requests.find(token); if (it == h->pending_requests.end()) return HAKO_PDU_RPC_ERROR_NOT_FOUND; request = it->second; }
+    PduData response;
+    h->rpc->create_reply_buffer(request.header, static_cast<Hako_uint8>(status), static_cast<Hako_int32>(result_code), response);
+    return copy_pdu(response, buffer, capacity, out_size);
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_server_send_reply(hako_pdu_rpc_server_handle_t* h, uint64_t token, const uint8_t* pdu, size_t pdu_size)
+{
+    if (!h || (pdu_size > 0 && !pdu)) return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    if (!h->started || !h->rpc) return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    RpcRequest request;
+    { std::lock_guard<std::mutex> lock(h->pending_mutex); const auto it = h->pending_requests.find(token); if (it == h->pending_requests.end()) return HAKO_PDU_RPC_ERROR_NOT_FOUND; request = it->second; h->pending_requests.erase(it); }
+    h->rpc->send_reply(request.header, make_pdu(pdu, pdu_size));
+    return HAKO_PDU_RPC_OK;
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_stop_pair(hako_pdu_rpc_server_handle_t* server, hako_pdu_rpc_client_handle_t* client)
+{
+    if (!server || !client) return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    stop_server_endpoint(server);
+    stop_client_endpoint(client);
+    stop_server_rpc(server);
+    stop_client_rpc(client);
+    release_server(server);
+    release_client(client);
+    return HAKO_PDU_RPC_OK;
+}
+
+} // extern "C"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,64 +13,39 @@ if(NOT TARGET GTest::gtest_main)
   FetchContent_MakeAvailable(googletest)
 endif()
 
-# Phase 1: focused, cross-platform-safe RPC contract tests.
 add_executable(hakoniwa_pdu_rpc_basic_test
   rpc_basic_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_basic_test
-  PRIVATE
-    hakoniwa_pdu_rpc::rpc
-    GTest::gtest_main
-)
+target_link_libraries(hakoniwa_pdu_rpc_basic_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_basic_test COMMAND hakoniwa_pdu_rpc_basic_test)
-set_tests_properties(hakoniwa_pdu_rpc_basic_test PROPERTIES
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  TIMEOUT 30
-)
+set_tests_properties(hakoniwa_pdu_rpc_basic_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
-# Phase 2: timeout == 0 means the in-flight RPC has no timeout deadline.
+# C API parity test for the same two basic contracts. Keep this beside the
+# existing C++ test until the C facade has proven equivalent on every platform.
+add_executable(hakoniwa_pdu_rpc_c_api_basic_test
+  c_rpc_basic_contract_test.cpp
+)
+target_link_libraries(hakoniwa_pdu_rpc_c_api_basic_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
+add_test(NAME hakoniwa_pdu_rpc_c_api_basic_test COMMAND hakoniwa_pdu_rpc_c_api_basic_test)
+set_tests_properties(hakoniwa_pdu_rpc_c_api_basic_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
+
 add_executable(hakoniwa_pdu_rpc_infinite_wait_test
   rpc_infinite_wait_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_infinite_wait_test
-  PRIVATE
-    hakoniwa_pdu_rpc::rpc
-    GTest::gtest_main
-)
+target_link_libraries(hakoniwa_pdu_rpc_infinite_wait_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_infinite_wait_test COMMAND hakoniwa_pdu_rpc_infinite_wait_test)
-set_tests_properties(hakoniwa_pdu_rpc_infinite_wait_test PROPERTIES
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  TIMEOUT 30
-)
+set_tests_properties(hakoniwa_pdu_rpc_infinite_wait_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
-# Phase 3: timeout is a notification; cancellation is explicit; only a terminal
-# cancel response returns the endpoint to a reusable state.
 add_executable(hakoniwa_pdu_rpc_timeout_cancel_test
   rpc_timeout_cancel_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_timeout_cancel_test
-  PRIVATE
-    hakoniwa_pdu_rpc::rpc
-    GTest::gtest_main
-)
+target_link_libraries(hakoniwa_pdu_rpc_timeout_cancel_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_timeout_cancel_test COMMAND hakoniwa_pdu_rpc_timeout_cancel_test)
-set_tests_properties(hakoniwa_pdu_rpc_timeout_cancel_test PROPERTIES
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  TIMEOUT 30
-)
+set_tests_properties(hakoniwa_pdu_rpc_timeout_cancel_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
-# Phase 4: after explicit cancellation, a normal response may still win before
-# the server processes the CANCEL. A late CANCEL must be harmless.
 add_executable(hakoniwa_pdu_rpc_cancel_race_test
   rpc_cancel_race_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_cancel_race_test
-  PRIVATE
-    hakoniwa_pdu_rpc::rpc
-    GTest::gtest_main
-)
+target_link_libraries(hakoniwa_pdu_rpc_cancel_race_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_cancel_race_test COMMAND hakoniwa_pdu_rpc_cancel_race_test)
-set_tests_properties(hakoniwa_pdu_rpc_cancel_race_test PROPERTIES
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  TIMEOUT 30
-)
+set_tests_properties(hakoniwa_pdu_rpc_cancel_race_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)

--- a/test/c_rpc_basic_contract_test.cpp
+++ b/test/c_rpc_basic_contract_test.cpp
@@ -1,0 +1,150 @@
+#include <gtest/gtest.h>
+
+#include "hakoniwa/pdu/rpc/c_rpc.h"
+#include "hakoniwa/pdu/rpc/rpc_types.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsRequestPacket.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsResponsePacket.hpp"
+
+#include <chrono>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+namespace {
+using namespace std::chrono_literals;
+using hako::pdu::msgs::hako_srv_msgs::AddTwoIntsRequestPacket;
+using hako::pdu::msgs::hako_srv_msgs::AddTwoIntsResponsePacket;
+
+constexpr const char* kServiceConfig = "configs/service_config.json";
+constexpr const char* kEndpointConfig = "configs/endpoints.json";
+constexpr const char* kService = "Service/Add";
+constexpr size_t kMaxPdu = 4 * 1024 * 1024;
+
+class CRpcRuntime {
+public:
+    ~CRpcRuntime()
+    {
+        if (server_ && client_) (void)hako_pdu_rpc_stop_pair(server_, client_);
+        if (client_) hako_pdu_rpc_client_destroy(client_);
+        if (server_) hako_pdu_rpc_server_destroy(server_);
+    }
+
+    bool start()
+    {
+        server_ = hako_pdu_rpc_server_create("server_node", kServiceConfig, kEndpointConfig, 1000, "real");
+        client_ = hako_pdu_rpc_client_create("client_node", "TestClient", kServiceConfig, kEndpointConfig, 1000, "real");
+        return server_ && client_ &&
+            hako_pdu_rpc_server_start(server_) == HAKO_PDU_RPC_OK &&
+            hako_pdu_rpc_client_start(client_) == HAKO_PDU_RPC_OK;
+    }
+
+    bool execute(long long a, long long b, long long expected)
+    {
+        size_t request_size = 0;
+        if (hako_pdu_rpc_client_create_request_buffer(client_, kService, nullptr, 0, &request_size) != HAKO_PDU_RPC_ERROR_BUFFER_TOO_SMALL) return false;
+        std::vector<uint8_t> request(request_size);
+        if (hako_pdu_rpc_client_create_request_buffer(client_, kService, request.data(), request.size(), &request_size) != HAKO_PDU_RPC_OK) return false;
+        request.resize(request_size);
+
+        AddTwoIntsRequestPacket request_converter;
+        HakoCpp_AddTwoIntsRequestPacket request_cpp{};
+        if (!request_converter.pdu2cpp(reinterpret_cast<char*>(request.data()), request_cpp)) return false;
+        request_cpp.body.a = a;
+        request_cpp.body.b = b;
+        const int encoded_request = request_converter.cpp2pdu(request_cpp, reinterpret_cast<char*>(request.data()), static_cast<int>(request.size()));
+        if (encoded_request <= 0) return false;
+        request.resize(static_cast<size_t>(encoded_request));
+
+        const auto connect_deadline = std::chrono::steady_clock::now() + 3s;
+        while (hako_pdu_rpc_client_call(client_, kService, request.data(), request.size(), 1'000'000) != HAKO_PDU_RPC_OK) {
+            if (std::chrono::steady_clock::now() >= connect_deadline) return false;
+            std::this_thread::sleep_for(10ms);
+        }
+
+        hako_pdu_rpc_request_info_t request_info{};
+        std::vector<uint8_t> received_request(kMaxPdu);
+        if (wait_server(request_info, received_request) != HAKO_PDU_RPC_SERVER_EVENT_REQUEST_IN) return false;
+        if (std::strcmp(request_info.service_name, kService) != 0) return false;
+
+        HakoCpp_AddTwoIntsRequestPacket received_cpp{};
+        if (!request_converter.pdu2cpp(reinterpret_cast<char*>(received_request.data()), received_cpp)) return false;
+        if (received_cpp.body.a != a || received_cpp.body.b != b) return false;
+
+        size_t reply_size = 0;
+        if (hako_pdu_rpc_server_create_reply_buffer(server_, request_info.request_token,
+                static_cast<uint8_t>(hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE),
+                static_cast<int32_t>(hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_OK),
+                nullptr, 0, &reply_size) != HAKO_PDU_RPC_ERROR_BUFFER_TOO_SMALL) return false;
+        std::vector<uint8_t> reply(reply_size);
+        if (hako_pdu_rpc_server_create_reply_buffer(server_, request_info.request_token,
+                static_cast<uint8_t>(hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE),
+                static_cast<int32_t>(hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_OK),
+                reply.data(), reply.size(), &reply_size) != HAKO_PDU_RPC_OK) return false;
+        reply.resize(reply_size);
+
+        AddTwoIntsResponsePacket response_converter;
+        HakoCpp_AddTwoIntsResponsePacket response_cpp{};
+        if (!response_converter.pdu2cpp(reinterpret_cast<char*>(reply.data()), response_cpp)) return false;
+        response_cpp.body.sum = a + b;
+        const int encoded_reply = response_converter.cpp2pdu(response_cpp, reinterpret_cast<char*>(reply.data()), static_cast<int>(reply.size()));
+        if (encoded_reply <= 0) return false;
+        reply.resize(static_cast<size_t>(encoded_reply));
+        if (hako_pdu_rpc_server_send_reply(server_, request_info.request_token, reply.data(), reply.size()) != HAKO_PDU_RPC_OK) return false;
+
+        hako_pdu_rpc_response_info_t response_info{};
+        std::vector<uint8_t> response(kMaxPdu);
+        if (wait_client(response_info, response) != HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_IN) return false;
+        if (std::strcmp(response_info.service_name, kService) != 0) return false;
+        HakoCpp_AddTwoIntsResponsePacket parsed{};
+        return response_converter.pdu2cpp(reinterpret_cast<char*>(response.data()), parsed) && parsed.body.sum == expected;
+    }
+
+private:
+    hako_pdu_rpc_server_event_t wait_server(hako_pdu_rpc_request_info_t& info, std::vector<uint8_t>& pdu)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        do {
+            size_t size = 0;
+            hako_pdu_rpc_error_t error = HAKO_PDU_RPC_OK;
+            const auto event = hako_pdu_rpc_server_poll(server_, &info, pdu.data(), pdu.size(), &size, &error);
+            if (error != HAKO_PDU_RPC_OK) return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+            if (event != HAKO_PDU_RPC_SERVER_EVENT_NONE) { pdu.resize(size); return event; }
+            std::this_thread::sleep_for(1ms);
+        } while (std::chrono::steady_clock::now() < deadline);
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+
+    hako_pdu_rpc_client_event_t wait_client(hako_pdu_rpc_response_info_t& info, std::vector<uint8_t>& pdu)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        do {
+            size_t size = 0;
+            hako_pdu_rpc_error_t error = HAKO_PDU_RPC_OK;
+            const auto event = hako_pdu_rpc_client_poll(client_, &info, pdu.data(), pdu.size(), &size, &error);
+            if (error != HAKO_PDU_RPC_OK) return HAKO_PDU_RPC_CLIENT_EVENT_NONE;
+            if (event != HAKO_PDU_RPC_CLIENT_EVENT_NONE) { pdu.resize(size); return event; }
+            std::this_thread::sleep_for(1ms);
+        } while (std::chrono::steady_clock::now() < deadline);
+        return HAKO_PDU_RPC_CLIENT_EVENT_NONE;
+    }
+
+    hako_pdu_rpc_server_handle_t* server_{nullptr};
+    hako_pdu_rpc_client_handle_t* client_{nullptr};
+};
+
+TEST(CRpcBasicContractTest, BasicRoundTrip)
+{
+    CRpcRuntime runtime;
+    ASSERT_TRUE(runtime.start());
+    EXPECT_TRUE(runtime.execute(5, 7, 12));
+}
+
+TEST(CRpcBasicContractTest, ConsecutiveCallsReuseEndpoint)
+{
+    CRpcRuntime runtime;
+    ASSERT_TRUE(runtime.start());
+    ASSERT_TRUE(runtime.execute(10, 20, 30));
+    EXPECT_TRUE(runtime.execute(15, 25, 40));
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Add the first tested C API boundary for hakoniwa-pdu-rpc.

## Scope

- add opaque C client/server handles;
- preserve the existing C++ initialization sequence;
- expose raw PDU request/reply buffers for the basic RPC contract;
- preserve the established co-located shutdown order:
  - server Endpoint
  - client Endpoint
  - server RPC services
  - client RPC services
- add C API versions of the two existing basic contracts:
  - one AddTwoInts round trip
  - consecutive calls reusing the same Endpoint;
- run the existing C++ basic contract and the new C API basic contract side by side on Ubuntu x64, Ubuntu ARM64, macOS, and Windows x64.

## Deliberately excluded

- no Python or CFFI implementation;
- no timeout/cancel C API yet;
- no replacement or removal of the existing C++ contract test;
- no changes to Endpoint or RPC state-machine behavior.

## Merge condition

Both the existing C++ basic contract and the equivalent C API contract must pass on all four platforms.