### PR TITLE
feat: connect Python CFFI to the C RPC API

### DIFF
--- a/.github/workflows/python-cffi-tests.yml
+++ b/.github/workflows/python-cffi-tests.yml
@@ -1,0 +1,75 @@
+name: python-cffi-tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pdu-rpc-python-cffi-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  basic-round-trip:
+    name: Ubuntu x64
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout with Registry submodule
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libboost-dev
+          python -m pip install --upgrade pip
+          python -m pip install cffi pytest
+
+      - name: Build and install shared Core-free Endpoint package
+        shell: bash
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF \
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --parallel
+          cmake --install endpoint/build --config Release --prefix "${GITHUB_WORKSPACE}/endpoint-install"
+
+      - name: Build shared RPC library
+        shell: bash
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
+            -DHAKO_PDU_RPC_BUILD_TESTS=OFF \
+            -DHAKO_PDU_ENDPOINT_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
+            -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/endpoint-install"
+          cmake --build build --config Release --target hakoniwa_pdu_rpc --parallel
+
+      - name: Python CFFI basic round trip
+        shell: bash
+        run: |
+          RPC_LIBRARY="$(find "${GITHUB_WORKSPACE}/build" -name 'libhakoniwa_pdu_rpc.so' -print -quit)"
+          test -n "$RPC_LIBRARY"
+          export HAKO_PDU_RPC_LIBRARY="$RPC_LIBRARY"
+          export PYTHONPATH="${GITHUB_WORKSPACE}/python"
+          export LD_LIBRARY_PATH="${GITHUB_WORKSPACE}/endpoint-install/lib:${GITHUB_WORKSPACE}/build/src:${LD_LIBRARY_PATH:-}"
+          python -m pytest -q python/test_cffi_basic.py

--- a/include/hakoniwa/pdu/rpc/c_rpc.h
+++ b/include/hakoniwa/pdu/rpc/c_rpc.h
@@ -51,21 +51,33 @@ typedef struct {
     size_t pdu_size;
 } hako_pdu_rpc_request_info_t;
 
+/*
+ * Buffers returned by an *_alloc function are owned by the caller and must be
+ * released with hako_pdu_rpc_buffer_free(). The function is NULL-safe.
+ * Language bindings should copy the bytes into their native memory and free
+ * the C buffer immediately.
+ */
+void hako_pdu_rpc_buffer_free(uint8_t* buffer);
+
 hako_pdu_rpc_client_handle_t* hako_pdu_rpc_client_create(const char* node_id, const char* client_name, const char* service_config_path, const char* endpoint_config_path, uint64_t delta_time_usec, const char* time_source_type);
 void hako_pdu_rpc_client_destroy(hako_pdu_rpc_client_handle_t* handle);
 hako_pdu_rpc_error_t hako_pdu_rpc_client_start(hako_pdu_rpc_client_handle_t* handle);
 hako_pdu_rpc_error_t hako_pdu_rpc_client_stop(hako_pdu_rpc_client_handle_t* handle);
 hako_pdu_rpc_error_t hako_pdu_rpc_client_create_request_buffer(hako_pdu_rpc_client_handle_t* handle, const char* service_name, uint8_t* buffer, size_t capacity, size_t* out_size);
+hako_pdu_rpc_error_t hako_pdu_rpc_client_create_request_buffer_alloc(hako_pdu_rpc_client_handle_t* handle, const char* service_name, uint8_t** out_buffer, size_t* out_size);
 hako_pdu_rpc_error_t hako_pdu_rpc_client_call(hako_pdu_rpc_client_handle_t* handle, const char* service_name, const uint8_t* pdu, size_t pdu_size, uint64_t timeout_usec);
 hako_pdu_rpc_error_t hako_pdu_rpc_client_cancel(hako_pdu_rpc_client_handle_t* handle, const char* service_name);
 hako_pdu_rpc_client_event_t hako_pdu_rpc_client_poll(hako_pdu_rpc_client_handle_t* handle, hako_pdu_rpc_response_info_t* out_info, uint8_t* buffer, size_t capacity, size_t* out_size, hako_pdu_rpc_error_t* out_error);
