### PR TITLE
build: validate Python CFFI on shared libraries across platforms

### DIFF
--- a/.github/workflows/python-cffi-tests.yml
+++ b/.github/workflows/python-cffi-tests.yml
@@ -149,7 +149,26 @@ jobs:
         run: |
           $rpc = Get-ChildItem -Path "$env:GITHUB_WORKSPACE/build" -Recurse -Filter "hakoniwa_pdu_rpc.dll" | Select-Object -First 1
           if (-not $rpc) { throw "hakoniwa_pdu_rpc.dll was not found" }
+
+          $dllDirs = @(
+            $rpc.DirectoryName,
+            "$env:GITHUB_WORKSPACE/endpoint-install/bin",
+            "$env:VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
+          ) | Where-Object { Test-Path $_ } | Select-Object -Unique
+
           $env:HAKO_PDU_RPC_LIBRARY = $rpc.FullName
           $env:PYTHONPATH = "$env:GITHUB_WORKSPACE/python"
-          $env:PATH = "$env:GITHUB_WORKSPACE/endpoint-install/bin;$($rpc.DirectoryName);$env:PATH"
-          python -m pytest -q python/test_cffi_basic.py
+          $env:HAKO_PDU_RPC_DLL_DIRS = ($dllDirs -join [IO.Path]::PathSeparator)
+          $env:PATH = "$($dllDirs -join ';');$env:PATH"
+
+          @'
+          import os
+          import pytest
+
+          handles = []
+          for directory in os.environ["HAKO_PDU_RPC_DLL_DIRS"].split(os.pathsep):
+              if directory:
+                  handles.append(os.add_dll_directory(directory))
+
+          raise SystemExit(pytest.main(["-q", "python/test_cffi_basic.py"]))
+          '@ | python -

--- a/.github/workflows/python-cffi-tests.yml
+++ b/.github/workflows/python-cffi-tests.yml
@@ -13,9 +13,21 @@ concurrency:
 
 jobs:
   basic-round-trip:
-    name: Ubuntu x64
-    runs-on: ubuntu-latest
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu x64
+            os: ubuntu-latest
+          - name: Ubuntu ARM64
+            os: ubuntu-24.04-arm
+          - name: macOS
+            os: macos-15
+          - name: Windows x64
+            os: windows-2025
 
     steps:
       - name: Checkout with Registry submodule
@@ -28,15 +40,33 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cffi pytest
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake g++ libboost-dev
-          python -m pip install --upgrade pip
-          python -m pip install cffi pytest
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: brew install cmake boost
+
+      - name: Install Windows dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install boost-asio:x64-windows boost-beast:x64-windows
 
       - name: Build and install shared Core-free Endpoint package
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
@@ -53,7 +83,27 @@ jobs:
           cmake --build endpoint/build --config Release --parallel
           cmake --install endpoint/build --config Release --prefix "${GITHUB_WORKSPACE}/endpoint-install"
 
+      - name: Build and install shared Core-free Endpoint package on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          cmake -S endpoint -B endpoint/build -A x64 `
+            -DBUILD_SHARED_LIBS=ON `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows `
+            -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/endpoint-install" `
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF `
+            -DHAKO_PDU_ENDPOINT_INSTALL=ON
+          cmake --build endpoint/build --config Release --parallel
+          cmake --install endpoint/build --config Release --prefix "$env:GITHUB_WORKSPACE/endpoint-install"
+
       - name: Build shared RPC library
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           cmake -S . -B build \
@@ -64,12 +114,42 @@ jobs:
             -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/endpoint-install"
           cmake --build build --config Release --target hakoniwa_pdu_rpc --parallel
 
+      - name: Build shared RPC library on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cmake -S . -B build -A x64 `
+            -DBUILD_SHARED_LIBS=ON `
+            -DHAKO_PDU_RPC_BUILD_TESTS=OFF `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows `
+            -DHAKO_PDU_ENDPOINT_PREFIX="$env:GITHUB_WORKSPACE/endpoint-install" `
+            -DCMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE/endpoint-install"
+          cmake --build build --config Release --target hakoniwa_pdu_rpc --parallel
+
       - name: Python CFFI basic round trip
