### PR TITLE
build: produce static and shared RPC artifacts through hako.py

### DIFF
--- a/.github/workflows/package-contract.yml
+++ b/.github/workflows/package-contract.yml
@@ -105,6 +105,7 @@ jobs:
           git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
           cmake -S endpoint -B endpoint/build \
             -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" \
+            -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
             -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
             -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \
@@ -123,6 +124,7 @@ jobs:
           git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
           cmake -S endpoint -B endpoint/build -A x64 `
             -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" `
+            -DBUILD_SHARED_LIBS=ON `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=x64-windows `
             -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/endpoint-install" `

--- a/.github/workflows/package-contract.yml
+++ b/.github/workflows/package-contract.yml
@@ -156,6 +156,11 @@ jobs:
       - name: Installed package consumer
         run: python tools/hako.py package-test --config "${{ matrix.config }}"
 
+      # Windows native contracts run in the dedicated RPC workflows against the
+      # historical static Endpoint + static RPC combination. This package job
+      # intentionally uses a shared Endpoint to validate the installed shared
+      # RPC target and must not mix that package configuration into native ABI
+      # contract coverage.
       - name: Reviewed RPC contract tests
-        if: matrix.config == 'hakoniwa-build.yaml' || matrix.os == 'ubuntu-latest'
+        if: runner.os != 'Windows' && (matrix.config == 'hakoniwa-build.yaml' || matrix.os == 'ubuntu-latest')
         run: python tools/hako.py test --config "${{ matrix.config }}"

--- a/.github/workflows/python-cffi-tests.yml
+++ b/.github/workflows/python-cffi-tests.yml
@@ -82,6 +82,7 @@ jobs:
             -DHAKO_PDU_ENDPOINT_INSTALL=ON
           cmake --build endpoint/build --config Release --parallel
           cmake --install endpoint/build --config Release --prefix "${GITHUB_WORKSPACE}/endpoint-install"
+          echo "HAKO_PDU_ENDPOINT_ROOT=${GITHUB_WORKSPACE}/endpoint-install" >> "$GITHUB_ENV"
 
       - name: Build and install shared Core-free Endpoint package on Windows
         if: runner.os == 'Windows'
@@ -101,31 +102,13 @@ jobs:
             -DHAKO_PDU_ENDPOINT_INSTALL=ON
           cmake --build endpoint/build --config Release --parallel
           cmake --install endpoint/build --config Release --prefix "$env:GITHUB_WORKSPACE/endpoint-install"
+          "HAKO_PDU_ENDPOINT_ROOT=$env:GITHUB_WORKSPACE/endpoint-install" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Build shared RPC library
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          cmake -S . -B build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DBUILD_SHARED_LIBS=ON \
-            -DHAKO_PDU_RPC_BUILD_TESTS=OFF \
-            -DHAKO_PDU_ENDPOINT_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
-            -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/endpoint-install"
-          cmake --build build --config Release --target hakoniwa_pdu_rpc --parallel
+      - name: Doctor
+        run: python tools/hako.py doctor
 
