### PR TITLE
feat: add ROS-independent asynchronous RPC API

### DIFF
--- a/python/hakoniwa_pdu_rpc/__init__.py
+++ b/python/hakoniwa_pdu_rpc/__init__.py
@@ -11,6 +11,7 @@ from .cffi_api import (
     ServerPollResult,
 )
 from .client import RpcCanceledError, RpcClient, RpcTimeoutError
+from .future import RpcFuture
 
 __all__ = [
     "CffiRpcClient",
@@ -19,6 +20,7 @@ __all__ = [
     "RpcCanceledError",
     "RpcClient",
     "RpcError",
+    "RpcFuture",
     "RpcServer",
     "RpcTimeoutError",
     "ServerEvent",

--- a/python/hakoniwa_pdu_rpc/client.py
+++ b/python/hakoniwa_pdu_rpc/client.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import threading
 import time
 from pathlib import Path
 
 from .cffi_api import ClientEvent, RpcClient as CffiRpcClient, RpcError
+from .future import RpcFuture
 
 
 class RpcTimeoutError(RpcError):
@@ -15,10 +17,14 @@ class RpcCanceledError(RpcError):
 
 
 class RpcClient:
-    """Synchronous high-level RPC client built on the thin CFFI binding.
+    """High-level RPC client with synchronous and non-blocking call APIs.
 
     Native PDU buffers never escape the CFFI layer. Responses returned by
-    :meth:`call` are ordinary Python ``bytes``.
+    :meth:`call` and :meth:`call_async` are ordinary Python ``bytes``.
+
+    The underlying native client exposes one shared response queue, so one
+    ``RpcClient`` instance supports one in-flight request at a time. Create
+    separate clients when independent concurrent calls are required.
     """
 
     def __init__(
@@ -40,6 +46,7 @@ class RpcClient:
             delta_time_usec,
             time_source_type,
         )
+        self._inflight_lock = threading.Lock()
 
     def start(self) -> None:
         self._client.start()
@@ -58,14 +65,91 @@ class RpcClient:
         event_timeout_sec: float = 5.0,
         poll_interval_sec: float = 0.001,
     ) -> bytes:
-        """Send one request and wait for its terminal response.
+        """Send one request and synchronously wait for terminal completion."""
+        return self.call_async(
+            service_name,
+            pdu,
+            timeout_usec,
+            cancel_on_timeout=cancel_on_timeout,
+            connect_timeout_sec=connect_timeout_sec,
+            event_timeout_sec=event_timeout_sec,
+            poll_interval_sec=poll_interval_sec,
+        ).result()
 
-        A normal response returns its PDU as ``bytes``. When the native timeout
-        event occurs, the default behavior is to issue an explicit cancel and
-        wait for terminal completion so the endpoint remains reusable. If a
-        normal response wins the cancel race, that response is returned.
-        Otherwise :class:`RpcTimeoutError` is raised after cancel completion.
+    def call_async(
+        self,
+        service_name: str,
+        pdu: bytes,
+        timeout_usec: int,
+        *,
+        cancel_on_timeout: bool = True,
+        connect_timeout_sec: float = 3.0,
+        event_timeout_sec: float = 5.0,
+        poll_interval_sec: float = 0.001,
+    ) -> RpcFuture[bytes]:
+        """Start one RPC call and return immediately with an :class:`RpcFuture`.
+
+        The worker owns the existing timeout, cancel, and response/cancel race
+        state machine. The returned future is independent of ROS and asyncio;
+        adapters can use ``add_done_callback()`` or bridge ``result()`` into
+        their own executor model without blocking the caller thread.
         """
+        if not self._inflight_lock.acquire(blocking=False):
+            raise RpcError("another RPC call is already in flight on this client")
+
+        future = RpcFuture[bytes](lambda: self.cancel(service_name))
+
+        def run() -> None:
+            if not future._set_running_or_notify_cancel():
+                self._inflight_lock.release()
+                return
+            try:
+                response = self._call_impl(
+                    service_name,
+                    pdu,
+                    timeout_usec,
+                    cancel_on_timeout=cancel_on_timeout,
+                    connect_timeout_sec=connect_timeout_sec,
+                    event_timeout_sec=event_timeout_sec,
+                    poll_interval_sec=poll_interval_sec,
+                )
+            except BaseException as error:
+                future._set_exception(error)
+            else:
+                future._set_result(response)
+            finally:
+                self._inflight_lock.release()
+
+        threading.Thread(
+            target=run,
+            name=f"hakoniwa-rpc-{service_name}",
+            daemon=True,
+        ).start()
+        return future
+
+    def cancel(self, service_name: str) -> None:
+        self._client.cancel(service_name)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "RpcClient":
+        return self
+
+    def __exit__(self, *_args) -> None:
+        self.close()
+
+    def _call_impl(
+        self,
+        service_name: str,
+        pdu: bytes,
+        timeout_usec: int,
+        *,
+        cancel_on_timeout: bool,
+        connect_timeout_sec: float,
+        event_timeout_sec: float,
+        poll_interval_sec: float,
+    ) -> bytes:
         self._send_when_connected(
             service_name,
             pdu,
@@ -99,18 +183,6 @@ class RpcClient:
                 )
 
         raise RpcError(f"RPC terminal event was not received: {service_name}")
-
-    def cancel(self, service_name: str) -> None:
-        self._client.cancel(service_name)
-
-    def close(self) -> None:
-        self._client.close()
-
-    def __enter__(self) -> "RpcClient":
-        return self
-
-    def __exit__(self, *_args) -> None:
-        self.close()
 
     def _send_when_connected(
         self,
@@ -146,11 +218,9 @@ class RpcClient:
                     f"unexpected service response: {result.service_name!r}"
                 )
             if result.event == ClientEvent.RESPONSE_IN:
-                # The server completed normally before processing the cancel.
                 return result.pdu
             if result.event == ClientEvent.RESPONSE_CANCEL:
                 raise RpcTimeoutError(f"RPC timed out and was canceled: {service_name}")
-            # A repeated timeout notification is non-terminal; keep waiting.
 
         raise RpcError(
             f"RPC cancel completion was not received after timeout: {service_name}"

--- a/python/hakoniwa_pdu_rpc/future.py
+++ b/python/hakoniwa_pdu_rpc/future.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from concurrent.futures import Future
+from typing import Callable, Generic, TypeVar
+
+
+T = TypeVar("T")
+
+
+class RpcFuture(Generic[T]):
+    """ROS-independent handle for one in-flight RPC operation.
+
+    Completion is driven by the RPC client's background worker. ``cancel()``
+    requests protocol-level cancellation; terminal completion is still reported
+    through ``result()`` or ``exception()``.
+    """
+
+    def __init__(self, cancel_callback: Callable[[], None]):
+        self._future: Future[T] = Future()
+        self._cancel_callback = cancel_callback
+
+    def cancel(self) -> bool:
+        if self._future.done():
+            return False
+        self._cancel_callback()
+        return True
+
+    def cancelled(self) -> bool:
+        return self._future.cancelled()
+
+    def running(self) -> bool:
+        return self._future.running()
+
+    def done(self) -> bool:
+        return self._future.done()
+
+    def result(self, timeout: float | None = None) -> T:
+        return self._future.result(timeout=timeout)
+
+    def exception(self, timeout: float | None = None) -> BaseException | None:
+        return self._future.exception(timeout=timeout)
+
+    def add_done_callback(self, fn: Callable[["RpcFuture[T]"], object]) -> None:
+        self._future.add_done_callback(lambda _future: fn(self))
+
+    def _set_running_or_notify_cancel(self) -> bool:
+        return self._future.set_running_or_notify_cancel()
+
+    def _set_result(self, result: T) -> None:
+        self._future.set_result(result)
+
+    def _set_exception(self, exception: BaseException) -> None:
+        self._future.set_exception(exception)

--- a/python/test_cffi_async_api.py
+++ b/python/test_cffi_async_api.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import threading
+import time
+from types import MethodType
+
+import pytest
+
+from hakoniwa_pdu_rpc import RpcClient, RpcError, RpcFuture
+
+
+def make_client(worker):
+    client = RpcClient.__new__(RpcClient)
+    client._client = object()
+    client._inflight_lock = threading.Lock()
+    client._call_impl = MethodType(worker, client)
+    client.cancel = MethodType(lambda self, service_name: None, client)
+    return client
+
+
+def test_call_async_returns_immediately_and_completes_future():
+    release = threading.Event()
+
+    def worker(self, service_name, pdu, timeout_usec, **kwargs):
+        assert service_name == "Service/Add"
+        assert pdu == b"request"
+        release.wait(timeout=2.0)
+        return b"response"
+
+    client = make_client(worker)
+    started = time.monotonic()
+    future = client.call_async("Service/Add", b"request", 1_000_000)
+
+    assert isinstance(future, RpcFuture)
+    assert time.monotonic() - started < 0.2
+    assert not future.done()
+
+    release.set()
+    assert future.result(timeout=2.0) == b"response"
+    assert future.done()
+
+
+def test_call_async_invokes_done_callback():
+    callback_done = threading.Event()
+    observed = []
+
+    def worker(self, service_name, pdu, timeout_usec, **kwargs):
+        return b"response"
+
+    client = make_client(worker)
+    future = client.call_async("Service/Add", b"request", 1_000_000)
+
+    def on_done(completed):
+        observed.append(completed.result())
+        callback_done.set()
+
+    future.add_done_callback(on_done)
+    assert callback_done.wait(timeout=2.0)
+    assert observed == [b"response"]
+
+
+def test_client_rejects_multiple_inflight_calls():
+    release = threading.Event()
+
+    def worker(self, service_name, pdu, timeout_usec, **kwargs):
+        release.wait(timeout=2.0)
+        return b"response"
+
+    client = make_client(worker)
+    first = client.call_async("Service/Add", b"one", 1_000_000)
+
+    with pytest.raises(RpcError, match="already in flight"):
+        client.call_async("Service/Add", b"two", 1_000_000)
+
+    release.set()
+    assert first.result(timeout=2.0) == b"response"


### PR DESCRIPTION
## Summary

Add a non-blocking Python RPC API to `hakoniwa-pdu-rpc` without introducing ROS or asyncio dependencies.

## API

```python
future = client.call_async(
    "Service/Add",
    request_pdu,
    timeout_usec=1_000_000,
)

future.add_done_callback(on_done)
response_pdu = future.result()
```

`RpcFuture` provides:

- `result()`
- `exception()`
- `done()`
- `add_done_callback()`
- protocol-level `cancel()`

## Design

- The existing timeout, explicit cancel, and response/cancel race state machine remains in one implementation.
- `call_async()` runs that state machine in a daemon worker and returns immediately.
- Synchronous `call()` is now implemented as `call_async(...).result()`.
- The API is independent of `rclpy`; `hakoniwa-pdu-ros` can bridge completion into its executor and Future model.
- One native client currently has one shared response queue, so one `RpcClient` instance permits one in-flight request. Independent concurrent calls use separate client instances.

## Tests

Add ROS-independent tests for:

- immediate non-blocking return
- Future completion and result propagation
- done callback execution
- explicit rejection of multiple in-flight calls on one client

The existing four-platform CFFI integration suite remains the merge condition.