### PR TITLE
feat: add typed asynchronous Python RPC calls

### DIFF
--- a/.github/workflows/python-cffi-tests.yml
+++ b/.github/workflows/python-cffi-tests.yml
@@ -146,6 +146,8 @@ jobs:
 
           @'
           import os
+          from pathlib import Path
+
           import pytest
 
           handles = []
@@ -153,5 +155,6 @@ jobs:
               if directory:
                   handles.append(os.add_dll_directory(directory))
 
-          raise SystemExit(pytest.main(["-q", "python/test_cffi_basic.py", "python/test_cffi_timeout_cancel.py", "python/test_cffi_cancel_race.py"]))
+          tests = [str(path) for path in sorted(Path("python").glob("test_cffi_*.py"))]
+          raise SystemExit(pytest.main(["-q", *tests]))
           '@ | python -

--- a/python/hakoniwa_pdu_rpc/auto_wire.py
+++ b/python/hakoniwa_pdu_rpc/auto_wire.py
@@ -5,6 +5,7 @@ from importlib import import_module
 from typing import Any, Callable
 
 from .client import RpcClient
+from .future import RpcFuture
 
 
 DEFAULT_SERVICE_PACKAGES = (
@@ -108,18 +109,50 @@ class TypedRpcClient:
         timeout_usec: int,
         **kwargs: Any,
     ) -> Any:
-        """Encode a request body, perform RPC, and return the response body."""
-        base_pdu = self._rpc_client.create_request_buffer(self.service_name)
-        request_packet = self.wire.request_decode(base_pdu)
-        request_packet.body = request
-        request_id = request_packet.header.request_id
+        """Encode a request body and synchronously return the response body."""
+        return self.call_async(request, timeout_usec, **kwargs).result()
 