-      - name: Build shared RPC library on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          cmake -S . -B build -A x64 `
-            -DBUILD_SHARED_LIBS=ON `
-            -DHAKO_PDU_RPC_BUILD_TESTS=OFF `
-            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
-            -DVCPKG_TARGET_TRIPLET=x64-windows `
-            -DHAKO_PDU_ENDPOINT_PREFIX="$env:GITHUB_WORKSPACE/endpoint-install" `
-            -DCMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE/endpoint-install"
-          cmake --build build --config Release --target hakoniwa_pdu_rpc --parallel
+      - name: Build shared RPC library through hako.py
+        run: python tools/hako.py build
 
       - name: Python CFFI contract tests
         if: runner.os != 'Windows'

--- a/.github/workflows/rpc-basic-tests.yml
+++ b/.github/workflows/rpc-basic-tests.yml
@@ -67,6 +67,7 @@ jobs:
           git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
           cmake -S endpoint -B endpoint/build \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
             -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
             -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \

--- a/.github/workflows/rpc-cancel-race-tests.yml
+++ b/.github/workflows/rpc-cancel-race-tests.yml
@@ -67,6 +67,7 @@ jobs:
           git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
           cmake -S endpoint -B endpoint/build \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
             -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
             -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \

--- a/.github/workflows/rpc-infinite-wait-tests.yml
+++ b/.github/workflows/rpc-infinite-wait-tests.yml
@@ -67,6 +67,7 @@ jobs:
           git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
           cmake -S endpoint -B endpoint/build \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
             -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
             -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \

--- a/.github/workflows/rpc-timeout-cancel-tests.yml
+++ b/.github/workflows/rpc-timeout-cancel-tests.yml
@@ -67,6 +67,7 @@ jobs:
           git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
           cmake -S endpoint -B endpoint/build \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/endpoint-install" \
             -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
             -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,6 @@ project(hakoniwa-pdu-rpc VERSION 0.1.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# The Python CFFI binding loads the native RPC library at runtime. Keep the
-# standard build CFFI-ready while preserving an explicit static opt-out for
-# native-only consumers.
-option(BUILD_SHARED_LIBS "Build shared libraries instead of static libraries" ON)
-
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(hakoniwa-pdu-rpc VERSION 0.1.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# The Python CFFI binding loads the native RPC library at runtime. Keep the
+# standard build CFFI-ready while preserving an explicit static opt-out for
+# native-only consumers.
+option(BUILD_SHARED_LIBS "Build shared libraries instead of static libraries" ON)
+
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,30 +40,35 @@ function(hako_pdu_rpc_configure_target target)
   )
 endfunction()
 
-add_library(hakoniwa_pdu_rpc ${HAKO_PDU_RPC_SOURCES})
+# Keep the historical native CMake target static. Existing C++ consumers and
+# all native contract tests therefore retain the same linkage that was already
+# validated across Linux, macOS, and Windows.
+add_library(hakoniwa_pdu_rpc STATIC ${HAKO_PDU_RPC_SOURCES})
 hako_pdu_rpc_configure_target(hakoniwa_pdu_rpc)
+set_target_properties(hakoniwa_pdu_rpc PROPERTIES EXPORT_NAME rpc)
 
 add_library(hakoniwa_pdu_rpc::rpc ALIAS hakoniwa_pdu_rpc)
 add_library(hakoniwa_pdu_rpc::hakoniwa_pdu_rpc ALIAS hakoniwa_pdu_rpc)
 
-set_target_properties(hakoniwa_pdu_rpc PROPERTIES
-  EXPORT_NAME rpc
+# Build the CFFI-loadable artifact beside the static library from the same
+# sources. The runtime file keeps the established hakoniwa_pdu_rpc name, while
+# its Windows import library uses a distinct name to avoid colliding with the
+# real static hakoniwa_pdu_rpc.lib.
+add_library(hakoniwa_pdu_rpc_shared SHARED ${HAKO_PDU_RPC_SOURCES})
+hako_pdu_rpc_configure_target(hakoniwa_pdu_rpc_shared)
+set_target_properties(hakoniwa_pdu_rpc_shared PROPERTIES
+  EXPORT_NAME rpc_shared
+  OUTPUT_NAME hakoniwa_pdu_rpc
+  ARCHIVE_OUTPUT_NAME hakoniwa_pdu_rpc_shared
   WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
 
-# The supported Windows shared-library boundary is the C API used by CFFI.
-# Native C++ contract tests instantiate STL-bearing implementation classes, so
-# keep those tests inside one binary instead of exercising an unstable C++ DLL
-# ABI. C API contract tests continue to link the real shared target above.
-if(WIN32 AND BUILD_SHARED_LIBS AND HAKO_PDU_RPC_BUILD_TESTS)
-  add_library(hakoniwa_pdu_rpc_cpp_contract_static STATIC
-    ${HAKO_PDU_RPC_SOURCES}
-  )
-  hako_pdu_rpc_configure_target(hakoniwa_pdu_rpc_cpp_contract_static)
-endif()
+add_library(hakoniwa_pdu_rpc::rpc_shared ALIAS hakoniwa_pdu_rpc_shared)
 
 install(
-  TARGETS hakoniwa_pdu_rpc
+  TARGETS
+    hakoniwa_pdu_rpc
+    hakoniwa_pdu_rpc_shared
   EXPORT hakoniwa_pdu_rpcTargets
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT TARGET nlohmann_json::nlohmann_json)
   FetchContent_MakeAvailable(nlohmann_json)
 endif()
 
-add_library(hakoniwa_pdu_rpc
+set(HAKO_PDU_RPC_SOURCES
   rpc_server_endpoint_impl.cpp
   rpc_services_server.cpp
   rpc_client_endpoint_impl.cpp
@@ -24,27 +24,43 @@ add_library(hakoniwa_pdu_rpc
   c_rpc_alloc.cpp
 )
 
+function(hako_pdu_rpc_configure_target target)
+  target_compile_features(${target} PUBLIC cxx_std_20)
+  target_include_directories(${target}
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+      $<BUILD_INTERFACE:${HAKONIWA_PDU_REGISTRY_DIR}/pdu/types>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+
+  target_link_libraries(${target}
+    PUBLIC
+      hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint
+      nlohmann_json::nlohmann_json
+  )
+endfunction()
+
+add_library(hakoniwa_pdu_rpc ${HAKO_PDU_RPC_SOURCES})
+hako_pdu_rpc_configure_target(hakoniwa_pdu_rpc)
+
 add_library(hakoniwa_pdu_rpc::rpc ALIAS hakoniwa_pdu_rpc)
 add_library(hakoniwa_pdu_rpc::hakoniwa_pdu_rpc ALIAS hakoniwa_pdu_rpc)
-
-target_compile_features(hakoniwa_pdu_rpc PUBLIC cxx_std_20)
-target_include_directories(hakoniwa_pdu_rpc
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-    $<BUILD_INTERFACE:${HAKONIWA_PDU_REGISTRY_DIR}/pdu/types>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
-
-target_link_libraries(hakoniwa_pdu_rpc
-  PUBLIC
-    hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint
-    nlohmann_json::nlohmann_json
-)
 
 set_target_properties(hakoniwa_pdu_rpc PROPERTIES
   EXPORT_NAME rpc
   WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
+
+# The supported Windows shared-library boundary is the C API used by CFFI.
+# Native C++ contract tests instantiate STL-bearing implementation classes, so
+# keep those tests inside one binary instead of exercising an unstable C++ DLL
+# ABI. C API contract tests continue to link the real shared target above.
+if(WIN32 AND BUILD_SHARED_LIBS AND HAKO_PDU_RPC_BUILD_TESTS)
+  add_library(hakoniwa_pdu_rpc_cpp_contract_static STATIC
+    ${HAKO_PDU_RPC_SOURCES}
+  )
+  hako_pdu_rpc_configure_target(hakoniwa_pdu_rpc_cpp_contract_static)
+endif()
 
 install(
   TARGETS hakoniwa_pdu_rpc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,18 +5,31 @@ if(NOT TARGET GTest::gtest_main)
   if(WIN32)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   endif()
+
+  # BUILD_SHARED_LIBS controls the RPC artifact, but GoogleTest is only test
+  # infrastructure. Keep it static so enabling the CFFI-ready RPC DLL does not
+  # introduce additional test-only DLL boundaries.
+  set(_hako_pdu_rpc_saved_build_shared_libs "${BUILD_SHARED_LIBS}")
+  set(BUILD_SHARED_LIBS OFF)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG v1.15.2
   )
   FetchContent_MakeAvailable(googletest)
+  set(BUILD_SHARED_LIBS "${_hako_pdu_rpc_saved_build_shared_libs}")
+  unset(_hako_pdu_rpc_saved_build_shared_libs)
+endif()
+
+set(HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY hakoniwa_pdu_rpc::rpc)
+if(TARGET hakoniwa_pdu_rpc_cpp_contract_static)
+  set(HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY hakoniwa_pdu_rpc_cpp_contract_static)
 endif()
 
 add_executable(hakoniwa_pdu_rpc_basic_test
   rpc_basic_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_basic_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_basic_test PRIVATE ${HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_basic_test COMMAND hakoniwa_pdu_rpc_basic_test)
 set_tests_properties(hakoniwa_pdu_rpc_basic_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
@@ -32,7 +45,7 @@ set_tests_properties(hakoniwa_pdu_rpc_c_api_basic_test PROPERTIES WORKING_DIRECT
 add_executable(hakoniwa_pdu_rpc_infinite_wait_test
   rpc_infinite_wait_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_infinite_wait_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_infinite_wait_test PRIVATE ${HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_infinite_wait_test COMMAND hakoniwa_pdu_rpc_infinite_wait_test)
 set_tests_properties(hakoniwa_pdu_rpc_infinite_wait_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
@@ -46,7 +59,7 @@ set_tests_properties(hakoniwa_pdu_rpc_c_api_infinite_wait_test PROPERTIES WORKIN
 add_executable(hakoniwa_pdu_rpc_timeout_cancel_test
   rpc_timeout_cancel_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_timeout_cancel_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_timeout_cancel_test PRIVATE ${HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_timeout_cancel_test COMMAND hakoniwa_pdu_rpc_timeout_cancel_test)
 set_tests_properties(hakoniwa_pdu_rpc_timeout_cancel_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
@@ -60,7 +73,7 @@ set_tests_properties(hakoniwa_pdu_rpc_c_api_timeout_cancel_test PROPERTIES WORKI
 add_executable(hakoniwa_pdu_rpc_cancel_race_test
   rpc_cancel_race_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_cancel_race_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_cancel_race_test PRIVATE ${HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_cancel_race_test COMMAND hakoniwa_pdu_rpc_cancel_race_test)
 set_tests_properties(hakoniwa_pdu_rpc_cancel_race_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,9 +6,8 @@ if(NOT TARGET GTest::gtest_main)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   endif()
 
-  # BUILD_SHARED_LIBS controls the RPC artifact, but GoogleTest is only test
-  # infrastructure. Keep it static so enabling the CFFI-ready RPC DLL does not
-  # introduce additional test-only DLL boundaries.
+  # GoogleTest is test infrastructure, not a shipped RPC artifact. Keep it
+  # static even if a parent project enables BUILD_SHARED_LIBS globally.
   set(_hako_pdu_rpc_saved_build_shared_libs "${BUILD_SHARED_LIBS}")
   set(BUILD_SHARED_LIBS OFF)
   FetchContent_Declare(
@@ -21,65 +20,65 @@ if(NOT TARGET GTest::gtest_main)
   unset(_hako_pdu_rpc_saved_build_shared_libs)
 endif()
 
-set(HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY hakoniwa_pdu_rpc::rpc)
-if(TARGET hakoniwa_pdu_rpc_cpp_contract_static)
-  set(HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY hakoniwa_pdu_rpc_cpp_contract_static)
-endif()
+# Native contract tests retain the fully static RPC boundary that was already
+# validated on all supported platforms. The shared C API boundary is exercised
+# separately by the Python CFFI integration suite.
+set(HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY hakoniwa_pdu_rpc::rpc)
 
 add_executable(hakoniwa_pdu_rpc_basic_test
   rpc_basic_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_basic_test PRIVATE ${HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY} GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_basic_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_basic_test COMMAND hakoniwa_pdu_rpc_basic_test)
 set_tests_properties(hakoniwa_pdu_rpc_basic_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
-# C API parity test for the same two basic contracts. Keep this beside the
-# existing C++ test until the C facade has proven equivalent on every platform.
+# C API parity test for the same two basic contracts. It remains a native
+# contract test and therefore links the static RPC target as well.
 add_executable(hakoniwa_pdu_rpc_c_api_basic_test
   c_rpc_basic_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_c_api_basic_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_c_api_basic_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_c_api_basic_test COMMAND hakoniwa_pdu_rpc_c_api_basic_test)
 set_tests_properties(hakoniwa_pdu_rpc_c_api_basic_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
 add_executable(hakoniwa_pdu_rpc_infinite_wait_test
   rpc_infinite_wait_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_infinite_wait_test PRIVATE ${HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY} GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_infinite_wait_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_infinite_wait_test COMMAND hakoniwa_pdu_rpc_infinite_wait_test)
 set_tests_properties(hakoniwa_pdu_rpc_infinite_wait_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
 add_executable(hakoniwa_pdu_rpc_c_api_infinite_wait_test
   c_rpc_infinite_wait_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_c_api_infinite_wait_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_c_api_infinite_wait_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_c_api_infinite_wait_test COMMAND hakoniwa_pdu_rpc_c_api_infinite_wait_test)
 set_tests_properties(hakoniwa_pdu_rpc_c_api_infinite_wait_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
 add_executable(hakoniwa_pdu_rpc_timeout_cancel_test
   rpc_timeout_cancel_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_timeout_cancel_test PRIVATE ${HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY} GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_timeout_cancel_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_timeout_cancel_test COMMAND hakoniwa_pdu_rpc_timeout_cancel_test)
 set_tests_properties(hakoniwa_pdu_rpc_timeout_cancel_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
 add_executable(hakoniwa_pdu_rpc_c_api_timeout_cancel_test
   c_rpc_timeout_cancel_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_c_api_timeout_cancel_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_c_api_timeout_cancel_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_c_api_timeout_cancel_test COMMAND hakoniwa_pdu_rpc_c_api_timeout_cancel_test)
 set_tests_properties(hakoniwa_pdu_rpc_c_api_timeout_cancel_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
 add_executable(hakoniwa_pdu_rpc_cancel_race_test
   rpc_cancel_race_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_cancel_race_test PRIVATE ${HAKO_PDU_RPC_CPP_CONTRACT_LIBRARY} GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_cancel_race_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_cancel_race_test COMMAND hakoniwa_pdu_rpc_cancel_race_test)
 set_tests_properties(hakoniwa_pdu_rpc_cancel_race_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
 add_executable(hakoniwa_pdu_rpc_c_api_cancel_race_test
   c_rpc_cancel_race_contract_test.cpp
 )
-target_link_libraries(hakoniwa_pdu_rpc_c_api_cancel_race_test PRIVATE hakoniwa_pdu_rpc::rpc GTest::gtest_main)
+target_link_libraries(hakoniwa_pdu_rpc_c_api_cancel_race_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_c_api_cancel_race_test COMMAND hakoniwa_pdu_rpc_c_api_cancel_race_test)
 set_tests_properties(hakoniwa_pdu_rpc_c_api_cancel_race_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)

--- a/test/package_consumer/CMakeLists.txt
+++ b/test/package_consumer/CMakeLists.txt
@@ -10,3 +10,7 @@ target_link_libraries(rpc_package_consumer PRIVATE hakoniwa_pdu_rpc::rpc)
 add_executable(rpc_package_consumer_compat main.cpp)
 target_compile_features(rpc_package_consumer_compat PRIVATE cxx_std_20)
 target_link_libraries(rpc_package_consumer_compat PRIVATE hakoniwa_pdu_rpc::hakoniwa_pdu_rpc)
+
+add_executable(rpc_package_consumer_shared main.cpp)
+target_compile_features(rpc_package_consumer_shared PRIVATE cxx_std_20)
+target_link_libraries(rpc_package_consumer_shared PRIVATE hakoniwa_pdu_rpc::rpc_shared)


### PR DESCRIPTION
## Summary

Make the standard `python tools/hako.py build` path produce both native RPC artifacts from the same source set:

- a static library for existing C++ consumers and native contract tests;
- a shared library for Python CFFI and other dynamic-loading integrations.

## Root cause

The previous implementation changed the project-wide `BUILD_SHARED_LIBS` default to `ON`. That made `hako.py build` produce the required shared library, but it also silently changed the linkage of the native C and C++ contract tests that had already been validated as static builds.

On Windows, those native tests then crossed DLL boundaries and timed out even though the same contracts had passed before the build-method change. The RPC state machine and shutdown contract were not the new variable; the linkage model was.

## Design

The build no longer chooses between static and shared artifacts globally. It declares both explicitly:

- `hakoniwa_pdu_rpc` / `hakoniwa_pdu_rpc::rpc`: static, backward-compatible native target;
- `hakoniwa_pdu_rpc_shared` / `hakoniwa_pdu_rpc::rpc_shared`: shared target for CFFI.

The shared runtime keeps the established platform filename:

- Linux: `libhakoniwa_pdu_rpc.so`
- macOS: `libhakoniwa_pdu_rpc.dylib`
- Windows: `hakoniwa_pdu_rpc.dll`

On Windows, the DLL import library is named `hakoniwa_pdu_rpc_shared.lib` so it does not collide with the real static `hakoniwa_pdu_rpc.lib`.

## Changes

- remove the project-wide `BUILD_SHARED_LIBS=ON` default;
- compile the RPC source set into explicit STATIC and SHARED targets;
- preserve `hakoniwa_pdu_rpc::rpc` and the compatibility alias as static targets;
- export and install the additional `hakoniwa_pdu_rpc::rpc_shared` target;
- link all native C++ and C API contract tests to the static RPC target;
- keep the Python CFFI suite loading the real shared artifact produced by `hako.py build`;
- validate both installed CMake targets in the downstream package consumer;
- keep Windows native contract execution in the dedicated workflows, where both Endpoint and RPC use the previously validated static linkage;
- keep GoogleTest static and retain PIC for Unix static Endpoint archives used by a shared RPC target.

## User impact

The supported build remains:

```bash
python tools/hako.py doctor
python tools/hako.py build
```

That single command now produces both the static and shared RPC libraries. Existing native CMake consumers continue using `hakoniwa_pdu_rpc::rpc`; dynamic integrations may use the installed shared file or link `hakoniwa_pdu_rpc::rpc_shared`.

## Validation

The PR CI validates:

- native C++ and C API contracts using static RPC linkage on Ubuntu x64, Ubuntu ARM64, macOS, and Windows x64;
- all Python CFFI contracts using the shared RPC library produced by `hako.py build` on the same four platforms;
- installation and downstream consumption of both `rpc` and `rpc_shared` targets;
- package generation across default and alternate build manifests.