+hako_pdu_rpc_client_event_t hako_pdu_rpc_client_poll_alloc(hako_pdu_rpc_client_handle_t* handle, hako_pdu_rpc_response_info_t* out_info, uint8_t** out_buffer, size_t* out_size, hako_pdu_rpc_error_t* out_error);
 
 hako_pdu_rpc_server_handle_t* hako_pdu_rpc_server_create(const char* node_id, const char* service_config_path, const char* endpoint_config_path, uint64_t delta_time_usec, const char* time_source_type);
 void hako_pdu_rpc_server_destroy(hako_pdu_rpc_server_handle_t* handle);
 hako_pdu_rpc_error_t hako_pdu_rpc_server_start(hako_pdu_rpc_server_handle_t* handle);
 hako_pdu_rpc_error_t hako_pdu_rpc_server_stop(hako_pdu_rpc_server_handle_t* handle);
 hako_pdu_rpc_server_event_t hako_pdu_rpc_server_poll(hako_pdu_rpc_server_handle_t* handle, hako_pdu_rpc_request_info_t* out_info, uint8_t* buffer, size_t capacity, size_t* out_size, hako_pdu_rpc_error_t* out_error);
+hako_pdu_rpc_server_event_t hako_pdu_rpc_server_poll_alloc(hako_pdu_rpc_server_handle_t* handle, hako_pdu_rpc_request_info_t* out_info, uint8_t** out_buffer, size_t* out_size, hako_pdu_rpc_error_t* out_error);
 hako_pdu_rpc_error_t hako_pdu_rpc_server_create_reply_buffer(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, uint8_t status, int32_t result_code, uint8_t* buffer, size_t capacity, size_t* out_size);
+hako_pdu_rpc_error_t hako_pdu_rpc_server_create_reply_buffer_alloc(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, uint8_t status, int32_t result_code, uint8_t** out_buffer, size_t* out_size);
 hako_pdu_rpc_error_t hako_pdu_rpc_server_send_reply(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, const uint8_t* pdu, size_t pdu_size);
 hako_pdu_rpc_error_t hako_pdu_rpc_server_send_cancel_reply(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, const uint8_t* pdu, size_t pdu_size);
 

--- a/python/hakoniwa_pdu_rpc/__init__.py
+++ b/python/hakoniwa_pdu_rpc/__init__.py
@@ -1,3 +1,22 @@
-"""Hakoniwa PDU RPC validation utilities."""
+"""Hakoniwa PDU RPC Python bindings and validation utilities."""
 
-__all__ = ["validate_configs"]
+from .cffi_api import (
+    ClientEvent,
+    ClientPollResult,
+    RpcClient,
+    RpcError,
+    RpcServer,
+    ServerEvent,
+    ServerPollResult,
+)
+
+__all__ = [
+    "ClientEvent",
+    "ClientPollResult",
+    "RpcClient",
+    "RpcError",
+    "RpcServer",
+    "ServerEvent",
+    "ServerPollResult",
+    "validate_configs",
+]