-        response_pdu = self._rpc_client.call(
+    def call_async(
+        self,
+        request: Any,
+        timeout_usec: int,
+        **kwargs: Any,
+    ) -> RpcFuture[Any]:
+        """Encode a request body and return a Future for the response body.
+
+        Packet conversion and request-ID validation remain owned by the typed
+        adapter. Cancellation is forwarded to the underlying protocol-level
+        RPC Future.
+        """
+        request_pdu, request_id = self._encode_request(request)
+        raw_future = self._rpc_client.call_async(
             self.service_name,
-            self.wire.request_encode(request_packet),
+            request_pdu,
             timeout_usec,
             **kwargs,
         )
+
+        typed_future = RpcFuture[Any](raw_future.cancel)
+        typed_future._set_running_or_notify_cancel()
+
+        def complete(completed: RpcFuture[bytes]) -> None:
+            try:
+                response = self._decode_response(completed.result(), request_id)
+            except BaseException as error:
+                typed_future._set_exception(error)
+            else:
+                typed_future._set_result(response)
+
+        raw_future.add_done_callback(complete)
+        return typed_future
+
+    def _encode_request(self, request: Any) -> tuple[bytes, Any]:
+        base_pdu = self._rpc_client.create_request_buffer(self.service_name)
+        request_packet = self.wire.request_decode(base_pdu)
+        request_packet.body = request
+        return self.wire.request_encode(request_packet), request_packet.header.request_id
+
+    def _decode_response(self, response_pdu: bytes, request_id: Any) -> Any:
         response_packet = self.wire.response_decode(response_pdu)
         if response_packet.header.request_id != request_id:
             raise RuntimeError(

--- a/python/test_cffi_registry_auto_wire.py
+++ b/python/test_cffi_registry_auto_wire.py
@@ -35,7 +35,7 @@ def wait_request(server: RpcServer, timeout: float = 3.0):
     raise AssertionError("server request timed out")
 
 
-def test_registry_auto_wire_round_trip_returns_generated_response_body():
+def run_registry_round_trip(*, asynchronous: bool) -> None:
     library = os.environ["HAKO_PDU_RPC_LIBRARY"]
     wire = load_service_wire("AddTwoInts")
 
@@ -90,10 +90,24 @@ def test_registry_auto_wire_round_trip_returns_generated_response_body():
             request = client.create_request()
             request.a = 10
             request.b = 20
-            response = client.call(request, timeout_usec=1_000_000)
+            if asynchronous:
+                response = client.call_async(
+                    request,
+                    timeout_usec=1_000_000,
+                ).result(timeout=3.0)
+            else:
+                response = client.call(request, timeout_usec=1_000_000)
             assert response.sum == 30
         finally:
             worker.join(timeout=5.0)
 
         assert not worker.is_alive()
         assert not errors
+
+
+def test_registry_auto_wire_round_trip_returns_generated_response_body() -> None:
+    run_registry_round_trip(asynchronous=False)
+
+
+def test_registry_auto_wire_async_round_trip_returns_generated_response_body() -> None:
+    run_registry_round_trip(asynchronous=True)

--- a/python/test_cffi_typed_async_api.py
+++ b/python/test_cffi_typed_async_api.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hakoniwa_pdu_rpc import RpcFuture, ServiceWire, TypedRpcClient
+
+
+@dataclass
+class Header:
+    request_id: int
+
+
+@dataclass
+class Packet:
+    header: Header
+    body: Any
+
+
+class RequestPacket:
+    def __init__(self) -> None:
+        self.body = SimpleNamespace()
+
+
+class FakeRpcClient:
+    def __init__(self) -> None:
+        self.cancel_requested = threading.Event()
+        self.raw_future = RpcFuture[bytes](self._cancel)
+        self.raw_future._set_running_or_notify_cancel()
+        self.calls: list[tuple[str, bytes, int, dict[str, Any]]] = []
+
+    def _cancel(self) -> None:
+        self.cancel_requested.set()
+
+    def create_request_buffer(self, service_name: str) -> bytes:
+        assert service_name == "Service/Add"
+        return b"base-request"
+
+    def call_async(
+        self,
+        service_name: str,
+        pdu: bytes,
+        timeout_usec: int,
+        **kwargs: Any,
+    ) -> RpcFuture[bytes]:
+        self.calls.append((service_name, pdu, timeout_usec, kwargs))
+        return self.raw_future
+
+
+def make_typed_client() -> tuple[TypedRpcClient, FakeRpcClient]:
+    rpc_client = FakeRpcClient()
+
+    def request_decode(pdu: bytes) -> Packet:
+        assert pdu == b"base-request"
+        return Packet(header=Header(request_id=17), body=None)
+
+    def request_encode(packet: Packet) -> bytes:
+        assert packet.header.request_id == 17
+        assert packet.body.a == 10
+        assert packet.body.b == 20
+        return b"encoded-request"
+
+    def response_decode(pdu: bytes) -> Packet:
+        request_id = 99 if pdu == b"mismatched-response" else 17
+        return Packet(
+            header=Header(request_id=request_id),
+            body=SimpleNamespace(sum=30),
+        )
+
+    client = TypedRpcClient.__new__(TypedRpcClient)
+    client._rpc_client = rpc_client
+    client.service_name = "Service/Add"
+    client.service_type = "AddTwoInts"
+    client.wire = ServiceWire(
+        request_packet_type=RequestPacket,
+        response_packet_type=Packet,
+        request_encode=request_encode,
+        request_decode=request_decode,
+        response_encode=lambda packet: b"unused",
+        response_decode=response_decode,
+    )
+    return client, rpc_client
+
+
+def make_request() -> SimpleNamespace:
+    return SimpleNamespace(a=10, b=20)
+
+
+def test_typed_call_async_returns_typed_response_body() -> None:
+    client, rpc_client = make_typed_client()
+
+    future = client.call_async(
+        make_request(),
+        timeout_usec=1_000_000,
+        event_timeout_sec=2.0,
+    )
+
+    assert isinstance(future, RpcFuture)
+    assert future.running()
+    assert rpc_client.calls == [
+        (
+            "Service/Add",
+            b"encoded-request",
+            1_000_000,
+            {"event_timeout_sec": 2.0},
+        )
+    ]
+
+    rpc_client.raw_future._set_result(b"response")
+    response = future.result(timeout=1.0)
+    assert response.sum == 30
+
+
+def test_typed_call_uses_the_same_async_conversion_path() -> None:
+    client, rpc_client = make_typed_client()
+    rpc_client.raw_future._set_result(b"response")
+
+    response = client.call(make_request(), timeout_usec=1_000_000)
+
+    assert response.sum == 30
+
+
+def test_typed_call_async_propagates_request_id_mismatch() -> None:
+    client, rpc_client = make_typed_client()
+    future = client.call_async(make_request(), timeout_usec=1_000_000)
+
+    rpc_client.raw_future._set_result(b"mismatched-response")
+
+    with pytest.raises(RuntimeError, match="request_id mismatch"):
+        future.result(timeout=1.0)
+
+
+def test_typed_call_async_propagates_raw_rpc_exception() -> None:
+    client, rpc_client = make_typed_client()
+    future = client.call_async(make_request(), timeout_usec=1_000_000)
+
+    rpc_client.raw_future._set_exception(RuntimeError("transport failed"))
+
+    with pytest.raises(RuntimeError, match="transport failed"):
+        future.result(timeout=1.0)
+
+
+def test_typed_future_cancel_forwards_protocol_cancel() -> None:
+    client, rpc_client = make_typed_client()
+    future = client.call_async(make_request(), timeout_usec=1_000_000)
+
+    assert future.cancel()
+    assert rpc_client.cancel_requested.wait(timeout=1.0)


### PR DESCRIPTION
## Summary

Add `TypedRpcClient.call_async()` so executor-based adapters such as `hakoniwa-pdu-ros` can perform typed PDU-RPC calls without blocking a ROS callback thread.

## Design

The raw Python `RpcClient` already exposes `call_async()` and returns `RpcFuture[bytes]`. This PR adds a thin typed transformation layer:

```python
future = typed_client.call_async(
    request,
    timeout_usec=1_000_000,
)
response = future.result()
```

The returned Future resolves to the generated typed response body rather than raw PDU bytes.

The typed adapter remains responsible for:

- creating the canonical request packet;
- replacing only the generated request body;
- encoding the request through Registry-generated converters;
- decoding the response packet;
- validating the response `request_id`;
- returning only the generated response body.

Protocol cancellation is forwarded to the underlying raw RPC Future. Raw RPC exceptions and typed conversion failures are propagated through the typed Future.

## Compatibility

- Existing synchronous `TypedRpcClient.call()` remains available.
- The synchronous method is now implemented as `call_async(...).result()`, so typed conversion and request-ID validation have one implementation path.
- The one-client/one-in-flight constraint remains inherited from the underlying `RpcClient`.
- No `rclpy` or `asyncio` dependency is introduced.

## Tests

Add contracts for:

- typed asynchronous response conversion;
- synchronous calls using the same async conversion path;
- request-ID mismatch propagation;
- raw RPC exception propagation;
- protocol-level cancellation forwarding.

The Windows Python workflow now discovers the same complete `test_cffi_*.py` suite as Linux and macOS instead of maintaining a partial hard-coded file list.