### PR TITLE
test: validate timeout-cancel through C API

### DIFF
--- a/.github/workflows/rpc-timeout-cancel-tests.yml
+++ b/.github/workflows/rpc-timeout-cancel-tests.yml
@@ -100,5 +100,11 @@ jobs:
       - name: Doctor
         run: python tools/hako.py doctor
 
-      - name: Phase 3 timeout-cancel RPC test
+      - name: Existing C++ timeout-cancel RPC contract
         run: python tools/hako.py test-timeout-cancel
+
+      - name: Build C API timeout-cancel RPC contract
+        run: cmake --build build --config Release --target hakoniwa_pdu_rpc_c_api_timeout_cancel_test --parallel
+
+      - name: Run C API timeout-cancel RPC contract
+        run: ctest --test-dir build -C Release --output-on-failure -R "^hakoniwa_pdu_rpc_c_api_timeout_cancel_test$"

--- a/include/hakoniwa/pdu/rpc/c_rpc.h
+++ b/include/hakoniwa/pdu/rpc/c_rpc.h
@@ -57,6 +57,7 @@ hako_pdu_rpc_error_t hako_pdu_rpc_client_start(hako_pdu_rpc_client_handle_t* han
 hako_pdu_rpc_error_t hako_pdu_rpc_client_stop(hako_pdu_rpc_client_handle_t* handle);
 hako_pdu_rpc_error_t hako_pdu_rpc_client_create_request_buffer(hako_pdu_rpc_client_handle_t* handle, const char* service_name, uint8_t* buffer, size_t capacity, size_t* out_size);
 hako_pdu_rpc_error_t hako_pdu_rpc_client_call(hako_pdu_rpc_client_handle_t* handle, const char* service_name, const uint8_t* pdu, size_t pdu_size, uint64_t timeout_usec);
+hako_pdu_rpc_error_t hako_pdu_rpc_client_cancel(hako_pdu_rpc_client_handle_t* handle, const char* service_name);
 hako_pdu_rpc_client_event_t hako_pdu_rpc_client_poll(hako_pdu_rpc_client_handle_t* handle, hako_pdu_rpc_response_info_t* out_info, uint8_t* buffer, size_t capacity, size_t* out_size, hako_pdu_rpc_error_t* out_error);
 
 hako_pdu_rpc_server_handle_t* hako_pdu_rpc_server_create(const char* node_id, const char* service_config_path, const char* endpoint_config_path, uint64_t delta_time_usec, const char* time_source_type);
@@ -66,6 +67,7 @@ hako_pdu_rpc_error_t hako_pdu_rpc_server_stop(hako_pdu_rpc_server_handle_t* hand
 hako_pdu_rpc_server_event_t hako_pdu_rpc_server_poll(hako_pdu_rpc_server_handle_t* handle, hako_pdu_rpc_request_info_t* out_info, uint8_t* buffer, size_t capacity, size_t* out_size, hako_pdu_rpc_error_t* out_error);
 hako_pdu_rpc_error_t hako_pdu_rpc_server_create_reply_buffer(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, uint8_t status, int32_t result_code, uint8_t* buffer, size_t capacity, size_t* out_size);
 hako_pdu_rpc_error_t hako_pdu_rpc_server_send_reply(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, const uint8_t* pdu, size_t pdu_size);
+hako_pdu_rpc_error_t hako_pdu_rpc_server_send_cancel_reply(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, const uint8_t* pdu, size_t pdu_size);
 
 /* Co-located test/application shutdown order: server Endpoint, client Endpoint, server RPC, client RPC. */
 hako_pdu_rpc_error_t hako_pdu_rpc_stop_pair(hako_pdu_rpc_server_handle_t* server, hako_pdu_rpc_client_handle_t* client);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(hakoniwa_pdu_rpc
   rpc_client_endpoint_impl.cpp
   rpc_services_client.cpp
   c_rpc.cpp
+  c_rpc_cancel.cpp
 )
 
 add_library(hakoniwa_pdu_rpc::rpc ALIAS hakoniwa_pdu_rpc)

--- a/src/c_rpc_cancel.cpp
+++ b/src/c_rpc_cancel.cpp
@@ -1,0 +1,99 @@
+#include "hakoniwa/pdu/rpc/c_rpc.h"
+
+#include "hakoniwa/pdu/endpoint_container.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_client.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_server.hpp"
+
+#include <map>
+#include <memory>
+#include <mutex>
+
+using hakoniwa::pdu::EndpointContainer;
+using hakoniwa::pdu::rpc::PduData;
+using hakoniwa::pdu::rpc::RpcRequest;
+using hakoniwa::pdu::rpc::RpcServicesClient;
+using hakoniwa::pdu::rpc::RpcServicesServer;
+
+struct hako_pdu_rpc_client_handle {
+    std::shared_ptr<EndpointContainer> endpoints;
+    std::unique_ptr<RpcServicesClient> rpc;
+    bool started{false};
+};
+
+struct hako_pdu_rpc_server_handle {
+    std::shared_ptr<EndpointContainer> endpoints;
+    std::unique_ptr<RpcServicesServer> rpc;
+    std::mutex pending_mutex;
+    uint64_t next_token{1};
+    std::map<uint64_t, RpcRequest> pending_requests;
+    bool started{false};
+};
+
+namespace {
+bool valid_text(const char* value)
+{
+    return value != nullptr && value[0] != '\0';
+}
+
+PduData make_pdu(const uint8_t* data, size_t size)
+{
+    return size == 0 ? PduData{} : PduData(data, data + size);
+}
+} // namespace
+
+extern "C" {
+
+hako_pdu_rpc_error_t hako_pdu_rpc_client_cancel(
+    hako_pdu_rpc_client_handle_t* handle,
+    const char* service_name)
+{
+    if (handle == nullptr || !valid_text(service_name)) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    if (!handle->started || !handle->rpc) {
+        return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    }
+    try {
+        return handle->rpc->send_cancel_request(service_name)
+            ? HAKO_PDU_RPC_OK
+            : HAKO_PDU_RPC_ERROR_CALL;
+    } catch (...) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_server_send_cancel_reply(
+    hako_pdu_rpc_server_handle_t* handle,
+    uint64_t request_token,
+    const uint8_t* pdu,
+    size_t pdu_size)
+{
+    if (handle == nullptr || (pdu_size > 0 && pdu == nullptr)) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    if (!handle->started || !handle->rpc) {
+        return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    }
+
+    RpcRequest request;
+    {
+        std::lock_guard<std::mutex> lock(handle->pending_mutex);
+        const auto it = handle->pending_requests.find(request_token);
+        if (it == handle->pending_requests.end()) {
+            return HAKO_PDU_RPC_ERROR_NOT_FOUND;
+        }
+        request = it->second;
+        handle->pending_requests.erase(it);
+    }
+
+    try {
+        handle->rpc->send_cancel_reply(
+            request.header,
+            make_pdu(pdu, pdu_size));
+        return HAKO_PDU_RPC_OK;
+    } catch (...) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+}
+
+} // extern "C"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,13 @@ target_link_libraries(hakoniwa_pdu_rpc_timeout_cancel_test PRIVATE hakoniwa_pdu_
 add_test(NAME hakoniwa_pdu_rpc_timeout_cancel_test COMMAND hakoniwa_pdu_rpc_timeout_cancel_test)
 set_tests_properties(hakoniwa_pdu_rpc_timeout_cancel_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
+add_executable(hakoniwa_pdu_rpc_c_api_timeout_cancel_test
+  c_rpc_timeout_cancel_contract_test.cpp
+)
+target_link_libraries(hakoniwa_pdu_rpc_c_api_timeout_cancel_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
+add_test(NAME hakoniwa_pdu_rpc_c_api_timeout_cancel_test COMMAND hakoniwa_pdu_rpc_c_api_timeout_cancel_test)
+set_tests_properties(hakoniwa_pdu_rpc_c_api_timeout_cancel_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
+
 add_executable(hakoniwa_pdu_rpc_cancel_race_test
   rpc_cancel_race_contract_test.cpp
 )

--- a/test/c_rpc_timeout_cancel_contract_test.cpp
+++ b/test/c_rpc_timeout_cancel_contract_test.cpp
@@ -1,0 +1,224 @@
+#include <gtest/gtest.h>
+
+#include "hakoniwa/pdu/rpc/c_rpc.h"
+#include "hakoniwa/pdu/rpc/rpc_types.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsRequestPacket.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsResponsePacket.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+namespace {
+using namespace std::chrono_literals;
+using hako::pdu::msgs::hako_srv_msgs::AddTwoIntsRequestPacket;
+using hako::pdu::msgs::hako_srv_msgs::AddTwoIntsResponsePacket;
+
+constexpr const char* kServiceConfig = "configs/service_config.json";
+constexpr const char* kEndpointConfig = "configs/endpoints.json";
+constexpr const char* kService = "Service/Add";
+constexpr size_t kMaxPdu = 4 * 1024 * 1024;
+
+struct Runtime {
+    hako_pdu_rpc_server_handle_t* server{nullptr};
+    hako_pdu_rpc_client_handle_t* client{nullptr};
+
+    ~Runtime()
+    {
+        if (server && client) (void)hako_pdu_rpc_stop_pair(server, client);
+        if (client) hako_pdu_rpc_client_destroy(client);
+        if (server) hako_pdu_rpc_server_destroy(server);
+    }
+
+    bool start()
+    {
+        server = hako_pdu_rpc_server_create(
+            "server_node", kServiceConfig, kEndpointConfig, 1000, "real");
+        client = hako_pdu_rpc_client_create(
+            "client_node", "TestClient", kServiceConfig, kEndpointConfig, 1000, "real");
+        return server && client &&
+            hako_pdu_rpc_server_start(server) == HAKO_PDU_RPC_OK &&
+            hako_pdu_rpc_client_start(client) == HAKO_PDU_RPC_OK;
+    }
+};
+
+std::vector<uint8_t> make_request(hako_pdu_rpc_client_handle_t* client, long long a, long long b)
+{
+    size_t size = 0;
+    EXPECT_EQ(hako_pdu_rpc_client_create_request_buffer(client, kService, nullptr, 0, &size),
+        HAKO_PDU_RPC_ERROR_BUFFER_TOO_SMALL);
+    std::vector<uint8_t> pdu(size);
+    EXPECT_EQ(hako_pdu_rpc_client_create_request_buffer(client, kService, pdu.data(), pdu.size(), &size),
+        HAKO_PDU_RPC_OK);
+    pdu.resize(size);
+
+    AddTwoIntsRequestPacket converter;
+    HakoCpp_AddTwoIntsRequestPacket value{};
+    EXPECT_TRUE(converter.pdu2cpp(reinterpret_cast<char*>(pdu.data()), value));
+    value.body.a = a;
+    value.body.b = b;
+    const int encoded = converter.cpp2pdu(
+        value, reinterpret_cast<char*>(pdu.data()), static_cast<int>(pdu.size()));
+    EXPECT_GT(encoded, 0);
+    pdu.resize(static_cast<size_t>(encoded));
+    return pdu;
+}
+
+bool call_when_connected(hako_pdu_rpc_client_handle_t* client, const std::vector<uint8_t>& pdu, uint64_t timeout)
+{
+    const auto deadline = std::chrono::steady_clock::now() + 3s;
+    do {
+        const auto result = hako_pdu_rpc_client_call(client, kService, pdu.data(), pdu.size(), timeout);
+        if (result == HAKO_PDU_RPC_OK) return true;
+        if (result != HAKO_PDU_RPC_ERROR_CALL) return false;
+        std::this_thread::sleep_for(10ms);
+    } while (std::chrono::steady_clock::now() < deadline);
+    return false;
+}
+
+hako_pdu_rpc_server_event_t wait_server(
+    hako_pdu_rpc_server_handle_t* server,
+    hako_pdu_rpc_request_info_t& info,
+    std::vector<uint8_t>& pdu)
+{
+    const auto deadline = std::chrono::steady_clock::now() + 3s;
+    do {
+        size_t size = 0;
+        hako_pdu_rpc_error_t error = HAKO_PDU_RPC_OK;
+        const auto event = hako_pdu_rpc_server_poll(
+            server, &info, pdu.data(), pdu.size(), &size, &error);
+        if (error != HAKO_PDU_RPC_OK) return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+        if (event != HAKO_PDU_RPC_SERVER_EVENT_NONE) {
+            pdu.resize(size);
+            return event;
+        }
+        std::this_thread::sleep_for(1ms);
+    } while (std::chrono::steady_clock::now() < deadline);
+    return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+}
+
+hako_pdu_rpc_client_event_t wait_client(
+    hako_pdu_rpc_client_handle_t* client,
+    hako_pdu_rpc_response_info_t& info,
+    std::vector<uint8_t>& pdu)
+{
+    const auto deadline = std::chrono::steady_clock::now() + 3s;
+    do {
+        size_t size = 0;
+        hako_pdu_rpc_error_t error = HAKO_PDU_RPC_OK;
+        const auto event = hako_pdu_rpc_client_poll(
+            client, &info, pdu.data(), pdu.size(), &size, &error);
+        if (error != HAKO_PDU_RPC_OK) return HAKO_PDU_RPC_CLIENT_EVENT_NONE;
+        if (event != HAKO_PDU_RPC_CLIENT_EVENT_NONE) {
+            pdu.resize(size);
+            return event;
+        }
+        std::this_thread::sleep_for(1ms);
+    } while (std::chrono::steady_clock::now() < deadline);
+    return HAKO_PDU_RPC_CLIENT_EVENT_NONE;
+}
+
+std::vector<uint8_t> make_reply(
+    hako_pdu_rpc_server_handle_t* server,
+    uint64_t token,
+    int32_t result_code,
+    long long sum)
+{
+    const auto done = static_cast<uint8_t>(hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE);
+    size_t size = 0;
+    EXPECT_EQ(hako_pdu_rpc_server_create_reply_buffer(
+        server, token, done, result_code, nullptr, 0, &size),
+        HAKO_PDU_RPC_ERROR_BUFFER_TOO_SMALL);
+    std::vector<uint8_t> pdu(size);
+    EXPECT_EQ(hako_pdu_rpc_server_create_reply_buffer(
+        server, token, done, result_code, pdu.data(), pdu.size(), &size),
+        HAKO_PDU_RPC_OK);
+    pdu.resize(size);
+
+    AddTwoIntsResponsePacket converter;
+    HakoCpp_AddTwoIntsResponsePacket value{};
+    EXPECT_TRUE(converter.pdu2cpp(reinterpret_cast<char*>(pdu.data()), value));
+    value.body.sum = sum;
+    const int encoded = converter.cpp2pdu(
+        value, reinterpret_cast<char*>(pdu.data()), static_cast<int>(pdu.size()));
+    EXPECT_GT(encoded, 0);
+    pdu.resize(static_cast<size_t>(encoded));
+    return pdu;
+}
+
+TEST(CRpcTimeoutCancelContractTest, TimeoutRequiresExplicitCancelAndTerminalCancelCompletion)
+{
+    Runtime runtime;
+    ASSERT_TRUE(runtime.start());
+
+    auto request = make_request(runtime.client, 10, 20);
+    ASSERT_TRUE(call_when_connected(runtime.client, request, 50'000));
+
+    hako_pdu_rpc_request_info_t original_info{};
+    std::vector<uint8_t> original_pdu(kMaxPdu);
+    ASSERT_EQ(wait_server(runtime.server, original_info, original_pdu),
+        HAKO_PDU_RPC_SERVER_EVENT_REQUEST_IN);
+
+    AddTwoIntsRequestPacket request_converter;
+    HakoCpp_AddTwoIntsRequestPacket original_cpp{};
+    ASSERT_TRUE(request_converter.pdu2cpp(
+        reinterpret_cast<char*>(original_pdu.data()), original_cpp));
+
+    hako_pdu_rpc_response_info_t response_info{};
+    std::vector<uint8_t> response(kMaxPdu);
+    ASSERT_EQ(wait_client(runtime.client, response_info, response),
+        HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_TIMEOUT);
+    ASSERT_STREQ(response_info.service_name, kService);
+
+    ASSERT_EQ(hako_pdu_rpc_client_cancel(runtime.client, kService), HAKO_PDU_RPC_OK);
+
+    hako_pdu_rpc_request_info_t cancel_info{};
+    std::vector<uint8_t> cancel_pdu(kMaxPdu);
+    ASSERT_EQ(wait_server(runtime.server, cancel_info, cancel_pdu),
+        HAKO_PDU_RPC_SERVER_EVENT_REQUEST_CANCEL);
+
+    HakoCpp_AddTwoIntsRequestPacket cancel_cpp{};
+    ASSERT_TRUE(request_converter.pdu2cpp(
+        reinterpret_cast<char*>(cancel_pdu.data()), cancel_cpp));
+    ASSERT_EQ(cancel_cpp.header.request_id, original_cpp.header.request_id);
+
+    const auto canceled = static_cast<int32_t>(
+        hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_CANCELED);
+    auto cancel_reply = make_reply(runtime.server, cancel_info.request_token, canceled, 0);
+    ASSERT_EQ(hako_pdu_rpc_server_send_cancel_reply(
+        runtime.server, cancel_info.request_token, cancel_reply.data(), cancel_reply.size()),
+        HAKO_PDU_RPC_OK);
+
+    response_info = {};
+    response.assign(kMaxPdu, 0);
+    ASSERT_EQ(wait_client(runtime.client, response_info, response),
+        HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_CANCEL);
+
+    auto next_request = make_request(runtime.client, 7, 8);
+    ASSERT_TRUE(call_when_connected(runtime.client, next_request, 1'000'000));
+
+    hako_pdu_rpc_request_info_t next_info{};
+    std::vector<uint8_t> next_pdu(kMaxPdu);
+    ASSERT_EQ(wait_server(runtime.server, next_info, next_pdu),
+        HAKO_PDU_RPC_SERVER_EVENT_REQUEST_IN);
+
+    const auto ok = static_cast<int32_t>(hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_OK);
+    auto next_reply = make_reply(runtime.server, next_info.request_token, ok, 15);
+    ASSERT_EQ(hako_pdu_rpc_server_send_reply(
+        runtime.server, next_info.request_token, next_reply.data(), next_reply.size()),
+        HAKO_PDU_RPC_OK);
+
+    response_info = {};
+    response.assign(kMaxPdu, 0);
+    ASSERT_EQ(wait_client(runtime.client, response_info, response),
+        HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_IN);
+
+    AddTwoIntsResponsePacket response_converter;
+    HakoCpp_AddTwoIntsResponsePacket parsed{};
+    ASSERT_TRUE(response_converter.pdu2cpp(reinterpret_cast<char*>(response.data()), parsed));
+    EXPECT_EQ(parsed.body.sum, 15);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Validate the existing timeout/cancel contract through the C API.

## Scope

- issue an AddTwoInts request with a finite timeout;
- verify timeout is reported as a notification while the request remains in flight;
- send an explicit cancel request;
- verify the server receives a cancel for the same request ID;
- send a terminal canceled response;
- verify the client reports `RESPONSE_CANCEL`;
- verify the endpoint becomes reusable by completing a second normal RPC;
- run the existing C++ and new C API contracts side by side on Ubuntu x64, Ubuntu ARM64, macOS, and Windows x64.

## Deliberately excluded

- no Python or CFFI changes;
- no cancel-race migration yet;
- no RPC or Endpoint state-machine changes;
- no removal of the existing C++ contract.

## Merge condition

Both timeout-cancel contracts must pass on all four platforms.