--- a/python/hakoniwa_pdu_rpc/cffi_api.py
+++ b/python/hakoniwa_pdu_rpc/cffi_api.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+from typing import Optional
+
+from cffi import FFI
+
+
+class RpcError(RuntimeError):
+    pass
+
+
+class ClientEvent(IntEnum):
+    NONE = 0
+    RESPONSE_IN = 1
+    RESPONSE_CANCEL = 2
+    RESPONSE_TIMEOUT = 3
+
+
+class ServerEvent(IntEnum):
+    NONE = 0
+    REQUEST_IN = 1
+    REQUEST_CANCEL = 2
+
+
+@dataclass(frozen=True)
+class ClientPollResult:
+    event: ClientEvent
+    service_name: str
+    pdu: bytes
+
+
+@dataclass(frozen=True)
+class ServerPollResult:
+    event: ServerEvent
+    request_token: int
+    service_name: str
+    client_name: str
+    pdu: bytes
+
+
+_CDEF = r"""
+typedef struct hako_pdu_rpc_client_handle hako_pdu_rpc_client_handle_t;
+typedef struct hako_pdu_rpc_server_handle hako_pdu_rpc_server_handle_t;
+
+typedef int hako_pdu_rpc_error_t;
+typedef int hako_pdu_rpc_client_event_t;
+typedef int hako_pdu_rpc_server_event_t;
+
+typedef struct {
+    char service_name[128];
+    size_t pdu_size;
+} hako_pdu_rpc_response_info_t;
+
+typedef struct {
+    uint64_t request_token;
+    char service_name[128];
+    char client_name[128];
+    size_t pdu_size;
+} hako_pdu_rpc_request_info_t;
+
+void hako_pdu_rpc_buffer_free(uint8_t* buffer);
+
+hako_pdu_rpc_client_handle_t* hako_pdu_rpc_client_create(
+    const char*, const char*, const char*, const char*, uint64_t, const char*);
+void hako_pdu_rpc_client_destroy(hako_pdu_rpc_client_handle_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_client_start(hako_pdu_rpc_client_handle_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_client_stop(hako_pdu_rpc_client_handle_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_client_create_request_buffer_alloc(
+    hako_pdu_rpc_client_handle_t*, const char*, uint8_t**, size_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_client_call(
+    hako_pdu_rpc_client_handle_t*, const char*, const uint8_t*, size_t, uint64_t);
+hako_pdu_rpc_error_t hako_pdu_rpc_client_cancel(
+    hako_pdu_rpc_client_handle_t*, const char*);
+hako_pdu_rpc_client_event_t hako_pdu_rpc_client_poll_alloc(
+    hako_pdu_rpc_client_handle_t*, hako_pdu_rpc_response_info_t*,
+    uint8_t**, size_t*, hako_pdu_rpc_error_t*);
+
+hako_pdu_rpc_server_handle_t* hako_pdu_rpc_server_create(
+    const char*, const char*, const char*, uint64_t, const char*);
+void hako_pdu_rpc_server_destroy(hako_pdu_rpc_server_handle_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_server_start(hako_pdu_rpc_server_handle_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_server_stop(hako_pdu_rpc_server_handle_t*);
+hako_pdu_rpc_server_event_t hako_pdu_rpc_server_poll_alloc(
+    hako_pdu_rpc_server_handle_t*, hako_pdu_rpc_request_info_t*,
+    uint8_t**, size_t*, hako_pdu_rpc_error_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_server_create_reply_buffer_alloc(
+    hako_pdu_rpc_server_handle_t*, uint64_t, uint8_t, int32_t,
+    uint8_t**, size_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_server_send_reply(
+    hako_pdu_rpc_server_handle_t*, uint64_t, const uint8_t*, size_t);
+hako_pdu_rpc_error_t hako_pdu_rpc_server_send_cancel_reply(
+    hako_pdu_rpc_server_handle_t*, uint64_t, const uint8_t*, size_t);
+"""
+
+
+class _Binding:
+    def __init__(self, library_path: str | Path):
+        self.ffi = FFI()
+        self.ffi.cdef(_CDEF)
+        self.lib = self.ffi.dlopen(str(library_path))
+
+    def encode(self, value: str | Path):
+        return self.ffi.new("char[]", str(value).encode("utf-8"))
+
+    def take_bytes(self, pointer, size: int) -> bytes:
+        if pointer == self.ffi.NULL or size == 0:
+            return b""
+        try:
+            return bytes(self.ffi.buffer(pointer, size))
+        finally:
+            self.lib.hako_pdu_rpc_buffer_free(pointer)
+
+    def allocated_call(self, function, *args) -> bytes:
+        out_buffer = self.ffi.new("uint8_t **")
+        out_size = self.ffi.new("size_t *")
+        error = int(function(*args, out_buffer, out_size))
+        pointer = out_buffer[0]
+        try:
+            if error != 0:
+                raise RpcError(f"native RPC error: {error}")
+            return b"" if pointer == self.ffi.NULL else bytes(
+                self.ffi.buffer(pointer, int(out_size[0]))
+            )
+        finally:
+            self.lib.hako_pdu_rpc_buffer_free(pointer)
+
+
+def _borrow_bytes(binding: _Binding, data: bytes):
+    if not data:
+        return binding.ffi.NULL
+    return binding.ffi.new("uint8_t[]", data)
+
+
+class RpcClient:
+    def __init__(
+        self,
+        library_path: str | Path,
+        node_id: str,
+        client_name: str,
+        service_config_path: str | Path,
+        endpoint_config_path: str | Path,
+        delta_time_usec: int = 1000,
+        time_source_type: str = "real",
+    ):
+        self._binding = _Binding(library_path)
+        b = self._binding
+        self._handle = b.lib.hako_pdu_rpc_client_create(
+            b.encode(node_id),
+            b.encode(client_name),
+            b.encode(service_config_path),
+            b.encode(endpoint_config_path),
+            delta_time_usec,
+            b.encode(time_source_type),
+        )
+        if self._handle == b.ffi.NULL:
+            raise RpcError("failed to create RPC client")
+        self._closed = False
+
+    def start(self) -> None:
+        self._check(self._binding.lib.hako_pdu_rpc_client_start(self._handle))
+
+    def create_request_buffer(self, service_name: str) -> bytes:
+        b = self._binding
+        return b.allocated_call(
+            b.lib.hako_pdu_rpc_client_create_request_buffer_alloc,
+            self._handle,
+            b.encode(service_name),
+        )
+
+    def call(self, service_name: str, pdu: bytes, timeout_usec: int) -> None:
+        b = self._binding
+        native = _borrow_bytes(b, pdu)
+        self._check(
+            b.lib.hako_pdu_rpc_client_call(
+                self._handle,
+                b.encode(service_name),
+                native,
+                len(pdu),
+                timeout_usec,
+            )
+        )
+
+    def cancel(self, service_name: str) -> None:
+        b = self._binding
+        self._check(
+            b.lib.hako_pdu_rpc_client_cancel(self._handle, b.encode(service_name))
+        )
+
+    def poll(self) -> ClientPollResult:
+        b = self._binding
+        info = b.ffi.new("hako_pdu_rpc_response_info_t *")
+        out_buffer = b.ffi.new("uint8_t **")
+        out_size = b.ffi.new("size_t *")
+        out_error = b.ffi.new("hako_pdu_rpc_error_t *")
+        event = ClientEvent(
+            int(
+                b.lib.hako_pdu_rpc_client_poll_alloc(
+                    self._handle, info, out_buffer, out_size, out_error
+                )
+            )
+        )
+        pointer = out_buffer[0]
+        try:
+            if int(out_error[0]) != 0:
+                raise RpcError(f"native RPC error: {int(out_error[0])}")
+            data = b"" if pointer == b.ffi.NULL else bytes(
+                b.ffi.buffer(pointer, int(out_size[0]))
+            )
+        finally:
+            b.lib.hako_pdu_rpc_buffer_free(pointer)
+        return ClientPollResult(
+            event=event,
+            service_name=b.ffi.string(info.service_name).decode("utf-8"),
+            pdu=data,
+        )
+
+    def close(self) -> None:
+        if not self._closed:
+            self._binding.lib.hako_pdu_rpc_client_destroy(self._handle)
+            self._handle = self._binding.ffi.NULL
+            self._closed = True
+
+    def __enter__(self) -> "RpcClient":
+        return self
+
+    def __exit__(self, *_args) -> None:
+        self.close()
+
+    @staticmethod
+    def _check(error: int) -> None:
+        if int(error) != 0:
+            raise RpcError(f"native RPC error: {int(error)}")
+
+
+class RpcServer:
+    def __init__(
+        self,
+        library_path: str | Path,
+        node_id: str,
+        service_config_path: str | Path,
+        endpoint_config_path: str | Path,
+        delta_time_usec: int = 1000,
+        time_source_type: str = "real",
+    ):
+        self._binding = _Binding(library_path)
+        b = self._binding
+        self._handle = b.lib.hako_pdu_rpc_server_create(
+            b.encode(node_id),
+            b.encode(service_config_path),
+            b.encode(endpoint_config_path),
+            delta_time_usec,
+            b.encode(time_source_type),
+        )
+        if self._handle == b.ffi.NULL:
+            raise RpcError("failed to create RPC server")
+        self._closed = False
+
+    def start(self) -> None:
+        self._check(self._binding.lib.hako_pdu_rpc_server_start(self._handle))
+
+    def poll(self) -> ServerPollResult:
+        b = self._binding
+        info = b.ffi.new("hako_pdu_rpc_request_info_t *")
+        out_buffer = b.ffi.new("uint8_t **")
+        out_size = b.ffi.new("size_t *")
+        out_error = b.ffi.new("hako_pdu_rpc_error_t *")
+        event = ServerEvent(
+            int(
+                b.lib.hako_pdu_rpc_server_poll_alloc(
+                    self._handle, info, out_buffer, out_size, out_error
+                )
+            )
+        )
+        pointer = out_buffer[0]
+        try:
+            if int(out_error[0]) != 0:
+                raise RpcError(f"native RPC error: {int(out_error[0])}")
+            data = b"" if pointer == b.ffi.NULL else bytes(
+                b.ffi.buffer(pointer, int(out_size[0]))
+            )
+        finally:
+            b.lib.hako_pdu_rpc_buffer_free(pointer)
+        return ServerPollResult(
+            event=event,
+            request_token=int(info.request_token),
+            service_name=b.ffi.string(info.service_name).decode("utf-8"),
+            client_name=b.ffi.string(info.client_name).decode("utf-8"),
+            pdu=data,
+        )
+
+    def create_reply_buffer(
+        self, request_token: int, status: int, result_code: int
+    ) -> bytes:
+        b = self._binding
+        return b.allocated_call(
+            b.lib.hako_pdu_rpc_server_create_reply_buffer_alloc,
+            self._handle,
+            request_token,
+            status,
+            result_code,
+        )
+
+    def send_reply(self, request_token: int, pdu: bytes) -> None:
+        b = self._binding
+        native = _borrow_bytes(b, pdu)
+        self._check(
+            b.lib.hako_pdu_rpc_server_send_reply(
+                self._handle, request_token, native, len(pdu)
+            )
+        )
+
+    def send_cancel_reply(self, request_token: int, pdu: bytes) -> None:
+        b = self._binding
+        native = _borrow_bytes(b, pdu)
+        self._check(
+            b.lib.hako_pdu_rpc_server_send_cancel_reply(
+                self._handle, request_token, native, len(pdu)
+            )
+        )
+
+    def close(self) -> None:
+        if not self._closed:
+            self._binding.lib.hako_pdu_rpc_server_destroy(self._handle)
+            self._handle = self._binding.ffi.NULL
+            self._closed = True
+
+    def __enter__(self) -> "RpcServer":
+        return self
+
+    def __exit__(self, *_args) -> None:
+        self.close()
+
+    @staticmethod
+    def _check(error: int) -> None:
+        if int(error) != 0:
+            raise RpcError(f"native RPC error: {int(error)}")