+        if: runner.os != 'Windows'
         shell: bash
         run: |
-          RPC_LIBRARY="$(find "${GITHUB_WORKSPACE}/build" -name 'libhakoniwa_pdu_rpc.so' -print -quit)"
+          if [[ "${RUNNER_OS}" == "macOS" ]]; then
+            RPC_LIBRARY="$(find "${GITHUB_WORKSPACE}/build" -name 'libhakoniwa_pdu_rpc.dylib' -print -quit)"
+            export DYLD_LIBRARY_PATH="${GITHUB_WORKSPACE}/endpoint-install/lib:${GITHUB_WORKSPACE}/build/src:${DYLD_LIBRARY_PATH:-}"
+          else
+            RPC_LIBRARY="$(find "${GITHUB_WORKSPACE}/build" -name 'libhakoniwa_pdu_rpc.so' -print -quit)"
+            export LD_LIBRARY_PATH="${GITHUB_WORKSPACE}/endpoint-install/lib:${GITHUB_WORKSPACE}/build/src:${LD_LIBRARY_PATH:-}"
+          fi
           test -n "$RPC_LIBRARY"
           export HAKO_PDU_RPC_LIBRARY="$RPC_LIBRARY"
           export PYTHONPATH="${GITHUB_WORKSPACE}/python"
-          export LD_LIBRARY_PATH="${GITHUB_WORKSPACE}/endpoint-install/lib:${GITHUB_WORKSPACE}/build/src:${LD_LIBRARY_PATH:-}"
+          python -m pytest -q python/test_cffi_basic.py
+
+      - name: Python CFFI basic round trip on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $rpc = Get-ChildItem -Path "$env:GITHUB_WORKSPACE/build" -Recurse -Filter "hakoniwa_pdu_rpc.dll" | Select-Object -First 1
+          if (-not $rpc) { throw "hakoniwa_pdu_rpc.dll was not found" }
+          $env:HAKO_PDU_RPC_LIBRARY = $rpc.FullName
+          $env:PYTHONPATH = "$env:GITHUB_WORKSPACE/python"
+          $env:PATH = "$env:GITHUB_WORKSPACE/endpoint-install/bin;$($rpc.DirectoryName);$env:PATH"
           python -m pytest -q python/test_cffi_basic.py

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,7 +41,10 @@ target_link_libraries(hakoniwa_pdu_rpc
     nlohmann_json::nlohmann_json
 )
 
-set_target_properties(hakoniwa_pdu_rpc PROPERTIES EXPORT_NAME rpc)
+set_target_properties(hakoniwa_pdu_rpc PROPERTIES
+  EXPORT_NAME rpc
+  WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
 
 install(
   TARGETS hakoniwa_pdu_rpc


### PR DESCRIPTION
## Summary

Extend the Python/CFFI basic round-trip smoke test from Ubuntu x64 to the supported shared-library platforms.

## Scope

- export the RPC shared-library symbols on Windows with `WINDOWS_EXPORT_ALL_SYMBOLS`;
- build shared Core-free Endpoint and RPC libraries on Ubuntu x64, Ubuntu ARM64, macOS, and Windows x64;
- load the platform-native RPC library through the existing `HAKO_PDU_RPC_LIBRARY` boundary;
- configure runtime dependency discovery with `LD_LIBRARY_PATH`, `DYLD_LIBRARY_PATH`, or `PATH` as appropriate;
- run the same Python/CFFI basic round trip on all four platforms.

## Ownership contract

This PR does not change the Python/C memory model established previously:

- C allocates the temporary PDU buffer;
- the thin CFFI layer copies it to Python `bytes`;
- the C buffer is freed immediately in `finally`;
- Python users never retain or free a native PDU pointer.

## Deliberately excluded

- no high-level blocking or async Python call API;
- no timeout/cancel Python contract tests yet;
- no wheel publishing or bundled dependency packaging;
- no state-machine changes.

## Merge condition

The Python CFFI basic round trip and existing native contract tests must pass on all configured platforms.