### PR TITLE
test: validate cancel race through Python CFFI

### DIFF
--- a/.github/workflows/python-cffi-tests.yml
+++ b/.github/workflows/python-cffi-tests.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  basic-round-trip:
+  contracts:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -127,7 +127,7 @@ jobs:
             -DCMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE/endpoint-install"
           cmake --build build --config Release --target hakoniwa_pdu_rpc --parallel
 
-      - name: Python CFFI basic round trip
+      - name: Python CFFI contract tests
         if: runner.os != 'Windows'
         shell: bash
         run: |
@@ -141,9 +141,9 @@ jobs:
           test -n "$RPC_LIBRARY"
           export HAKO_PDU_RPC_LIBRARY="$RPC_LIBRARY"
           export PYTHONPATH="${GITHUB_WORKSPACE}/python"
-          python -m pytest -q python/test_cffi_basic.py
+          python -m pytest -q python/test_cffi_*.py
 
-      - name: Python CFFI basic round trip on Windows
+      - name: Python CFFI contract tests on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -170,5 +170,5 @@ jobs:
               if directory:
                   handles.append(os.add_dll_directory(directory))
 
-          raise SystemExit(pytest.main(["-q", "python/test_cffi_basic.py"]))
+          raise SystemExit(pytest.main(["-q", "python/test_cffi_basic.py", "python/test_cffi_timeout_cancel.py", "python/test_cffi_cancel_race.py"]))
           '@ | python -

--- a/python/test_cffi_cancel_race.py
+++ b/python/test_cffi_cancel_race.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from hakoniwa_pdu_rpc.cffi_api import ClientEvent, RpcClient, RpcServer, ServerEvent
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_CONFIG = ROOT / "test" / "configs" / "service_config.json"
+ENDPOINT_CONFIG = ROOT / "test" / "configs" / "endpoints.json"
+SERVICE = "Service/Add"
+
+STATUS_DONE = 3
+RESULT_OK = 0
+
+
+def wait_server(server: RpcServer, timeout: float = 3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = server.poll()
+        if result.event != ServerEvent.NONE:
+            return result
+        time.sleep(0.001)
+    raise AssertionError("server event timed out")
+
+
+def wait_client(client: RpcClient, timeout: float = 3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = client.poll()
+        if result.event != ClientEvent.NONE:
+            return result
+        time.sleep(0.001)
+    raise AssertionError("client event timed out")
+
+
+def call_when_connected(
+    client: RpcClient, request: bytes, timeout_usec: int, timeout: float = 3.0
+) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            client.call(SERVICE, request, timeout_usec=timeout_usec)
+            return
+        except Exception:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.01)
+
+
+def send_normal_reply(server: RpcServer, request_token: int) -> None:
+    reply = server.create_reply_buffer(
+        request_token,
+        status=STATUS_DONE,
+        result_code=RESULT_OK,
+    )
+    server.send_reply(request_token, reply)
+
+
+def test_normal_response_can_win_after_explicit_cancel_and_endpoint_is_reusable():
+    library = os.environ["HAKO_PDU_RPC_LIBRARY"]
+
+    with RpcServer(
+        library,
+        "server_node",
+        SERVICE_CONFIG,
+        ENDPOINT_CONFIG,
+    ) as server, RpcClient(
+        library,
+        "client_node",
+        "TestClient",
+        SERVICE_CONFIG,
+        ENDPOINT_CONFIG,
+    ) as client:
+        server.start()
+        client.start()
+
+        request = client.create_request_buffer(SERVICE)
+        call_when_connected(client, request, timeout_usec=50_000)
+
+        original = wait_server(server)
+        assert original.event == ServerEvent.REQUEST_IN
+        assert original.service_name == SERVICE
+
+        timeout = wait_client(client)
+        assert timeout.event == ClientEvent.RESPONSE_TIMEOUT
+        assert timeout.service_name == SERVICE
+
+        client.cancel(SERVICE)
+
+        # Do not poll the queued cancel yet. Complete the original request first.
+        send_normal_reply(server, original.request_token)
+
+        response = wait_client(client)
+        assert response.event == ClientEvent.RESPONSE_IN
+        assert response.service_name == SERVICE
+        assert isinstance(response.pdu, bytes)
+
+        # The queued late cancel must be harmless and must not poison reuse.
+        next_request = client.create_request_buffer(SERVICE)
+        call_when_connected(client, next_request, timeout_usec=1_000_000)
+
+        next_incoming = wait_server(server)
+        assert next_incoming.event == ServerEvent.REQUEST_IN
+        assert next_incoming.request_token != original.request_token
+
+        send_normal_reply(server, next_incoming.request_token)
+
+        next_response = wait_client(client)
+        assert next_response.event == ClientEvent.RESPONSE_IN
+        assert next_response.service_name == SERVICE
+        assert isinstance(next_response.pdu, bytes)


### PR DESCRIPTION
## Summary

Add the Python/CFFI cancel-race contract and make the shared-library workflow run the complete Python contract suite.

## Contract covered

1. send a request with a finite timeout;
2. server receives the original request;
3. client receives `RESPONSE_TIMEOUT`;
4. client explicitly sends cancel;
5. before the server polls the queued cancel, it completes the original request normally;
6. client receives `RESPONSE_IN`, proving normal completion wins the race;
7. the late queued cancel is harmless;
8. the same endpoint successfully completes the next RPC.

## CI correction

The workflow previously invoked only `python/test_cffi_basic.py` explicitly. This PR changes the workflow to run the complete Python CFFI contract suite on Ubuntu x64, Ubuntu ARM64, macOS, and Windows x64:

- basic round trip;
- timeout-cancel;
- cancel race.

## Memory boundary

All PDU buffers returned by C are still copied immediately to Python `bytes` and freed in the thin CFFI layer. No native PDU pointer is retained by Python.

## Deliberately excluded

- no high-level blocking or async Python API;
- no generated Python message conversion;
- no RPC state-machine changes;
- no packaging or wheel publishing.

## Merge condition

All three Python CFFI contracts pass on all four supported CI platforms, with existing native contracts remaining green.