### PR TITLE
feat: auto-wire PDU Registry service types in Python

### DIFF
--- a/python/hakoniwa_pdu_rpc/__init__.py
+++ b/python/hakoniwa_pdu_rpc/__init__.py
@@ -1,5 +1,6 @@
 """Hakoniwa PDU RPC Python bindings and validation utilities."""
 
+from .auto_wire import ServiceWire, TypedRpcClient, load_service_wire, make_typed_client
 from .cffi_api import (
     ClientEvent,
     ClientPollResult,
@@ -22,5 +23,9 @@ __all__ = [
     "RpcTimeoutError",
     "ServerEvent",
     "ServerPollResult",
+    "ServiceWire",
+    "TypedRpcClient",
+    "load_service_wire",
+    "make_typed_client",
     "validate_configs",
 ]

--- a/python/hakoniwa_pdu_rpc/auto_wire.py
+++ b/python/hakoniwa_pdu_rpc/auto_wire.py
@@ -39,18 +39,21 @@ def load_service_wire(
             f"{package}.pdu_conv_{response_name}"
         )
 
+        request_encoder = getattr(
+            request_converter_module, f"py_to_pdu_{request_name}"
+        )
+        response_encoder = getattr(
+            response_converter_module, f"py_to_pdu_{response_name}"
+        )
+
         return ServiceWire(
             request_packet_type=getattr(request_type_module, request_name),
             response_packet_type=getattr(response_type_module, response_name),
-            request_encode=getattr(
-                request_converter_module, f"py_to_pdu_{request_name}"
-            ),
+            request_encode=lambda packet: bytes(request_encoder(packet)),
             request_decode=getattr(
                 request_converter_module, f"pdu_to_py_{request_name}"
             ),
-            response_encode=getattr(
-                response_converter_module, f"py_to_pdu_{response_name}"
-            ),
+            response_encode=lambda packet: bytes(response_encoder(packet)),
             response_decode=getattr(
                 response_converter_module, f"pdu_to_py_{response_name}"
             ),

--- a/python/hakoniwa_pdu_rpc/auto_wire.py
+++ b/python/hakoniwa_pdu_rpc/auto_wire.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Callable
+
+from .client import RpcClient
+
+
+@dataclass(frozen=True)
+class ServiceWire:
+    request_packet_type: type
+    response_packet_type: type
+    request_encode: Callable[[Any], bytes]
+    request_decode: Callable[[bytes], Any]
+    response_encode: Callable[[Any], bytes]
+    response_decode: Callable[[bytes], Any]
+
+
+def load_service_wire(
+    service_type: str,
+    package: str = "pdu.python.hako_srv_msgs",
+) -> ServiceWire:
+    """Load generated PDU Registry packet types and converters by convention."""
+    request_name = f"{service_type}RequestPacket"
+    response_name = f"{service_type}ResponsePacket"
+
+    try:
+        request_type_module = import_module(
+            f"{package}.pdu_pytype_{request_name}"
+        )
+        response_type_module = import_module(
+            f"{package}.pdu_pytype_{response_name}"
+        )
+        request_converter_module = import_module(
+            f"{package}.pdu_conv_{request_name}"
+        )
+        response_converter_module = import_module(
+            f"{package}.pdu_conv_{response_name}"
+        )
+
+        return ServiceWire(
+            request_packet_type=getattr(request_type_module, request_name),
+            response_packet_type=getattr(response_type_module, response_name),
+            request_encode=getattr(
+                request_converter_module, f"py_to_pdu_{request_name}"
+            ),
+            request_decode=getattr(
+                request_converter_module, f"pdu_to_py_{request_name}"
+            ),
+            response_encode=getattr(
+                response_converter_module, f"py_to_pdu_{response_name}"
+            ),
+            response_decode=getattr(
+                response_converter_module, f"pdu_to_py_{response_name}"
+            ),
+        )
+    except (ImportError, AttributeError) as error:
+        raise RuntimeError(
+            "failed to load generated PDU Registry service components: "
+            f"service_type={service_type!r}, package={package!r}"
+        ) from error
+
+
+class TypedRpcClient:
+    """Registry-aware client that accepts and returns service body objects."""
+
+    def __init__(
+        self,
+        rpc_client: RpcClient,
+        service_name: str,
+        service_type: str,
+        *,
+        package: str = "pdu.python.hako_srv_msgs",
+    ):
+        self._rpc_client = rpc_client
+        self.service_name = service_name
+        self.service_type = service_type
+        self.wire = load_service_wire(service_type, package)
+
+    def create_request(self) -> Any:
+        """Create an empty generated request body object."""
+        return self.wire.request_packet_type().body
+
+    def call(
+        self,
+        request: Any,
+        timeout_usec: int,
+        **kwargs: Any,
+    ) -> Any:
+        """Encode a request body, perform RPC, and return the response body."""
+        base_pdu = self._rpc_client.create_request_buffer(self.service_name)
+        request_packet = self.wire.request_decode(base_pdu)
+        request_packet.body = request
+        request_id = request_packet.header.request_id
+
+        response_pdu = self._rpc_client.call(
+            self.service_name,
+            self.wire.request_encode(request_packet),
+            timeout_usec,
+            **kwargs,
+        )
+        response_packet = self.wire.response_decode(response_pdu)
+        if response_packet.header.request_id != request_id:
+            raise RuntimeError(
+                "RPC response request_id mismatch: "
+                f"expected={request_id}, actual={response_packet.header.request_id}"
+            )
+        return response_packet.body
+
+
+def make_typed_client(
+    rpc_client: RpcClient,
+    service_name: str,
+    service_type: str,
+    *,
+    package: str = "pdu.python.hako_srv_msgs",
+) -> TypedRpcClient:
+    return TypedRpcClient(
+        rpc_client,
+        service_name,
+        service_type,
+        package=package,
+    )

--- a/python/test_cffi_basic.py
+++ b/python/test_cffi_basic.py
@@ -9,6 +9,9 @@ import pytest
 
 from hakoniwa_pdu_rpc import RpcClient as HighLevelRpcClient, RpcTimeoutError
 from hakoniwa_pdu_rpc.cffi_api import ClientEvent, RpcClient, RpcServer, ServerEvent
+from test_cffi_registry_auto_wire import (
+    test_registry_auto_wire_round_trip_returns_generated_response_body,
+)
 from test_cffi_timeout_cancel import (
     test_timeout_requires_explicit_cancel_and_endpoint_remains_reusable,
 )

--- a/python/test_cffi_basic.py
+++ b/python/test_cffi_basic.py
@@ -9,9 +9,6 @@ import pytest
 
 from hakoniwa_pdu_rpc import RpcClient as HighLevelRpcClient, RpcTimeoutError
 from hakoniwa_pdu_rpc.cffi_api import ClientEvent, RpcClient, RpcServer, ServerEvent
-from test_cffi_registry_auto_wire import (
-    test_registry_auto_wire_round_trip_returns_generated_response_body,
-)
 from test_cffi_timeout_cancel import (
     test_timeout_requires_explicit_cancel_and_endpoint_remains_reusable,
 )

--- a/python/test_cffi_registry_auto_wire.py
+++ b/python/test_cffi_registry_auto_wire.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+import threading
+import time
+from pathlib import Path
+
+from hakoniwa_pdu_rpc import (
+    RpcClient,
+    RpcServer,
+    ServerEvent,
+    load_service_wire,
+    make_typed_client,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_CONFIG = ROOT / "test" / "configs" / "service_config.json"
+ENDPOINT_CONFIG = ROOT / "test" / "configs" / "endpoints.json"
+SERVICE = "Service/Add"
+STATUS_DONE = 3
+RESULT_OK = 0
+
+
+def wait_request(server: RpcServer, timeout: float = 3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        incoming = server.poll()
+        if incoming.event == ServerEvent.REQUEST_IN:
+            return incoming
+        time.sleep(0.001)
+    raise AssertionError("server request timed out")
+
+
+def test_registry_auto_wire_round_trip_returns_generated_response_body():
+    library = os.environ["HAKO_PDU_RPC_LIBRARY"]
+    wire = load_service_wire("AddTwoInts")
+
+    with RpcServer(
+        library,
+        "server_node",
+        SERVICE_CONFIG,
+        ENDPOINT_CONFIG,
+    ) as server, RpcClient(
+        library,
+        "client_node",
+        "TestClient",
+        SERVICE_CONFIG,
+        ENDPOINT_CONFIG,
+    ) as rpc_client:
+        server.start()
+        rpc_client.start()
+        client = make_typed_client(
+            rpc_client,
+            SERVICE,
+            "AddTwoInts",
+        )
+
+        errors: list[BaseException] = []
+
+        def serve_once() -> None:
+            try:
+                incoming = wait_request(server)
+                request_packet = wire.request_decode(incoming.pdu)
+                assert request_packet.body.a == 10
+                assert request_packet.body.b == 20
+
+                reply_pdu = server.create_reply_buffer(
+                    incoming.request_token,
+                    status=STATUS_DONE,
+                    result_code=RESULT_OK,
+                )
+                response_packet = wire.response_decode(reply_pdu)
+                response_packet.body.sum = (
+                    request_packet.body.a + request_packet.body.b
+                )
+                server.send_reply(
+                    incoming.request_token,
+                    wire.response_encode(response_packet),
+                )
+            except BaseException as error:
+                errors.append(error)
+
+        worker = threading.Thread(target=serve_once)
+        worker.start()
+        try:
+            request = client.create_request()
+            request.a = 10
+            request.b = 20
+            response = client.call(request, timeout_usec=1_000_000)
+            assert response.sum == 30
+        finally:
+            worker.join(timeout=5.0)
+
+        assert not worker.is_alive()
+        assert not errors

--- a/python/test_cffi_registry_auto_wire.py
+++ b/python/test_cffi_registry_auto_wire.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import threading
 import time
 from pathlib import Path
@@ -15,6 +16,8 @@ from hakoniwa_pdu_rpc import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hakoniwa-pdu-registry"))
+
 SERVICE_CONFIG = ROOT / "test" / "configs" / "service_config.json"
 ENDPOINT_CONFIG = ROOT / "test" / "configs" / "endpoints.json"
 SERVICE = "Service/Add"


### PR DESCRIPTION
## Summary

Add a Registry-aware typed Python RPC client by adapting the reflection-based `auto_wire.py` pattern from `hakoniwa-pdu-python`.

## Public API

- `load_service_wire(service_type, package=...)` dynamically loads generated request/response packet classes and converters by the PDU Registry naming convention.
- `TypedRpcClient` accepts generated request body objects and returns generated response body objects.
- `make_typed_client(...)` provides the simple construction path.

Example:

```python
client = make_typed_client(
    rpc_client,
    "Service/Add",
    "AddTwoInts",
)

request = client.create_request()
request.a = 10
request.b = 20
response = client.call(request, timeout_usec=1_000_000)
assert response.sum == 30
```

## Packet ownership and headers

The RPC layer still creates the canonical request packet buffer, including its service header and request ID. Auto Wire decodes that packet, replaces only `packet.body`, and re-encodes it through the generated Registry converter.

Responses are decoded through the Registry converter, checked against the original request ID, and returned as `packet.body`.

Native memory ownership remains unchanged: C buffers are copied and freed in the thin CFFI layer before Registry conversion.

## Integration test

Add an actual `AddTwoInts` round trip using generated artifacts from the `hakoniwa-pdu-registry` submodule:

- typed request body is created without manual converter imports;
- server decodes the generated request packet;
- server returns a generated response packet;
- client receives the generated response body and verifies `sum == 30`;
- the test is included in the existing four-platform Python CFFI suite, including the explicit Windows test entrypoint.

## Deliberately excluded

- no server-side typed dispatcher yet;
- no asyncio API;
- no package discovery beyond the Registry naming convention;
- no wheel bundling of generated Registry artifacts.

## Merge condition

All existing native and Python CFFI contracts remain green on Ubuntu x64, Ubuntu ARM64, macOS, and Windows x64, and the Registry Auto Wire integration test passes.