--- a/python/test_cffi_basic.py
+++ b/python/test_cffi_basic.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from hakoniwa_pdu_rpc.cffi_api import ClientEvent, RpcClient, RpcServer, ServerEvent
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_CONFIG = ROOT / "test" / "configs" / "service_config.json"
+ENDPOINT_CONFIG = ROOT / "test" / "configs" / "endpoints.json"
+SERVICE = "Service/Add"
+
+
+def wait_server(server: RpcServer, timeout: float = 3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = server.poll()
+        if result.event != ServerEvent.NONE:
+            return result
+        time.sleep(0.001)
+    raise AssertionError("server request timed out")
+
+
+def wait_client(client: RpcClient, timeout: float = 3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = client.poll()
+        if result.event != ClientEvent.NONE:
+            return result
+        time.sleep(0.001)
+    raise AssertionError("client response timed out")
+
+
+def test_basic_round_trip_copies_and_frees_native_buffers():
+    library = os.environ["HAKO_PDU_RPC_LIBRARY"]
+
+    with RpcServer(
+        library,
+        "server_node",
+        SERVICE_CONFIG,
+        ENDPOINT_CONFIG,
+    ) as server, RpcClient(
+        library,
+        "client_node",
+        "TestClient",
+        SERVICE_CONFIG,
+        ENDPOINT_CONFIG,
+    ) as client:
+        server.start()
+        client.start()
+
+        request = client.create_request_buffer(SERVICE)
+        assert isinstance(request, bytes)
+        assert request
+
+        deadline = time.monotonic() + 3.0
+        while True:
+            try:
+                client.call(SERVICE, request, timeout_usec=1_000_000)
+                break
+            except Exception:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.01)
+
+        incoming = wait_server(server)
+        assert incoming.event == ServerEvent.REQUEST_IN
+        assert incoming.service_name == SERVICE
+        assert isinstance(incoming.pdu, bytes)
+
+        # The Python smoke test validates the ownership boundary rather than
+        # generated message conversion. A default success reply is sufficient.
+        reply = server.create_reply_buffer(
+            incoming.request_token,
+            status=0,
+            result_code=0,
+        )
+        assert isinstance(reply, bytes)
+        server.send_reply(incoming.request_token, reply)
+
+        response = wait_client(client)
+        assert response.event == ClientEvent.RESPONSE_IN
+        assert response.service_name == SERVICE
+        assert isinstance(response.pdu, bytes)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(hakoniwa_pdu_rpc
   rpc_services_client.cpp
   c_rpc.cpp
   c_rpc_cancel.cpp
+  c_rpc_alloc.cpp
 )
 
 add_library(hakoniwa_pdu_rpc::rpc ALIAS hakoniwa_pdu_rpc)

--- a/src/c_rpc_alloc.cpp
+++ b/src/c_rpc_alloc.cpp
@@ -1,0 +1,312 @@
+#include "hakoniwa/pdu/rpc/c_rpc.h"
+
+#include "hakoniwa/pdu/endpoint_container.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_client.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_server.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+
+using hakoniwa::pdu::EndpointContainer;
+using hakoniwa::pdu::rpc::ClientEventType;
+using hakoniwa::pdu::rpc::PduData;
+using hakoniwa::pdu::rpc::RpcRequest;
+using hakoniwa::pdu::rpc::RpcResponse;
+using hakoniwa::pdu::rpc::RpcServicesClient;
+using hakoniwa::pdu::rpc::RpcServicesServer;
+using hakoniwa::pdu::rpc::ServerEventType;
+
+/* Keep these definitions token-compatible with c_rpc.cpp. */
+struct hako_pdu_rpc_client_handle {
+    std::shared_ptr<EndpointContainer> endpoints;
+    std::unique_ptr<RpcServicesClient> rpc;
+    bool started{false};
+};
+
+struct hako_pdu_rpc_server_handle {
+    std::shared_ptr<EndpointContainer> endpoints;
+    std::unique_ptr<RpcServicesServer> rpc;
+    std::mutex pending_mutex;
+    uint64_t next_token{1};
+    std::map<uint64_t, RpcRequest> pending_requests;
+    bool started{false};
+};
+
+namespace {
+
+bool valid_text(const char* value)
+{
+    return value != nullptr && value[0] != '\0';
+}
+
+void copy_name(char* dst, size_t capacity, const std::string& src)
+{
+    if (dst == nullptr || capacity == 0) {
+        return;
+    }
+    const size_t count = std::min(capacity - 1, src.size());
+    std::memcpy(dst, src.data(), count);
+    dst[count] = '\0';
+}
+
+hako_pdu_rpc_error_t allocate_pdu(
+    const PduData& source,
+    uint8_t** out_buffer,
+    size_t* out_size)
+{
+    if (out_buffer == nullptr || out_size == nullptr) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+
+    *out_buffer = nullptr;
+    *out_size = 0;
+    if (source.empty()) {
+        return HAKO_PDU_RPC_OK;
+    }
+
+    auto* buffer = static_cast<uint8_t*>(std::malloc(source.size()));
+    if (buffer == nullptr) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+    std::memcpy(buffer, source.data(), source.size());
+    *out_buffer = buffer;
+    *out_size = source.size();
+    return HAKO_PDU_RPC_OK;
+}
+
+hako_pdu_rpc_client_event_t map_client_event(ClientEventType event)
+{
+    switch (event) {
+    case ClientEventType::RESPONSE_IN:
+        return HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_IN;
+    case ClientEventType::RESPONSE_CANCEL:
+        return HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_CANCEL;
+    case ClientEventType::RESPONSE_TIMEOUT:
+        return HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_TIMEOUT;
+    default:
+        return HAKO_PDU_RPC_CLIENT_EVENT_NONE;
+    }
+}
+
+hako_pdu_rpc_server_event_t map_server_event(ServerEventType event)
+{
+    switch (event) {
+    case ServerEventType::REQUEST_IN:
+        return HAKO_PDU_RPC_SERVER_EVENT_REQUEST_IN;
+    case ServerEventType::REQUEST_CANCEL:
+        return HAKO_PDU_RPC_SERVER_EVENT_REQUEST_CANCEL;
+    default:
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+}
+
+} // namespace
+
+extern "C" {
+
+void hako_pdu_rpc_buffer_free(uint8_t* buffer)
+{
+    std::free(buffer);
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_client_create_request_buffer_alloc(
+    hako_pdu_rpc_client_handle_t* handle,
+    const char* service_name,
+    uint8_t** out_buffer,
+    size_t* out_size)
+{
+    if (out_buffer != nullptr) {
+        *out_buffer = nullptr;
+    }
+    if (out_size != nullptr) {
+        *out_size = 0;
+    }
+    if (handle == nullptr || !valid_text(service_name) || out_buffer == nullptr || out_size == nullptr) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    if (!handle->started || !handle->rpc) {
+        return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    }
+
+    try {
+        PduData pdu;
+        if (!handle->rpc->create_request_buffer(service_name, pdu)) {
+            return HAKO_PDU_RPC_ERROR_NOT_FOUND;
+        }
+        return allocate_pdu(pdu, out_buffer, out_size);
+    } catch (...) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+}
+
+hako_pdu_rpc_client_event_t hako_pdu_rpc_client_poll_alloc(
+    hako_pdu_rpc_client_handle_t* handle,
+    hako_pdu_rpc_response_info_t* info,
+    uint8_t** out_buffer,
+    size_t* out_size,
+    hako_pdu_rpc_error_t* out_error)
+{
+    if (out_buffer != nullptr) {
+        *out_buffer = nullptr;
+    }
+    if (out_size != nullptr) {
+        *out_size = 0;
+    }
+    if (out_error != nullptr) {
+        *out_error = HAKO_PDU_RPC_OK;
+    }
+    if (handle == nullptr || info == nullptr || out_buffer == nullptr || out_size == nullptr) {
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+        }
+        return HAKO_PDU_RPC_CLIENT_EVENT_NONE;
+    }
+    if (!handle->started || !handle->rpc) {
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+        }
+        return HAKO_PDU_RPC_CLIENT_EVENT_NONE;
+    }
+
+    try {
+        std::string service_name;
+        RpcResponse response;
+        const auto event = handle->rpc->poll(service_name, response);
+        if (event == ClientEventType::NONE) {
+            return HAKO_PDU_RPC_CLIENT_EVENT_NONE;
+        }
+
+        const auto result = allocate_pdu(response.pdu, out_buffer, out_size);
+        if (result != HAKO_PDU_RPC_OK) {
+            if (out_error != nullptr) {
+                *out_error = result;
+            }
+            return HAKO_PDU_RPC_CLIENT_EVENT_NONE;
+        }
+        copy_name(info->service_name, sizeof(info->service_name), service_name);
+        info->pdu_size = response.pdu.size();
+        return map_client_event(event);
+    } catch (...) {
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_INTERNAL;
+        }
+        return HAKO_PDU_RPC_CLIENT_EVENT_NONE;
+    }
+}
+
+hako_pdu_rpc_server_event_t hako_pdu_rpc_server_poll_alloc(
+    hako_pdu_rpc_server_handle_t* handle,
+    hako_pdu_rpc_request_info_t* info,
+    uint8_t** out_buffer,
+    size_t* out_size,
+    hako_pdu_rpc_error_t* out_error)
+{
+    if (out_buffer != nullptr) {
+        *out_buffer = nullptr;
+    }
+    if (out_size != nullptr) {
+        *out_size = 0;
+    }
+    if (out_error != nullptr) {
+        *out_error = HAKO_PDU_RPC_OK;
+    }
+    if (handle == nullptr || info == nullptr || out_buffer == nullptr || out_size == nullptr) {
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+        }
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+    if (!handle->started || !handle->rpc) {
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+        }
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+
+    try {
+        RpcRequest request;
+        const auto event = handle->rpc->poll(request);
+        if (event == ServerEventType::NONE) {
+            return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+        }
+
+        const auto result = allocate_pdu(request.pdu, out_buffer, out_size);
+        if (result != HAKO_PDU_RPC_OK) {
+            if (out_error != nullptr) {
+                *out_error = result;
+            }
+            return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+        }
+
+        uint64_t token = 0;
+        {
+            std::lock_guard<std::mutex> lock(handle->pending_mutex);
+            token = handle->next_token++;
+            handle->pending_requests.emplace(token, request);
+        }
+        info->request_token = token;
+        copy_name(info->service_name, sizeof(info->service_name), request.header.service_name);
+        copy_name(info->client_name, sizeof(info->client_name), request.client_name);
+        info->pdu_size = request.pdu.size();
+        return map_server_event(event);
+    } catch (...) {
+        hako_pdu_rpc_buffer_free(*out_buffer);
+        *out_buffer = nullptr;
+        *out_size = 0;
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_INTERNAL;
+        }
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_server_create_reply_buffer_alloc(
+    hako_pdu_rpc_server_handle_t* handle,
+    uint64_t request_token,
+    uint8_t status,
+    int32_t result_code,
+    uint8_t** out_buffer,
+    size_t* out_size)
+{
+    if (out_buffer != nullptr) {
+        *out_buffer = nullptr;
+    }
+    if (out_size != nullptr) {
+        *out_size = 0;
+    }
+    if (handle == nullptr || out_buffer == nullptr || out_size == nullptr) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    if (!handle->started || !handle->rpc) {
+        return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    }
+
+    try {
+        RpcRequest request;
+        {
+            std::lock_guard<std::mutex> lock(handle->pending_mutex);
+            const auto it = handle->pending_requests.find(request_token);
+            if (it == handle->pending_requests.end()) {
+                return HAKO_PDU_RPC_ERROR_NOT_FOUND;
+            }
+            request = it->second;
+        }
+
+        PduData response;
+        handle->rpc->create_reply_buffer(
+            request.header,
+            static_cast<Hako_uint8>(status),
+            static_cast<Hako_int32>(result_code),
+            response);
+        return allocate_pdu(response, out_buffer, out_size);
+    } catch (...) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+}
+
+} // extern "C"


### PR DESCRIPTION
## Summary

Add the first Python/CFFI connection on top of the stabilized C API.

## Ownership model

- C allocates each returned PDU buffer for one binding call;
- the thin CFFI layer copies it immediately into Python `bytes`;
- the C buffer is always released in `finally` through `hako_pdu_rpc_buffer_free()`;
- native PDU pointers are never retained by Python objects;
- Python users do not call `free()`.

## C API additions

- `hako_pdu_rpc_buffer_free()`;
- allocated request-buffer creation;
- allocated client poll;
- allocated server poll;
- allocated reply-buffer creation.

The existing caller-owned buffer API remains unchanged for C/C++ callers.

## Python scope

- thin ABI-mode CFFI loading;
- client/server create, start, call, poll, cancel and reply operations;
- Python `bytes` at every PDU boundary;
- explicit `close()` and context-manager handling for native handles;
- basic round-trip smoke test through the shared library.

## CI scope

The first smoke test runs on Ubuntu x64. Cross-platform shared-library export and packaging are deliberately deferred until the ownership boundary is proven.

## Deliberately excluded

- no high-level blocking or async `call()` abstraction;
- no generated Python message conversion yet;
- no wheel/package publishing;
- no removal of existing C API tests.

## Merge condition

- all existing C/C++ contract workflows remain green;
- the Python CFFI basic round trip passes;
- all returned native PDU buffers are copied and freed inside the thin wrapper.