### PR TITLE
feat: add TCP mux RPC server APIs

### DIFF
--- a/.github/workflows/rpc-basic-tests.yml
+++ b/.github/workflows/rpc-basic-tests.yml
@@ -104,8 +104,20 @@ jobs:
       - name: Existing C++ basic contracts
         run: python tools/hako.py test-basic
 
+      - name: Build TCP mux C++ contract
+        run: cmake --build build --config Release --target hakoniwa_pdu_rpc_mux_server_test --parallel
+
+      - name: TCP mux C++ contract
+        run: ctest --test-dir build -C Release --output-on-failure -R "^hakoniwa_pdu_rpc_mux_server_test$"
+
       - name: Build C API basic contract
         run: cmake --build build --config Release --target hakoniwa_pdu_rpc_c_api_basic_test --parallel
 
       - name: C API basic contracts
         run: ctest --test-dir build -C Release --output-on-failure -R "^hakoniwa_pdu_rpc_c_api_basic_test$"
+
+      - name: Build TCP mux C API contract
+        run: cmake --build build --config Release --target hakoniwa_pdu_rpc_c_api_mux_server_test --parallel
+
+      - name: TCP mux C API contract
+        run: ctest --test-dir build -C Release --output-on-failure -R "^hakoniwa_pdu_rpc_c_api_mux_server_test$"

--- a/docs/tcp-mux-server.md
+++ b/docs/tcp-mux-server.md
@@ -1,0 +1,130 @@
+# TCP Multiplexed RPC Server
+
+## Purpose
+
+The normal PDU-RPC server owns a static `EndpointContainer`. A normal TCP
+server endpoint accepts one active transport session at a time, so changing its
+communication JSON alone does not create a multi-client RPC server.
+
+`RpcServicesMuxServer` owns the complete server-side multiplexing lifecycle:
+
+```text
+multiple RpcClients
+        |
+        v
+one TCP listener / EndpointCommMultiplexer
+        |
+        +-- accepted Endpoint session 1 -- RpcServicesServer adapter 1
+        +-- accepted Endpoint session 2 -- RpcServicesServer adapter 2
+        `-- accepted Endpoint session N -- RpcServicesServer adapter N
+```
+
+The listener address and port remain shared. The operating system distinguishes
+TCP connections by their source and destination address/port tuple.
+
+## Configuration
+
+The mux server receives an Endpoint mux configuration directly. The endpoint
+configuration contains the normal PDU definition and cache references, plus a
+communication configuration with `expected_clients`.
+
+```json
+{
+  "name": "rpc_mux_server",
+  "pdu_def_path": "rpc-pdudef.json",
+  "cache": "rpc-queue.json",
+  "comm": "rpc-server-tcp-mux.json"
+}
+```
+
+```json
+{
+  "protocol": "tcp",
+  "direction": "inout",
+  "local": {
+    "address": "0.0.0.0",
+    "port": 54010
+  },
+  "expected_clients": 4
+}
+```
+
+`protocol` remains `tcp`: `EndpointCommMultiplexer` selects the TCP multiplexer
+implementation and turns each accepted socket into an opened Endpoint.
+
+Every client uses a normal TCP client endpoint and connects to the same server
+address and port.
+
+## C++ API
+
+```cpp
+#include "hakoniwa/pdu/rpc/rpc_services_mux_server.hpp"
+
+hakoniwa::pdu::rpc::RpcServicesMuxServer server(
+    "server_node",
+    "RpcServerEndpointImpl",
+    "rpc-server-services.json",
+    "rpc-server-endpoint-mux.json",
+    1000,
+    "real");
+
+if (!server.initialize() || !server.start()) {
+    // startup error
+}
+
+hakoniwa::pdu::rpc::RpcMuxRequest request;
+const auto event = server.poll(request);
+if (event == hakoniwa::pdu::rpc::ServerEventType::REQUEST_IN) {
+    // Build the response, then route it to the exact accepted session.
+    server.send_reply(request, response_pdu);
+}
+```
+
+`poll()` also accepts new sessions and removes disconnected slots. The returned
+`connection_id` is opaque and must be retained with the request until reply or
+cancel completion.
+
+The existing static `RpcServicesServer` API remains unchanged.
+
+## C API
+
+The C facade uses a separate handle so existing applications remain source and
+binary compatible:
+
+```c
+hako_pdu_rpc_mux_server_handle_t* server =
+    hako_pdu_rpc_mux_server_create(
+        "server_node",
+        "rpc-server-services.json",
+        "rpc-server-endpoint-mux.json",
+        1000,
+        "real");
+
+hako_pdu_rpc_mux_server_start(server);
+```
+
+The request token returned by `hako_pdu_rpc_mux_server_poll()` contains the
+accepted-session identity internally. Callers use the token with the mux reply
+functions; they do not manage connection IDs directly.
+
+Allocation-capable variants are provided for language bindings:
+
+- `hako_pdu_rpc_mux_server_poll_alloc()`
+- `hako_pdu_rpc_mux_server_create_reply_buffer_alloc()`
+
+Buffers returned by these functions are released with
+`hako_pdu_rpc_buffer_free()`.
+
+## Lifecycle ownership
+
+The mux server owns:
+
+- the TCP listener;
+- accepted Endpoint sessions;
+- one RPC adapter per accepted session;
+- disconnect callbacks and slot cleanup;
+- request-token to session routing.
+
+Applications own the service operation logic and must continue polling the
+server. Disconnect cleanup and acceptance of newly connected clients occur at
+that polling boundary.

--- a/include/hakoniwa/pdu/rpc/c_rpc.h
+++ b/include/hakoniwa/pdu/rpc/c_rpc.h
@@ -13,6 +13,7 @@ extern "C" {
 
 typedef struct hako_pdu_rpc_client_handle hako_pdu_rpc_client_handle_t;
 typedef struct hako_pdu_rpc_server_handle hako_pdu_rpc_server_handle_t;
+typedef struct hako_pdu_rpc_mux_server_handle hako_pdu_rpc_mux_server_handle_t;
 
 typedef enum {
     HAKO_PDU_RPC_OK = 0,
@@ -80,6 +81,26 @@ hako_pdu_rpc_error_t hako_pdu_rpc_server_create_reply_buffer(hako_pdu_rpc_server
 hako_pdu_rpc_error_t hako_pdu_rpc_server_create_reply_buffer_alloc(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, uint8_t status, int32_t result_code, uint8_t** out_buffer, size_t* out_size);
 hako_pdu_rpc_error_t hako_pdu_rpc_server_send_reply(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, const uint8_t* pdu, size_t pdu_size);
 hako_pdu_rpc_error_t hako_pdu_rpc_server_send_cancel_reply(hako_pdu_rpc_server_handle_t* handle, uint64_t request_token, const uint8_t* pdu, size_t pdu_size);
+
+/*
+ * Multiplexed server API. One endpoint mux listens on a single server port and
+ * creates one RPC adapter per accepted transport session. Request tokens retain
+ * the session identity internally, so callers use the same request-info shape
+ * as the static server API.
+ */
+hako_pdu_rpc_mux_server_handle_t* hako_pdu_rpc_mux_server_create(const char* node_id, const char* service_config_path, const char* endpoint_mux_config_path, uint64_t delta_time_usec, const char* time_source_type);
+void hako_pdu_rpc_mux_server_destroy(hako_pdu_rpc_mux_server_handle_t* handle);
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_start(hako_pdu_rpc_mux_server_handle_t* handle);
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_stop(hako_pdu_rpc_mux_server_handle_t* handle);
+hako_pdu_rpc_server_event_t hako_pdu_rpc_mux_server_poll(hako_pdu_rpc_mux_server_handle_t* handle, hako_pdu_rpc_request_info_t* out_info, uint8_t* buffer, size_t capacity, size_t* out_size, hako_pdu_rpc_error_t* out_error);
+hako_pdu_rpc_server_event_t hako_pdu_rpc_mux_server_poll_alloc(hako_pdu_rpc_mux_server_handle_t* handle, hako_pdu_rpc_request_info_t* out_info, uint8_t** out_buffer, size_t* out_size, hako_pdu_rpc_error_t* out_error);
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_create_reply_buffer(hako_pdu_rpc_mux_server_handle_t* handle, uint64_t request_token, uint8_t status, int32_t result_code, uint8_t* buffer, size_t capacity, size_t* out_size);
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_create_reply_buffer_alloc(hako_pdu_rpc_mux_server_handle_t* handle, uint64_t request_token, uint8_t status, int32_t result_code, uint8_t** out_buffer, size_t* out_size);
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_send_reply(hako_pdu_rpc_mux_server_handle_t* handle, uint64_t request_token, const uint8_t* pdu, size_t pdu_size);
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_send_cancel_reply(hako_pdu_rpc_mux_server_handle_t* handle, uint64_t request_token, const uint8_t* pdu, size_t pdu_size);
+size_t hako_pdu_rpc_mux_server_connected_count(const hako_pdu_rpc_mux_server_handle_t* handle);
+size_t hako_pdu_rpc_mux_server_expected_count(const hako_pdu_rpc_mux_server_handle_t* handle);
+int hako_pdu_rpc_mux_server_is_ready(const hako_pdu_rpc_mux_server_handle_t* handle);
 
 /* Co-located test/application shutdown order: server Endpoint, client Endpoint, server RPC, client RPC. */
 hako_pdu_rpc_error_t hako_pdu_rpc_stop_pair(hako_pdu_rpc_server_handle_t* server, hako_pdu_rpc_client_handle_t* client);

--- a/include/hakoniwa/pdu/rpc/rpc_service_helper.hpp
+++ b/include/hakoniwa/pdu/rpc/rpc_service_helper.hpp
@@ -1,21 +1,23 @@
 #pragma once
 
 #include "hakoniwa/pdu/rpc/rpc_services_server.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_mux_server.hpp"
 #include "hakoniwa/pdu/rpc/rpc_services_client.hpp"
+
+#include <iostream>
 
 /** Shorthand macro to resolve PDU type */
 #define HAKO_RPC_SERVICE_SERVER_TYPE(type) hako::pdu::msgs::hako_srv_msgs::type
 
 namespace hakoniwa::pdu::rpc {
-template<typename CppReqPacketType, typename CppResPacketType, 
-         typename CppReqBodyType, typename CppResBodyType, 
+template<typename CppReqPacketType, typename CppResPacketType,
+         typename CppReqBodyType, typename CppResBodyType,
          typename ConvertorReq, typename ConvertorRes>
 class HakoRpcAssetServiceServer {
 public:
     HakoRpcAssetServiceServer() = default;
     virtual ~HakoRpcAssetServiceServer() = default;
 
-    // get HakoCpp_AddTwoIntsRequest from packet
     bool get_request_body(RpcRequest& request, CppReqBodyType& req_body) {
         ConvertorReq convertor_request;
         CppReqPacketType request_packet;
@@ -27,6 +29,7 @@ public:
         req_body = request_packet.body;
         return true;
     }
+
     bool get_response_body(RpcResponse& response, CppResBodyType& res_body) {
         ConvertorRes convertor_response;
         CppResPacketType response_packet;
@@ -38,24 +41,40 @@ public:
         res_body = response_packet.body;
         return true;
     }
-    bool set_response_body(RpcServicesServer& server, RpcRequest& request, Hako_uint8 status, Hako_int32 result_code, const CppResBodyType& res_body, PduData& response_pdu) {
+
+    bool set_response_body(
+        RpcServicesServer& server,
+        RpcRequest& request,
+        Hako_uint8 status,
+        Hako_int32 result_code,
+        const CppResBodyType& res_body,
+        PduData& response_pdu)
+    {
         server.create_reply_buffer(request.header, status, result_code, response_pdu);
-        ConvertorRes convertor_response;
-        CppResPacketType response_packet;
-        auto ret = convertor_response.pdu2cpp(reinterpret_cast<char*>(response_pdu.data()), response_packet);
-        if (!ret) {
-            std::cerr << "ERROR: Failed to convert response PDU to C++ type." << std::endl;
-            return false;
-        }
-        response_packet.body = res_body;
-        int size = convertor_response.cpp2pdu(response_packet, reinterpret_cast<char*>(response_pdu.data()), response_pdu.size());
-        if (size < 0) {
-            std::cerr << "ERROR: Failed to convert response C++ type to PDU." << std::endl;
-            return false;
-        }
-        return true;
+        return encode_response_body(res_body, response_pdu);
     }
-    bool set_request_body(RpcServicesClient& client, const std::string& service_name, CppReqBodyType& req_body, PduData& request_pdu) {
+
+    bool set_response_body(
+        RpcServicesMuxServer& server,
+        RpcMuxRequest& request,
+        Hako_uint8 status,
+        Hako_int32 result_code,
+        const CppResBodyType& res_body,
+        PduData& response_pdu)
+    {
+        if (!server.create_reply_buffer(request, status, result_code, response_pdu)) {
+            std::cerr << "ERROR: Failed to create mux response PDU." << std::endl;
+            return false;
+        }
+        return encode_response_body(res_body, response_pdu);
+    }
+
+    bool set_request_body(
+        RpcServicesClient& client,
+        const std::string& service_name,
+        CppReqBodyType& req_body,
+        PduData& request_pdu)
+    {
         client.create_request_buffer(service_name, request_pdu);
         ConvertorReq convertor_request;
         CppReqPacketType request_packet;
@@ -65,7 +84,10 @@ public:
             return false;
         }
         request_packet.body = req_body;
-        int size = convertor_request.cpp2pdu(request_packet, reinterpret_cast<char*>(request_pdu.data()), request_pdu.size());
+        int size = convertor_request.cpp2pdu(
+            request_packet,
+            reinterpret_cast<char*>(request_pdu.data()),
+            request_pdu.size());
         if (size < 0) {
             std::cerr << "ERROR: Failed to convert request C++ type to PDU." << std::endl;
             return false;
@@ -73,8 +95,13 @@ public:
         return true;
     }
 
-    bool call(RpcServicesClient& client, const std::string& service_name, CppReqBodyType& req_body, uint64_t timeout_usec) {
-        hakoniwa::pdu::rpc::PduData request_pdu;
+    bool call(
+        RpcServicesClient& client,
+        const std::string& service_name,
+        CppReqBodyType& req_body,
+        uint64_t timeout_usec)
+    {
+        PduData request_pdu;
         bool set_req_body = set_request_body(client, service_name, req_body, request_pdu);
         if (!set_req_body) {
             std::cerr << "ERROR: Failed to set request body." << std::endl;
@@ -82,9 +109,17 @@ public:
         }
         return client.call(service_name, request_pdu, timeout_usec);
     }
-    bool reply(RpcServicesServer& server, RpcRequest& request, Hako_uint8 status, Hako_int32 result_code, const CppResBodyType& res_body) {
-        hakoniwa::pdu::rpc::PduData response_pdu;
-        bool set_res_body = set_response_body(server, request, status, result_code, res_body, response_pdu);
+
+    bool reply(
+        RpcServicesServer& server,
+        RpcRequest& request,
+        Hako_uint8 status,
+        Hako_int32 result_code,
+        const CppResBodyType& res_body)
+    {
+        PduData response_pdu;
+        bool set_res_body = set_response_body(
+            server, request, status, result_code, res_body, response_pdu);
         if (!set_res_body) {
             std::cerr << "ERROR: Failed to set response body." << std::endl;
             return false;
@@ -93,10 +128,50 @@ public:
         return true;
     }
 
+    bool reply(
+        RpcServicesMuxServer& server,
+        RpcMuxRequest& request,
+        Hako_uint8 status,
+        Hako_int32 result_code,
+        const CppResBodyType& res_body)
+    {
+        PduData response_pdu;
+        bool set_res_body = set_response_body(
+            server, request, status, result_code, res_body, response_pdu);
+        if (!set_res_body) {
+            std::cerr << "ERROR: Failed to set mux response body." << std::endl;
+            return false;
+        }
+        return server.send_reply(request, response_pdu);
+    }
+
+private:
+    bool encode_response_body(
+        const CppResBodyType& res_body,
+        PduData& response_pdu)
+    {
+        ConvertorRes convertor_response;
+        CppResPacketType response_packet;
+        auto ret = convertor_response.pdu2cpp(
+            reinterpret_cast<char*>(response_pdu.data()), response_packet);
+        if (!ret) {
+            std::cerr << "ERROR: Failed to convert response PDU to C++ type." << std::endl;
+            return false;
+        }
+        response_packet.body = res_body;
+        int size = convertor_response.cpp2pdu(
+            response_packet,
+            reinterpret_cast<char*>(response_pdu.data()),
+            response_pdu.size());
+        if (size < 0) {
+            std::cerr << "ERROR: Failed to convert response C++ type to PDU." << std::endl;
+            return false;
+        }
+        return true;
+    }
 };
 
 } // namespace hakoniwa::pdu::rpc
-
 
 /** Template instantiation helper */
 #define HakoRpcServiceServerTemplateType(SRVNAME) \
@@ -107,4 +182,3 @@ public:
         HakoCpp_##SRVNAME##Response, \
         HAKO_RPC_SERVICE_SERVER_TYPE(SRVNAME##RequestPacket), \
         HAKO_RPC_SERVICE_SERVER_TYPE(SRVNAME##ResponsePacket)>
-

--- a/include/hakoniwa/pdu/rpc/rpc_services_mux_server.hpp
+++ b/include/hakoniwa/pdu/rpc/rpc_services_mux_server.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "hakoniwa/pdu/rpc/rpc_services_server.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace hakoniwa::pdu::rpc {
+
+struct RpcMuxRequest {
+    std::uint64_t connection_id{0};
+    RpcRequest request;
+};
+
+// Server-side transport owner for EndpointCommMultiplexer sessions.
+//
+// One listening endpoint accepts multiple client connections. Each accepted
+// connection becomes an already-opened Endpoint and gets its own
+// RpcServicesServer adapter. Replies are routed by the connection_id returned
+// together with the request.
+class RpcServicesMuxServer {
+public:
+    RpcServicesMuxServer(
+        std::string node_id,
+        std::string impl_type,
+        std::string service_config_path,
+        std::string endpoint_mux_config_path,
+        std::uint64_t delta_time_usec,
+        std::string time_source_type = "real");
+    ~RpcServicesMuxServer();
+
+    RpcServicesMuxServer(const RpcServicesMuxServer&) = delete;
+    RpcServicesMuxServer& operator=(const RpcServicesMuxServer&) = delete;
+
+    bool initialize();
+    bool start();
+    void stop();
+
+    ServerEventType poll(RpcMuxRequest& request);
+
+    bool create_reply_buffer(
+        const RpcMuxRequest& request,
+        Hako_uint8 status,
+        Hako_int32 result_code,
+        PduData& pdu);
+    bool send_reply(const RpcMuxRequest& request, const PduData& pdu);
+    bool send_cancel_reply(const RpcMuxRequest& request, const PduData& pdu);
+
+    std::size_t connected_count() const;
+    std::size_t expected_count() const;
+    bool is_ready() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace hakoniwa::pdu::rpc

--- a/include/hakoniwa/pdu/rpc/rpc_services_server.hpp
+++ b/include/hakoniwa/pdu/rpc/rpc_services_server.hpp
@@ -16,12 +16,23 @@ namespace hakoniwa::pdu::rpc {
 class RpcServicesServer {
 public:
     RpcServicesServer(const std::string& node_id, const std::string& impl_type, const std::string& service_config_path, uint64_t delta_time_usec, std::string time_source_type = "real")
-        : node_id_(node_id), impl_type_(impl_type), service_config_path_(service_config_path), delta_time_usec_(delta_time_usec) 
+        : node_id_(node_id), impl_type_(impl_type), service_config_path_(service_config_path), delta_time_usec_(delta_time_usec)
         {
             time_source_ = hakoniwa::time_source::create_time_source(time_source_type, delta_time_usec);
         }
-    virtual ~RpcServicesServer(); // Removed = default;
-    bool initialize_services(std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container, std::optional<std::string> client_node_id = std::nullopt);
+    virtual ~RpcServicesServer();
+
+    bool initialize_services(
+        std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container,
+        std::optional<std::string> client_node_id = std::nullopt);
+
+    // Initialize all configured services on one already-opened Endpoint.
+    // This path is used by server-side communication multiplexers, where each
+    // accepted transport session becomes its own Endpoint instance.
+    bool initialize_services(
+        std::shared_ptr<hakoniwa::pdu::Endpoint> endpoint,
+        std::optional<std::string> client_node_id = std::nullopt);
+
     bool start_all_services();
     void stop_all_services();
     void clear_all_instances();
@@ -56,8 +67,11 @@ public:
     }
 
 private:
-    //(nodeId, endpointId), endpoint
-    //std::map<std::pair<std::string, std::string>, std::shared_ptr<hakoniwa::pdu::Endpoint>> pdu_endpoints_;
+    bool initialize_services_impl(
+        std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container,
+        std::shared_ptr<hakoniwa::pdu::Endpoint> endpoint_override,
+        std::optional<std::string> client_node_id);
+
     //service_name, endpoint
     std::map<std::string, std::shared_ptr<IRpcServerEndpoint>> rpc_endpoints_;
     std::string node_id_;

--- a/include/hakoniwa/pdu/rpc/rpc_services_server.hpp
+++ b/include/hakoniwa/pdu/rpc/rpc_services_server.hpp
@@ -4,12 +4,15 @@
 #include "hakoniwa/pdu/endpoint.hpp"
 #include "hakoniwa/pdu/endpoint_container.hpp"
 #include "hakoniwa/time_source/time_source_factory.hpp"
-#include <string>
+
+#include <iostream>
+#include <map>
 #include <memory>
 #include <optional>
-#include <vector>
-#include <map>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace hakoniwa::pdu::rpc {
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 set(HAKO_PDU_RPC_SOURCES
   rpc_server_endpoint_impl.cpp
   rpc_services_server.cpp
+  rpc_services_mux_server.cpp
   rpc_client_endpoint_impl.cpp
   rpc_services_client.cpp
   c_rpc.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ set(HAKO_PDU_RPC_SOURCES
   c_rpc.cpp
   c_rpc_cancel.cpp
   c_rpc_alloc.cpp
+  c_rpc_mux.cpp
 )
 
 function(hako_pdu_rpc_configure_target target)

--- a/src/c_rpc_mux.cpp
+++ b/src/c_rpc_mux.cpp
@@ -1,0 +1,509 @@
+#include "hakoniwa/pdu/rpc/c_rpc.h"
+
+#include "hakoniwa/pdu/rpc/rpc_services_mux_server.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+
+using hakoniwa::pdu::rpc::PduData;
+using hakoniwa::pdu::rpc::RpcMuxRequest;
+using hakoniwa::pdu::rpc::RpcServicesMuxServer;
+using hakoniwa::pdu::rpc::ServerEventType;
+
+namespace {
+
+constexpr const char* kServerImpl = "RpcServerEndpointImpl";
+constexpr const char* kDefaultTimeSource = "real";
+
+bool valid_text(const char* value)
+{
+    return value != nullptr && value[0] != '\0';
+}
+
+void copy_name(char* dst, size_t capacity, const std::string& src)
+{
+    if (dst == nullptr || capacity == 0) {
+        return;
+    }
+    const size_t count = std::min(capacity - 1, src.size());
+    std::memcpy(dst, src.data(), count);
+    dst[count] = '\0';
+}
+
+PduData make_pdu(const uint8_t* data, size_t size)
+{
+    return size == 0 ? PduData{} : PduData(data, data + size);
+}
+
+hako_pdu_rpc_error_t copy_pdu(
+    const PduData& source,
+    uint8_t* destination,
+    size_t capacity,
+    size_t* out_size)
+{
+    if (out_size == nullptr) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    *out_size = source.size();
+    if (source.size() > capacity || (!source.empty() && destination == nullptr)) {
+        return HAKO_PDU_RPC_ERROR_BUFFER_TOO_SMALL;
+    }
+    if (!source.empty()) {
+        std::memcpy(destination, source.data(), source.size());
+    }
+    return HAKO_PDU_RPC_OK;
+}
+
+hako_pdu_rpc_error_t allocate_pdu(
+    const PduData& source,
+    uint8_t** out_buffer,
+    size_t* out_size)
+{
+    if (out_buffer == nullptr || out_size == nullptr) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    *out_buffer = nullptr;
+    *out_size = 0;
+    if (source.empty()) {
+        return HAKO_PDU_RPC_OK;
+    }
+
+    auto* buffer = static_cast<uint8_t*>(std::malloc(source.size()));
+    if (buffer == nullptr) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+    std::memcpy(buffer, source.data(), source.size());
+    *out_buffer = buffer;
+    *out_size = source.size();
+    return HAKO_PDU_RPC_OK;
+}
+
+hako_pdu_rpc_server_event_t map_server_event(ServerEventType event)
+{
+    switch (event) {
+    case ServerEventType::REQUEST_IN:
+        return HAKO_PDU_RPC_SERVER_EVENT_REQUEST_IN;
+    case ServerEventType::REQUEST_CANCEL:
+        return HAKO_PDU_RPC_SERVER_EVENT_REQUEST_CANCEL;
+    default:
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+}
+
+} // namespace
+
+struct hako_pdu_rpc_mux_server_handle {
+    std::unique_ptr<RpcServicesMuxServer> rpc;
+    std::mutex pending_mutex;
+    uint64_t next_token{1};
+    std::map<uint64_t, RpcMuxRequest> pending_requests;
+    bool started{false};
+};
+
+namespace {
+
+hako_pdu_rpc_error_t store_request(
+    hako_pdu_rpc_mux_server_handle_t* handle,
+    RpcMuxRequest request,
+    hako_pdu_rpc_request_info_t* info)
+{
+    uint64_t token = 0;
+    {
+        std::lock_guard<std::mutex> lock(handle->pending_mutex);
+        token = handle->next_token++;
+        handle->pending_requests.emplace(token, request);
+    }
+    info->request_token = token;
+    copy_name(
+        info->service_name,
+        sizeof(info->service_name),
+        request.request.header.service_name);
+    copy_name(
+        info->client_name,
+        sizeof(info->client_name),
+        request.request.client_name);
+    info->pdu_size = request.request.pdu.size();
+    return HAKO_PDU_RPC_OK;
+}
+
+bool find_request(
+    hako_pdu_rpc_mux_server_handle_t* handle,
+    uint64_t token,
+    RpcMuxRequest& request)
+{
+    std::lock_guard<std::mutex> lock(handle->pending_mutex);
+    const auto it = handle->pending_requests.find(token);
+    if (it == handle->pending_requests.end()) {
+        return false;
+    }
+    request = it->second;
+    return true;
+}
+
+bool take_request(
+    hako_pdu_rpc_mux_server_handle_t* handle,
+    uint64_t token,
+    RpcMuxRequest& request)
+{
+    std::lock_guard<std::mutex> lock(handle->pending_mutex);
+    const auto it = handle->pending_requests.find(token);
+    if (it == handle->pending_requests.end()) {
+        return false;
+    }
+    request = it->second;
+    handle->pending_requests.erase(it);
+    return true;
+}
+
+void reset_output(
+    uint8_t** out_buffer,
+    size_t* out_size,
+    hako_pdu_rpc_error_t* out_error)
+{
+    if (out_buffer != nullptr) {
+        *out_buffer = nullptr;
+    }
+    if (out_size != nullptr) {
+        *out_size = 0;
+    }
+    if (out_error != nullptr) {
+        *out_error = HAKO_PDU_RPC_OK;
+    }
+}
+
+} // namespace
+
+extern "C" {
+
+hako_pdu_rpc_mux_server_handle_t* hako_pdu_rpc_mux_server_create(
+    const char* node_id,
+    const char* service_config_path,
+    const char* endpoint_mux_config_path,
+    uint64_t delta_time_usec,
+    const char* time_source_type)
+{
+    if (!valid_text(node_id) || !valid_text(service_config_path)
+        || !valid_text(endpoint_mux_config_path) || delta_time_usec == 0) {
+        return nullptr;
+    }
+
+    try {
+        auto handle = std::make_unique<hako_pdu_rpc_mux_server_handle_t>();
+        handle->rpc = std::make_unique<RpcServicesMuxServer>(
+            node_id,
+            kServerImpl,
+            service_config_path,
+            endpoint_mux_config_path,
+            delta_time_usec,
+            valid_text(time_source_type) ? time_source_type : kDefaultTimeSource);
+        if (!handle->rpc->initialize()) {
+            return nullptr;
+        }
+        return handle.release();
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void hako_pdu_rpc_mux_server_destroy(hako_pdu_rpc_mux_server_handle_t* handle)
+{
+    if (handle == nullptr) {
+        return;
+    }
+    (void)hako_pdu_rpc_mux_server_stop(handle);
+    delete handle;
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_start(
+    hako_pdu_rpc_mux_server_handle_t* handle)
+{
+    if (handle == nullptr) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    if (handle->started) {
+        return HAKO_PDU_RPC_OK;
+    }
+    if (!handle->rpc) {
+        return HAKO_PDU_RPC_ERROR_INITIALIZE;
+    }
+    try {
+        if (!handle->rpc->start()) {
+            return HAKO_PDU_RPC_ERROR_START;
+        }
+        handle->started = true;
+        return HAKO_PDU_RPC_OK;
+    } catch (...) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_stop(
+    hako_pdu_rpc_mux_server_handle_t* handle)
+{
+    if (handle == nullptr) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    try {
+        if (handle->rpc) {
+            handle->rpc->stop();
+        }
+        {
+            std::lock_guard<std::mutex> lock(handle->pending_mutex);
+            handle->pending_requests.clear();
+        }
+        handle->rpc.reset();
+        handle->started = false;
+        return HAKO_PDU_RPC_OK;
+    } catch (...) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+}
+
+hako_pdu_rpc_server_event_t hako_pdu_rpc_mux_server_poll(
+    hako_pdu_rpc_mux_server_handle_t* handle,
+    hako_pdu_rpc_request_info_t* info,
+    uint8_t* buffer,
+    size_t capacity,
+    size_t* out_size,
+    hako_pdu_rpc_error_t* out_error)
+{
+    if (out_error != nullptr) {
+        *out_error = HAKO_PDU_RPC_OK;
+    }
+    if (handle == nullptr || info == nullptr || out_size == nullptr) {
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+        }
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+    if (!handle->started || !handle->rpc) {
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+        }
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+
+    try {
+        RpcMuxRequest request;
+        const auto event = handle->rpc->poll(request);
+        if (event == ServerEventType::NONE) {
+            *out_size = 0;
+            return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+        }
+        const auto copy_result = copy_pdu(
+            request.request.pdu, buffer, capacity, out_size);
+        if (copy_result != HAKO_PDU_RPC_OK) {
+            if (out_error != nullptr) {
+                *out_error = copy_result;
+            }
+            return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+        }
+        (void)store_request(handle, request, info);
+        return map_server_event(event);
+    } catch (...) {
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_INTERNAL;
+        }
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+}
+
+hako_pdu_rpc_server_event_t hako_pdu_rpc_mux_server_poll_alloc(
+    hako_pdu_rpc_mux_server_handle_t* handle,
+    hako_pdu_rpc_request_info_t* info,
+    uint8_t** out_buffer,
+    size_t* out_size,
+    hako_pdu_rpc_error_t* out_error)
+{
+    reset_output(out_buffer, out_size, out_error);
+    if (handle == nullptr || info == nullptr || out_buffer == nullptr
+        || out_size == nullptr) {
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+        }
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+    if (!handle->started || !handle->rpc) {
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+        }
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+
+    try {
+        RpcMuxRequest request;
+        const auto event = handle->rpc->poll(request);
+        if (event == ServerEventType::NONE) {
+            return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+        }
+        const auto allocation = allocate_pdu(
+            request.request.pdu, out_buffer, out_size);
+        if (allocation != HAKO_PDU_RPC_OK) {
+            if (out_error != nullptr) {
+                *out_error = allocation;
+            }
+            return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+        }
+        (void)store_request(handle, request, info);
+        return map_server_event(event);
+    } catch (...) {
+        hako_pdu_rpc_buffer_free(*out_buffer);
+        *out_buffer = nullptr;
+        *out_size = 0;
+        if (out_error != nullptr) {
+            *out_error = HAKO_PDU_RPC_ERROR_INTERNAL;
+        }
+        return HAKO_PDU_RPC_SERVER_EVENT_NONE;
+    }
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_create_reply_buffer(
+    hako_pdu_rpc_mux_server_handle_t* handle,
+    uint64_t request_token,
+    uint8_t status,
+    int32_t result_code,
+    uint8_t* buffer,
+    size_t capacity,
+    size_t* out_size)
+{
+    if (handle == nullptr || out_size == nullptr) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    if (!handle->started || !handle->rpc) {
+        return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    }
+
+    try {
+        RpcMuxRequest request;
+        if (!find_request(handle, request_token, request)) {
+            return HAKO_PDU_RPC_ERROR_NOT_FOUND;
+        }
+        PduData response;
+        if (!handle->rpc->create_reply_buffer(
+                request,
+                static_cast<Hako_uint8>(status),
+                static_cast<Hako_int32>(result_code),
+                response)) {
+            return HAKO_PDU_RPC_ERROR_NOT_FOUND;
+        }
+        return copy_pdu(response, buffer, capacity, out_size);
+    } catch (...) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_create_reply_buffer_alloc(
+    hako_pdu_rpc_mux_server_handle_t* handle,
+    uint64_t request_token,
+    uint8_t status,
+    int32_t result_code,
+    uint8_t** out_buffer,
+    size_t* out_size)
+{
+    reset_output(out_buffer, out_size, nullptr);
+    if (handle == nullptr || out_buffer == nullptr || out_size == nullptr) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    if (!handle->started || !handle->rpc) {
+        return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    }
+
+    try {
+        RpcMuxRequest request;
+        if (!find_request(handle, request_token, request)) {
+            return HAKO_PDU_RPC_ERROR_NOT_FOUND;
+        }
+        PduData response;
+        if (!handle->rpc->create_reply_buffer(
+                request,
+                static_cast<Hako_uint8>(status),
+                static_cast<Hako_int32>(result_code),
+                response)) {
+            return HAKO_PDU_RPC_ERROR_NOT_FOUND;
+        }
+        return allocate_pdu(response, out_buffer, out_size);
+    } catch (...) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_send_reply(
+    hako_pdu_rpc_mux_server_handle_t* handle,
+    uint64_t request_token,
+    const uint8_t* pdu,
+    size_t pdu_size)
+{
+    if (handle == nullptr || (pdu_size > 0 && pdu == nullptr)) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    if (!handle->started || !handle->rpc) {
+        return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    }
+
+    try {
+        RpcMuxRequest request;
+        if (!take_request(handle, request_token, request)) {
+            return HAKO_PDU_RPC_ERROR_NOT_FOUND;
+        }
+        return handle->rpc->send_reply(request, make_pdu(pdu, pdu_size))
+            ? HAKO_PDU_RPC_OK
+            : HAKO_PDU_RPC_ERROR_CALL;
+    } catch (...) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+}
+
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_send_cancel_reply(
+    hako_pdu_rpc_mux_server_handle_t* handle,
+    uint64_t request_token,
+    const uint8_t* pdu,
+    size_t pdu_size)
+{
+    if (handle == nullptr || (pdu_size > 0 && pdu == nullptr)) {
+        return HAKO_PDU_RPC_ERROR_INVALID_ARGUMENT;
+    }
+    if (!handle->started || !handle->rpc) {
+        return HAKO_PDU_RPC_ERROR_NOT_RUNNING;
+    }
+
+    try {
+        RpcMuxRequest request;
+        if (!take_request(handle, request_token, request)) {
+            return HAKO_PDU_RPC_ERROR_NOT_FOUND;
+        }
+        return handle->rpc->send_cancel_reply(request, make_pdu(pdu, pdu_size))
+            ? HAKO_PDU_RPC_OK
+            : HAKO_PDU_RPC_ERROR_CALL;
+    } catch (...) {
+        return HAKO_PDU_RPC_ERROR_INTERNAL;
+    }
+}
+
+size_t hako_pdu_rpc_mux_server_connected_count(
+    const hako_pdu_rpc_mux_server_handle_t* handle)
+{
+    return handle != nullptr && handle->rpc
+        ? handle->rpc->connected_count()
+        : 0;
+}
+
+size_t hako_pdu_rpc_mux_server_expected_count(
+    const hako_pdu_rpc_mux_server_handle_t* handle)
+{
+    return handle != nullptr && handle->rpc
+        ? handle->rpc->expected_count()
+        : 0;
+}
+
+int hako_pdu_rpc_mux_server_is_ready(
+    const hako_pdu_rpc_mux_server_handle_t* handle)
+{
+    return handle != nullptr && handle->rpc && handle->rpc->is_ready() ? 1 : 0;
+}
+
+} // extern "C"

--- a/src/rpc_services_mux_server.cpp
+++ b/src/rpc_services_mux_server.cpp
@@ -1,0 +1,361 @@
+#include "hakoniwa/pdu/rpc/rpc_services_mux_server.hpp"
+
+#include "hakoniwa/pdu/endpoint.hpp"
+#include "hakoniwa/pdu/endpoint_comm_multiplexer.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+namespace hakoniwa::pdu::rpc {
+namespace {
+
+struct ConnectionSlot {
+    std::uint64_t connection_id{0};
+    std::shared_ptr<hakoniwa::pdu::Endpoint> endpoint;
+    std::unique_ptr<RpcServicesServer> server;
+    std::shared_ptr<std::atomic_bool> disconnected;
+};
+
+} // namespace
+
+class RpcServicesMuxServer::Impl {
+public:
+    Impl(
+        std::string node_id,
+        std::string impl_type,
+        std::string service_config_path,
+        std::string endpoint_mux_config_path,
+        std::uint64_t delta_time_usec,
+        std::string time_source_type)
+        : node_id_(std::move(node_id))
+        , impl_type_(std::move(impl_type))
+        , service_config_path_(std::move(service_config_path))
+        , endpoint_mux_config_path_(std::move(endpoint_mux_config_path))
+        , delta_time_usec_(delta_time_usec)
+        , time_source_type_(std::move(time_source_type))
+    {
+    }
+
+    ~Impl()
+    {
+        stop();
+    }
+
+    bool initialize()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (mux_) {
+            return true;
+        }
+        if (node_id_.empty() || impl_type_.empty() || service_config_path_.empty()
+            || endpoint_mux_config_path_.empty() || delta_time_usec_ == 0) {
+            return false;
+        }
+
+        auto mux = std::make_unique<hakoniwa::pdu::EndpointCommMultiplexer>(
+            node_id_ + "_rpc_mux",
+            HAKO_PDU_ENDPOINT_DIRECTION_INOUT);
+        if (mux->open(endpoint_mux_config_path_) != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        if (mux->expected_count() == 0) {
+            (void)mux->close();
+            return false;
+        }
+        mux_ = std::move(mux);
+        return true;
+    }
+
+    bool start()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (started_) {
+            return true;
+        }
+        if (!mux_) {
+            return false;
+        }
+        if (mux_->start() != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        started_ = true;
+        return true;
+    }
+
+    void stop()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (auto& slot : slots_) {
+            close_slot_(slot);
+        }
+        slots_.clear();
+
+        if (mux_) {
+            (void)mux_->stop();
+            (void)mux_->close();
+            mux_.reset();
+        }
+        started_ = false;
+    }
+
+    ServerEventType poll(RpcMuxRequest& request)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!started_ || !mux_) {
+            return ServerEventType::NONE;
+        }
+
+        accept_new_connections_();
+        cleanup_disconnected_();
+
+        for (auto& slot : slots_) {
+            if (!slot.server) {
+                continue;
+            }
+            RpcRequest candidate;
+            const auto event = slot.server->poll(candidate);
+            if (event != ServerEventType::NONE) {
+                request.connection_id = slot.connection_id;
+                request.request = std::move(candidate);
+                return event;
+            }
+        }
+
+        cleanup_disconnected_();
+        return ServerEventType::NONE;
+    }
+
+    bool create_reply_buffer(
+        const RpcMuxRequest& request,
+        Hako_uint8 status,
+        Hako_int32 result_code,
+        PduData& pdu)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto* slot = find_slot_(request.connection_id);
+        if (!slot || !slot->server) {
+            return false;
+        }
+        slot->server->create_reply_buffer(
+            request.request.header, status, result_code, pdu);
+        return !pdu.empty();
+    }
+
+    bool send_reply(const RpcMuxRequest& request, const PduData& pdu)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto* slot = find_slot_(request.connection_id);
+        if (!slot || !slot->server) {
+            return false;
+        }
+        slot->server->send_reply(request.request.header, pdu);
+        return true;
+    }
+
+    bool send_cancel_reply(const RpcMuxRequest& request, const PduData& pdu)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto* slot = find_slot_(request.connection_id);
+        if (!slot || !slot->server) {
+            return false;
+        }
+        slot->server->send_cancel_reply(request.request.header, pdu);
+        return true;
+    }
+
+    std::size_t connected_count() const
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return slots_.size();
+    }
+
+    std::size_t expected_count() const
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return mux_ ? mux_->expected_count() : 0;
+    }
+
+    bool is_ready() const
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return started_ && mux_ && mux_->is_ready();
+    }
+
+private:
+    void accept_new_connections_()
+    {
+        auto endpoints = mux_->take_endpoints();
+        const auto capacity = mux_->expected_count();
+        for (auto& endpoint_unique : endpoints) {
+            if (!endpoint_unique) {
+                continue;
+            }
+            if (slots_.size() >= capacity) {
+                (void)endpoint_unique->stop();
+                (void)endpoint_unique->close();
+                continue;
+            }
+
+            auto endpoint = std::shared_ptr<hakoniwa::pdu::Endpoint>(
+                std::move(endpoint_unique));
+            ConnectionSlot slot;
+            slot.connection_id = next_connection_id_++;
+            slot.endpoint = endpoint;
+            slot.disconnected = std::make_shared<std::atomic_bool>(false);
+
+            std::weak_ptr<std::atomic_bool> weak_disconnected = slot.disconnected;
+            endpoint->set_on_disconnected_callback([weak_disconnected](const auto&) {
+                if (auto disconnected = weak_disconnected.lock()) {
+                    disconnected->store(true);
+                }
+            });
+
+            slot.server = std::make_unique<RpcServicesServer>(
+                node_id_,
+                impl_type_,
+                service_config_path_,
+                delta_time_usec_,
+                time_source_type_);
+            if (!slot.server->initialize_services(endpoint)
+                || !slot.server->start_all_services()) {
+                slot.server.reset();
+                (void)endpoint->stop();
+                (void)endpoint->close();
+                continue;
+            }
+            slots_.push_back(std::move(slot));
+        }
+    }
+
+    void cleanup_disconnected_()
+    {
+        auto it = slots_.begin();
+        while (it != slots_.end()) {
+            if (!it->disconnected || !it->disconnected->load()) {
+                ++it;
+                continue;
+            }
+            close_slot_(*it);
+            it = slots_.erase(it);
+        }
+    }
+
+    static void close_slot_(ConnectionSlot& slot)
+    {
+        if (slot.server) {
+            slot.server->stop_all_services();
+            slot.server.reset();
+        }
+        if (slot.endpoint) {
+            (void)slot.endpoint->stop();
+            (void)slot.endpoint->close();
+            slot.endpoint.reset();
+        }
+    }
+
+    ConnectionSlot* find_slot_(std::uint64_t connection_id)
+    {
+        auto it = std::find_if(
+            slots_.begin(),
+            slots_.end(),
+            [connection_id](const ConnectionSlot& slot) {
+                return slot.connection_id == connection_id;
+            });
+        return it == slots_.end() ? nullptr : &*it;
+    }
+
+    std::string node_id_;
+    std::string impl_type_;
+    std::string service_config_path_;
+    std::string endpoint_mux_config_path_;
+    std::uint64_t delta_time_usec_{0};
+    std::string time_source_type_;
+
+    mutable std::mutex mutex_;
+    std::unique_ptr<hakoniwa::pdu::EndpointCommMultiplexer> mux_;
+    std::vector<ConnectionSlot> slots_;
+    std::uint64_t next_connection_id_{1};
+    bool started_{false};
+};
+
+RpcServicesMuxServer::RpcServicesMuxServer(
+    std::string node_id,
+    std::string impl_type,
+    std::string service_config_path,
+    std::string endpoint_mux_config_path,
+    std::uint64_t delta_time_usec,
+    std::string time_source_type)
+    : impl_(std::make_unique<Impl>(
+          std::move(node_id),
+          std::move(impl_type),
+          std::move(service_config_path),
+          std::move(endpoint_mux_config_path),
+          delta_time_usec,
+          std::move(time_source_type)))
+{
+}
+
+RpcServicesMuxServer::~RpcServicesMuxServer() = default;
+
+bool RpcServicesMuxServer::initialize()
+{
+    return impl_->initialize();
+}
+
+bool RpcServicesMuxServer::start()
+{
+    return impl_->start();
+}
+
+void RpcServicesMuxServer::stop()
+{
+    impl_->stop();
+}
+
+ServerEventType RpcServicesMuxServer::poll(RpcMuxRequest& request)
+{
+    return impl_->poll(request);
+}
+
+bool RpcServicesMuxServer::create_reply_buffer(
+    const RpcMuxRequest& request,
+    Hako_uint8 status,
+    Hako_int32 result_code,
+    PduData& pdu)
+{
+    return impl_->create_reply_buffer(request, status, result_code, pdu);
+}
+
+bool RpcServicesMuxServer::send_reply(
+    const RpcMuxRequest& request,
+    const PduData& pdu)
+{
+    return impl_->send_reply(request, pdu);
+}
+
+bool RpcServicesMuxServer::send_cancel_reply(
+    const RpcMuxRequest& request,
+    const PduData& pdu)
+{
+    return impl_->send_cancel_reply(request, pdu);
+}
+
+std::size_t RpcServicesMuxServer::connected_count() const
+{
+    return impl_->connected_count();
+}
+
+std::size_t RpcServicesMuxServer::expected_count() const
+{
+    return impl_->expected_count();
+}
+
+bool RpcServicesMuxServer::is_ready() const
+{
+    return impl_->is_ready();
+}
+
+} // namespace hakoniwa::pdu::rpc

--- a/src/rpc_services_server.cpp
+++ b/src/rpc_services_server.cpp
@@ -1,10 +1,10 @@
 #include "hakoniwa/pdu/rpc/rpc_services_server.hpp"
 #include "hakoniwa/pdu/rpc/rpc_server_endpoint_impl.hpp"
-#include "hakoniwa/pdu/endpoint_types.hpp" // For HAKO_PDU_ENDPOINT_DIRECTION_INOUT
-#include "hakoniwa/pdu/endpoint.hpp" // For hakoniwa::pdu::Endpoint
-#include "hakoniwa/time_source/real_time_source.hpp" // For RealTimeSource
-#include "hakoniwa/time_source/virtual_time_source.hpp" // For VirtualTimeSource
-#include "hakoniwa/time_source/hakoniwa_time_source.hpp" // For HakoniwaTimeSource
+#include "hakoniwa/pdu/endpoint_types.hpp"
+#include "hakoniwa/pdu/endpoint.hpp"
+#include "hakoniwa/time_source/real_time_source.hpp"
+#include "hakoniwa/time_source/virtual_time_source.hpp"
+#include "hakoniwa/time_source/hakoniwa_time_source.hpp"
 #include <fstream>
 #include <iostream>
 #include <nlohmann/json.hpp>
@@ -13,26 +13,43 @@
 #include <memory>
 #include <filesystem>
 
-
 namespace hakoniwa::pdu::rpc {
 
-
-// Constructor is already defined in the header with its initializer list.
-// If debug prints are needed in the constructor, the definition must be moved from header to here.
-// For now, we rely on existing initializers.
-
-// Destructor is explicitly defaulted in header.
-// If custom logic (like debug prints) is needed, it must be defined here, NOT defaulted.
 RpcServicesServer::~RpcServicesServer() {
     stop_all_services();
 }
 
-bool RpcServicesServer::initialize_services(std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container, std::optional<std::string> client_node_id) {
-    this->endpoint_container_ = endpoint_container;
-    std::cout << "INFO: Initializing RPC Services Server for node: " << this->node_id_ << std::endl;
-    std::cout << "INFO: service_config_path: " << this->service_config_path_ << std::endl;
-    fs::path file_path(this->service_config_path_);
-    fs::path parent_abs = fs::absolute(file_path.parent_path());
+bool RpcServicesServer::initialize_services(
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container,
+    std::optional<std::string> client_node_id)
+{
+    return initialize_services_impl(
+        std::move(endpoint_container), nullptr, std::move(client_node_id));
+}
+
+bool RpcServicesServer::initialize_services(
+    std::shared_ptr<hakoniwa::pdu::Endpoint> endpoint,
+    std::optional<std::string> client_node_id)
+{
+    return initialize_services_impl(
+        nullptr, std::move(endpoint), std::move(client_node_id));
+}
+
+bool RpcServicesServer::initialize_services_impl(
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container,
+    std::shared_ptr<hakoniwa::pdu::Endpoint> endpoint_override,
+    std::optional<std::string> client_node_id)
+{
+    if (!endpoint_container && !endpoint_override) {
+        std::cerr << "ERROR: Endpoint container or endpoint override is required." << std::endl;
+        return false;
+    }
+
+    endpoint_container_ = std::move(endpoint_container);
+    std::cout << "INFO: Initializing RPC Services Server for node: " << node_id_ << std::endl;
+    std::cout << "INFO: service_config_path: " << service_config_path_ << std::endl;
+    std::filesystem::path file_path(service_config_path_);
+    std::filesystem::path parent_abs = std::filesystem::absolute(file_path.parent_path());
     std::cout << "INFO: service_config_path parent: " << parent_abs << std::endl;
     std::ifstream ifs(service_config_path_);
     if (!ifs.is_open()) {
@@ -52,50 +69,49 @@ bool RpcServicesServer::initialize_services(std::shared_ptr<hakoniwa::pdu::Endpo
     try {
         int pdu_meta_data_size = json_config.value("pduMetaDataSize", 24);
 
-        // Then, initialize services that are meant for this server
         for (const auto& service_entry : json_config["services"]) {
             std::string service_name = service_entry["name"];
-            #ifdef ENABLE_DEBUG_MESSAGES
-            std::cout << "DEBUG: Looking for server endpoint for service: " << service_name << std::endl;
-            #endif
-            bool found = false;
-            std::string server_endpoint_id;
-            if (!service_entry.contains("server_endpoints") || !service_entry["server_endpoints"].is_array()) {
-                std::cerr << "ERROR: 'server_endpoints' section missing or not an array for service " << service_name << std::endl;
-                std::cout.flush();
-                stop_all_services();
-                return false;
-            }
-            for (const auto& server_ep : service_entry["server_endpoints"]) {
-                #ifdef ENABLE_DEBUG_MESSAGES
-                std::cout << "DEBUG: Checking server endpoint: " << server_ep.dump() << std::endl;
-                #endif
-                if (server_ep["nodeId"] != this->node_id_) {
-                    continue;
-                }
-                server_endpoint_id = server_ep["endpointId"];
-                found = true;
-                break;
-            }
-            if (!found) {
-                std::cerr << "ERROR: PDU Endpoint not found for service " << service_name 
-                          << " on node " << this->node_id_ << " with endpoint " << server_endpoint_id << ". Check 'endpoints' section in config." << std::endl;
-                std::cout.flush();
-                stop_all_services();
-                return false; // This is a configuration error
-            }
-            std::shared_ptr<hakoniwa::pdu::Endpoint> pdu_endpoint = endpoint_container_->ref(server_endpoint_id);
+            std::shared_ptr<hakoniwa::pdu::Endpoint> pdu_endpoint = endpoint_override;
+
             if (!pdu_endpoint) {
-                std::cerr << "ERROR: PDU Endpoint instance not found for service " << service_name 
-                          << " on node " << this->node_id_ << " with endpoint " << server_endpoint_id << ". Check 'endpoints' section in config." << std::endl;
-                std::cout.flush();
-                stop_all_services();
-                return false; // This is a configuration error
+                bool found = false;
+                std::string server_endpoint_id;
+                if (!service_entry.contains("server_endpoints") || !service_entry["server_endpoints"].is_array()) {
+                    std::cerr << "ERROR: 'server_endpoints' section missing or not an array for service " << service_name << std::endl;
+                    std::cout.flush();
+                    stop_all_services();
+                    return false;
+                }
+                for (const auto& server_ep : service_entry["server_endpoints"]) {
+                    if (server_ep["nodeId"] != node_id_) {
+                        continue;
+                    }
+                    server_endpoint_id = server_ep["endpointId"];
+                    found = true;
+                    break;
+                }
+                if (!found) {
+                    std::cerr << "ERROR: PDU Endpoint not found for service " << service_name
+                              << " on node " << node_id_ << ". Check 'server_endpoints' in config." << std::endl;
+                    std::cout.flush();
+                    stop_all_services();
+                    return false;
+                }
+                pdu_endpoint = endpoint_container_->ref(server_endpoint_id);
+                if (!pdu_endpoint) {
+                    std::cerr << "ERROR: PDU Endpoint instance not found for service " << service_name
+                              << " on node " << node_id_ << " with endpoint " << server_endpoint_id
+                              << ". Check endpoint configuration." << std::endl;
+                    std::cout.flush();
+                    stop_all_services();
+                    return false;
+                }
             }
+
             std::shared_ptr<IRpcServerEndpoint> rpc_server_endpoint;
             if (impl_type_ == "RpcServerEndpointImpl") {
-                //std::cout << "## endpoint_id: " << server_endpoint_id << std::endl;
-                rpc_server_endpoint = std::make_shared<RpcServerEndpointImpl>(service_name, delta_time_usec_, pdu_endpoint, time_source_);
+                rpc_server_endpoint = std::make_shared<RpcServerEndpointImpl>(
+                    service_name, delta_time_usec_, pdu_endpoint, time_source_);
             } else {
                 std::cerr << "ERROR: Unsupported RPC Server Endpoint Implementation Type: " << impl_type_ << std::endl;
                 std::cout.flush();
@@ -110,7 +126,8 @@ bool RpcServicesServer::initialize_services(std::shared_ptr<hakoniwa::pdu::Endpo
             }
 
             rpc_endpoints_[service_name] = rpc_server_endpoint;
-            std::cout << "INFO: Successfully initialized service: " << service_name << " on node " << this->node_id_ << std::endl;
+            std::cout << "INFO: Successfully initialized service: " << service_name
+                      << " on node " << node_id_ << std::endl;
             std::cout.flush();
         }
     } catch (const std::exception& e) {
@@ -123,7 +140,6 @@ bool RpcServicesServer::initialize_services(std::shared_ptr<hakoniwa::pdu::Endpo
 }
 
 bool RpcServicesServer::start_all_services() {
-    //nothing to do for now
     return true;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,13 @@ target_link_libraries(hakoniwa_pdu_rpc_basic_test PRIVATE ${HAKO_PDU_RPC_NATIVE_
 add_test(NAME hakoniwa_pdu_rpc_basic_test COMMAND hakoniwa_pdu_rpc_basic_test)
 set_tests_properties(hakoniwa_pdu_rpc_basic_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
+add_executable(hakoniwa_pdu_rpc_mux_server_test
+  rpc_mux_server_contract_test.cpp
+)
+target_link_libraries(hakoniwa_pdu_rpc_mux_server_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
+add_test(NAME hakoniwa_pdu_rpc_mux_server_test COMMAND hakoniwa_pdu_rpc_mux_server_test)
+set_tests_properties(hakoniwa_pdu_rpc_mux_server_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
+
 # C API parity test for the same two basic contracts. It remains a native
 # contract test and therefore links the static RPC target as well.
 add_executable(hakoniwa_pdu_rpc_c_api_basic_test

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,13 @@ target_link_libraries(hakoniwa_pdu_rpc_mux_server_test PRIVATE ${HAKO_PDU_RPC_NA
 add_test(NAME hakoniwa_pdu_rpc_mux_server_test COMMAND hakoniwa_pdu_rpc_mux_server_test)
 set_tests_properties(hakoniwa_pdu_rpc_mux_server_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
 
+add_executable(hakoniwa_pdu_rpc_c_api_mux_server_test
+  c_rpc_mux_server_contract_test.cpp
+)
+target_link_libraries(hakoniwa_pdu_rpc_c_api_mux_server_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
+add_test(NAME hakoniwa_pdu_rpc_c_api_mux_server_test COMMAND hakoniwa_pdu_rpc_c_api_mux_server_test)
+set_tests_properties(hakoniwa_pdu_rpc_c_api_mux_server_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
+
 # C API parity test for the same two basic contracts. It remains a native
 # contract test and therefore links the static RPC target as well.
 add_executable(hakoniwa_pdu_rpc_c_api_basic_test

--- a/test/c_rpc_mux_server_contract_test.cpp
+++ b/test/c_rpc_mux_server_contract_test.cpp
@@ -1,0 +1,309 @@
+#include <gtest/gtest.h>
+
+#include "hakoniwa/pdu/rpc/c_rpc.h"
+#include "hakoniwa/pdu/rpc/rpc_types.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsRequestPacket.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsResponsePacket.hpp"
+
+#include <chrono>
+#include <cstring>
+#include <map>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+using hako::pdu::msgs::hako_srv_msgs::AddTwoIntsRequestPacket;
+using hako::pdu::msgs::hako_srv_msgs::AddTwoIntsResponsePacket;
+
+constexpr const char* kServiceConfig = "configs/service_config_mux.json";
+constexpr const char* kClientEndpointConfig = "configs/endpoints_mux_clients.json";
+constexpr const char* kMuxEndpointConfig = "configs/mux_server_endpoint.json";
+constexpr const char* kService = "Service/Add";
+constexpr size_t kMaxPdu = 4 * 1024 * 1024;
+
+struct PendingCall {
+    hako_pdu_rpc_request_info_t info{};
+    std::vector<uint8_t> pdu;
+};
+
+class CMuxRuntime {
+public:
+    ~CMuxRuntime()
+    {
+        stop();
+    }
+
+    bool start()
+    {
+        server_ = hako_pdu_rpc_mux_server_create(
+            "server_node", kServiceConfig, kMuxEndpointConfig, 1000, "real");
+        client0_ = hako_pdu_rpc_client_create(
+            "client_node", "TestClient0", kServiceConfig,
+            kClientEndpointConfig, 1000, "real");
+        client1_ = hako_pdu_rpc_client_create(
+            "client_node", "TestClient1", kServiceConfig,
+            kClientEndpointConfig, 1000, "real");
+        if (!server_ || !client0_ || !client1_) {
+            return false;
+        }
+        if (hako_pdu_rpc_mux_server_start(server_) != HAKO_PDU_RPC_OK
+            || hako_pdu_rpc_client_start(client0_) != HAKO_PDU_RPC_OK
+            || hako_pdu_rpc_client_start(client1_) != HAKO_PDU_RPC_OK) {
+            return false;
+        }
+        return wait_connected(2);
+    }
+
+    void stop()
+    {
+        if (server_) {
+            (void)hako_pdu_rpc_mux_server_stop(server_);
+        }
+        if (client0_) {
+            (void)hako_pdu_rpc_client_stop(client0_);
+        }
+        if (client1_) {
+            (void)hako_pdu_rpc_client_stop(client1_);
+        }
+        if (client0_) {
+            hako_pdu_rpc_client_destroy(client0_);
+            client0_ = nullptr;
+        }
+        if (client1_) {
+            hako_pdu_rpc_client_destroy(client1_);
+            client1_ = nullptr;
+        }
+        if (server_) {
+            hako_pdu_rpc_mux_server_destroy(server_);
+            server_ = nullptr;
+        }
+    }
+
+    bool wait_connected(size_t expected)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        std::vector<uint8_t> scratch(kMaxPdu);
+        while (std::chrono::steady_clock::now() < deadline) {
+            hako_pdu_rpc_request_info_t info{};
+            size_t size = 0;
+            hako_pdu_rpc_error_t error = HAKO_PDU_RPC_OK;
+            (void)hako_pdu_rpc_mux_server_poll(
+                server_, &info, scratch.data(), scratch.size(), &size, &error);
+            if (error != HAKO_PDU_RPC_OK) {
+                return false;
+            }
+            if (hako_pdu_rpc_mux_server_connected_count(server_) == expected) {
+                return true;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+        return false;
+    }
+
+    bool call(hako_pdu_rpc_client_handle_t* client, long long a, long long b)
+    {
+        size_t request_size = 0;
+        if (hako_pdu_rpc_client_create_request_buffer(
+                client, kService, nullptr, 0, &request_size)
+            != HAKO_PDU_RPC_ERROR_BUFFER_TOO_SMALL) {
+            return false;
+        }
+        std::vector<uint8_t> request(request_size);
+        if (hako_pdu_rpc_client_create_request_buffer(
+                client, kService, request.data(), request.size(), &request_size)
+            != HAKO_PDU_RPC_OK) {
+            return false;
+        }
+        request.resize(request_size);
+
+        AddTwoIntsRequestPacket converter;
+        HakoCpp_AddTwoIntsRequestPacket packet{};
+        if (!converter.pdu2cpp(reinterpret_cast<char*>(request.data()), packet)) {
+            return false;
+        }
+        packet.body.a = a;
+        packet.body.b = b;
+        const int encoded = converter.cpp2pdu(
+            packet,
+            reinterpret_cast<char*>(request.data()),
+            static_cast<int>(request.size()));
+        if (encoded <= 0) {
+            return false;
+        }
+        request.resize(static_cast<size_t>(encoded));
+
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        while (hako_pdu_rpc_client_call(
+                   client, kService, request.data(), request.size(), 1'000'000)
+               != HAKO_PDU_RPC_OK) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return false;
+            }
+            std::this_thread::sleep_for(10ms);
+        }
+        return true;
+    }
+
+    bool wait_request(PendingCall& call)
+    {
+        call.pdu.assign(kMaxPdu, 0);
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        while (std::chrono::steady_clock::now() < deadline) {
+            size_t size = 0;
+            hako_pdu_rpc_error_t error = HAKO_PDU_RPC_OK;
+            const auto event = hako_pdu_rpc_mux_server_poll(
+                server_,
+                &call.info,
+                call.pdu.data(),
+                call.pdu.size(),
+                &size,
+                &error);
+            if (error != HAKO_PDU_RPC_OK) {
+                return false;
+            }
+            if (event == HAKO_PDU_RPC_SERVER_EVENT_REQUEST_IN) {
+                call.pdu.resize(size);
+                return true;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+        return false;
+    }
+
+    bool reply(const PendingCall& call, long long expected_a, long long expected_b)
+    {
+        AddTwoIntsRequestPacket request_converter;
+        HakoCpp_AddTwoIntsRequestPacket request{};
+        if (!request_converter.pdu2cpp(
+                reinterpret_cast<char*>(const_cast<uint8_t*>(call.pdu.data())), request)) {
+            return false;
+        }
+        if (request.body.a != expected_a || request.body.b != expected_b) {
+            return false;
+        }
+
+        size_t reply_size = 0;
+        if (hako_pdu_rpc_mux_server_create_reply_buffer(
+                server_,
+                call.info.request_token,
+                static_cast<uint8_t>(hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE),
+                static_cast<int32_t>(hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_OK),
+                nullptr,
+                0,
+                &reply_size)
+            != HAKO_PDU_RPC_ERROR_BUFFER_TOO_SMALL) {
+            return false;
+        }
+        std::vector<uint8_t> reply(reply_size);
+        if (hako_pdu_rpc_mux_server_create_reply_buffer(
+                server_,
+                call.info.request_token,
+                static_cast<uint8_t>(hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE),
+                static_cast<int32_t>(hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_OK),
+                reply.data(),
+                reply.size(),
+                &reply_size)
+            != HAKO_PDU_RPC_OK) {
+            return false;
+        }
+        reply.resize(reply_size);
+
+        AddTwoIntsResponsePacket response_converter;
+        HakoCpp_AddTwoIntsResponsePacket response{};
+        if (!response_converter.pdu2cpp(
+                reinterpret_cast<char*>(reply.data()), response)) {
+            return false;
+        }
+        response.body.sum = request.body.a + request.body.b;
+        const int encoded = response_converter.cpp2pdu(
+            response,
+            reinterpret_cast<char*>(reply.data()),
+            static_cast<int>(reply.size()));
+        if (encoded <= 0) {
+            return false;
+        }
+        reply.resize(static_cast<size_t>(encoded));
+        return hako_pdu_rpc_mux_server_send_reply(
+                   server_,
+                   call.info.request_token,
+                   reply.data(),
+                   reply.size())
+            == HAKO_PDU_RPC_OK;
+    }
+
+    bool wait_response(
+        hako_pdu_rpc_client_handle_t* client,
+        long long expected)
+    {
+        std::vector<uint8_t> response(kMaxPdu);
+        hako_pdu_rpc_response_info_t info{};
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        while (std::chrono::steady_clock::now() < deadline) {
+            size_t size = 0;
+            hako_pdu_rpc_error_t error = HAKO_PDU_RPC_OK;
+            const auto event = hako_pdu_rpc_client_poll(
+                client,
+                &info,
+                response.data(),
+                response.size(),
+                &size,
+                &error);
+            if (error != HAKO_PDU_RPC_OK) {
+                return false;
+            }
+            if (event == HAKO_PDU_RPC_CLIENT_EVENT_RESPONSE_IN) {
+                response.resize(size);
+                if (std::strcmp(info.service_name, kService) != 0) {
+                    return false;
+                }
+                AddTwoIntsResponsePacket converter;
+                HakoCpp_AddTwoIntsResponsePacket packet{};
+                return converter.pdu2cpp(
+                           reinterpret_cast<char*>(response.data()), packet)
+                    && packet.body.sum == expected;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+        return false;
+    }
+
+    hako_pdu_rpc_mux_server_handle_t* server() { return server_; }
+    hako_pdu_rpc_client_handle_t* client0() { return client0_; }
+    hako_pdu_rpc_client_handle_t* client1() { return client1_; }
+
+private:
+    hako_pdu_rpc_mux_server_handle_t* server_{nullptr};
+    hako_pdu_rpc_client_handle_t* client0_{nullptr};
+    hako_pdu_rpc_client_handle_t* client1_{nullptr};
+};
+
+TEST(CRpcMuxServerContractTest, TwoClientsShareOneListener)
+{
+    CMuxRuntime runtime;
+    ASSERT_TRUE(runtime.start());
+    EXPECT_EQ(hako_pdu_rpc_mux_server_expected_count(runtime.server()), 2U);
+    EXPECT_EQ(hako_pdu_rpc_mux_server_connected_count(runtime.server()), 2U);
+    EXPECT_EQ(hako_pdu_rpc_mux_server_is_ready(runtime.server()), 1);
+
+    ASSERT_TRUE(runtime.call(runtime.client0(), 10, 20));
+    ASSERT_TRUE(runtime.call(runtime.client1(), 40, 2));
+
+    std::map<std::string, PendingCall> calls;
+    for (int index = 0; index < 2; ++index) {
+        PendingCall call;
+        ASSERT_TRUE(runtime.wait_request(call));
+        calls.emplace(call.info.client_name, std::move(call));
+    }
+    ASSERT_TRUE(calls.contains("TestClient0"));
+    ASSERT_TRUE(calls.contains("TestClient1"));
+
+    ASSERT_TRUE(runtime.reply(calls.at("TestClient0"), 10, 20));
+    ASSERT_TRUE(runtime.reply(calls.at("TestClient1"), 40, 2));
+    EXPECT_TRUE(runtime.wait_response(runtime.client0(), 30));
+    EXPECT_TRUE(runtime.wait_response(runtime.client1(), 42));
+}
+
+} // namespace

--- a/test/configs/endpoints_mux_clients.json
+++ b/test/configs/endpoints_mux_clients.json
@@ -1,0 +1,11 @@
+[
+  {
+    "nodeId": "client_node",
+    "endpoints": [
+      {
+        "id": "client_ep_id",
+        "config_path": "mux_client_endpoint.json"
+      }
+    ]
+  }
+]

--- a/test/configs/mux_client_endpoint.json
+++ b/test/configs/mux_client_endpoint.json
@@ -1,0 +1,6 @@
+{
+  "name": "mux_client_endpoint",
+  "pdu_def_path": "pdudef.json",
+  "cache": "queue.json",
+  "comm": "tcp_mux_client_inout_comm.json"
+}

--- a/test/configs/mux_server_endpoint.json
+++ b/test/configs/mux_server_endpoint.json
@@ -1,0 +1,6 @@
+{
+  "name": "mux_server_endpoint",
+  "pdu_def_path": "pdudef.json",
+  "cache": "queue.json",
+  "comm": "tcp_mux_server_inout_comm.json"
+}

--- a/test/configs/service_config_mux.json
+++ b/test/configs/service_config_mux.json
@@ -1,0 +1,46 @@
+{
+  "pduMetaDataSize": 24,
+  "services": [
+    {
+      "name": "Service/Add",
+      "type": "hako_srv_msgs/AddTwoInts",
+      "maxClients": 2,
+      "pduSize": {
+        "server": {
+          "heapSize": 0,
+          "baseSize": 296
+        },
+        "client": {
+          "heapSize": 0,
+          "baseSize": 288
+        }
+      },
+      "server_endpoints": [
+        {
+          "nodeId": "server_node",
+          "endpointId": "mux_session"
+        }
+      ],
+      "clients": [
+        {
+          "name": "TestClient0",
+          "requestChannelId": 0,
+          "responseChannelId": 1,
+          "client_endpoint": {
+            "nodeId": "client_node",
+            "endpointId": "client_ep_id"
+          }
+        },
+        {
+          "name": "TestClient1",
+          "requestChannelId": 2,
+          "responseChannelId": 3,
+          "client_endpoint": {
+            "nodeId": "client_node",
+            "endpointId": "client_ep_id"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/configs/tcp_mux_client_inout_comm.json
+++ b/test/configs/tcp_mux_client_inout_comm.json
@@ -1,0 +1,15 @@
+{
+  "protocol": "tcp",
+  "name": "tcp_mux_client_inout",
+  "direction": "inout",
+  "role": "client",
+  "remote": {
+    "address": "127.0.0.1",
+    "port": 54011
+  },
+  "options": {
+    "connect_timeout_ms": 2000,
+    "read_timeout_ms": 1000,
+    "write_timeout_ms": 1000
+  }
+}

--- a/test/configs/tcp_mux_server_inout_comm.json
+++ b/test/configs/tcp_mux_server_inout_comm.json
@@ -1,0 +1,14 @@
+{
+  "protocol": "tcp",
+  "name": "tcp_mux_server_inout",
+  "direction": "inout",
+  "local": {
+    "address": "0.0.0.0",
+    "port": 54011
+  },
+  "expected_clients": 2,
+  "options": {
+    "read_timeout_ms": 1000,
+    "write_timeout_ms": 1000
+  }
+}

--- a/test/rpc_mux_server_contract_test.cpp
+++ b/test/rpc_mux_server_contract_test.cpp
@@ -1,0 +1,320 @@
+#include <gtest/gtest.h>
+
+#include "hakoniwa/pdu/endpoint_container.hpp"
+#include "hakoniwa/pdu/rpc/rpc_service_helper.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_client.hpp"
+#include "hakoniwa/pdu/rpc/rpc_services_mux_server.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsRequestPacket.hpp"
+#include "hako_srv_msgs/pdu_cpptype_conv_AddTwoIntsResponsePacket.hpp"
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <thread>
+#include <utility>
+
+namespace {
+
+using namespace std::chrono_literals;
+using hakoniwa::pdu::rpc::ClientEventType;
+using hakoniwa::pdu::rpc::RpcMuxRequest;
+using hakoniwa::pdu::rpc::RpcResponse;
+using hakoniwa::pdu::rpc::RpcServicesClient;
+using hakoniwa::pdu::rpc::RpcServicesMuxServer;
+using hakoniwa::pdu::rpc::ServerEventType;
+
+constexpr const char* kServiceConfig = "configs/service_config_mux.json";
+constexpr const char* kClientEndpointConfig = "configs/endpoints_mux_clients.json";
+constexpr const char* kMuxEndpointConfig = "configs/mux_server_endpoint.json";
+constexpr const char* kServerNodeId = "server_node";
+constexpr const char* kClientNodeId = "client_node";
+constexpr const char* kServiceName = "Service/Add";
+
+class ClientRuntime {
+public:
+    explicit ClientRuntime(std::string client_name)
+        : client_name_(std::move(client_name))
+        , endpoints_(std::make_shared<hakoniwa::pdu::EndpointContainer>(
+              kClientNodeId, kClientEndpointConfig))
+        , rpc_(
+              kClientNodeId,
+              client_name_,
+              kServiceConfig,
+              "RpcClientEndpointImpl",
+              1000)
+    {
+    }
+
+    bool start()
+    {
+        if (endpoints_->initialize() != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        if (!rpc_.initialize_services(endpoints_)) {
+            return false;
+        }
+        if (endpoints_->start_all() != HAKO_PDU_ERR_OK) {
+            return false;
+        }
+        if (!rpc_.start_all_services()) {
+            return false;
+        }
+
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        while (!endpoints_->is_running_all()) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return false;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+        started_ = true;
+        return true;
+    }
+
+    void stop_endpoint()
+    {
+        if (started_) {
+            (void)endpoints_->stop_all();
+        }
+    }
+
+    void stop_rpc()
+    {
+        if (started_) {
+            rpc_.stop_all_services();
+            started_ = false;
+        }
+    }
+
+    RpcServicesClient& rpc() { return rpc_; }
+    const std::string& name() const { return client_name_; }
+
+private:
+    std::string client_name_;
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoints_;
+    RpcServicesClient rpc_;
+    bool started_{false};
+};
+
+class MuxRuntime {
+public:
+    MuxRuntime()
+        : server_(
+              kServerNodeId,
+              "RpcServerEndpointImpl",
+              kServiceConfig,
+              kMuxEndpointConfig,
+              1000)
+        , client0_("TestClient0")
+        , client1_("TestClient1")
+    {
+    }
+
+    ~MuxRuntime()
+    {
+        stop();
+    }
+
+    bool start()
+    {
+        if (!server_.initialize() || !server_.start()) {
+            return false;
+        }
+        if (!client0_.start() || !client1_.start()) {
+            stop();
+            return false;
+        }
+        started_ = true;
+        return wait_for_connections(2);
+    }
+
+    void stop()
+    {
+        if (!started_) {
+            server_.stop();
+            return;
+        }
+
+        // Stop transport endpoints before clearing RPC instances. This also
+        // interrupts any blocking TCP reads on both sides.
+        server_.stop();
+        client0_.stop_endpoint();
+        client1_.stop_endpoint();
+        client0_.stop_rpc();
+        client1_.stop_rpc();
+        client0_.rpc().clear_all_instances();
+        started_ = false;
+    }
+
+    bool wait_for_connections(std::size_t expected)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        while (std::chrono::steady_clock::now() < deadline) {
+            RpcMuxRequest ignored;
+            (void)server_.poll(ignored);
+            if (server_.connected_count() == expected) {
+                return true;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+        return false;
+    }
+
+    ServerEventType wait_server_event(
+        RpcMuxRequest& request,
+        std::chrono::milliseconds timeout = 2s)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        for (;;) {
+            const auto event = server_.poll(request);
+            if (event != ServerEventType::NONE) {
+                return event;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return ServerEventType::NONE;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    ClientEventType wait_client_event(
+        ClientRuntime& client,
+        std::string& service_name,
+        RpcResponse& response,
+        std::chrono::milliseconds timeout = 2s)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        for (;;) {
+            const auto event = client.rpc().poll(service_name, response);
+            if (event != ClientEventType::NONE) {
+                return event;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return ClientEventType::NONE;
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    RpcServicesMuxServer& server() { return server_; }
+    ClientRuntime& client0() { return client0_; }
+    ClientRuntime& client1() { return client1_; }
+
+private:
+    RpcServicesMuxServer server_;
+    ClientRuntime client0_;
+    ClientRuntime client1_;
+    bool started_{false};
+};
+
+bool call_add(ClientRuntime& client, long long a, long long b)
+{
+    HakoRpcServiceServerTemplateType(AddTwoInts) service;
+    HakoCpp_AddTwoIntsRequest request{};
+    request.a = a;
+    request.b = b;
+    return service.call(client.rpc(), kServiceName, request, 1'000'000);
+}
+
+bool reply_add(
+    RpcServicesMuxServer& server,
+    RpcMuxRequest& request,
+    long long expected_a,
+    long long expected_b)
+{
+    HakoRpcServiceServerTemplateType(AddTwoInts) service;
+    HakoCpp_AddTwoIntsRequest body{};
+    if (!service.get_request_body(request.request, body)) {
+        return false;
+    }
+    if (body.a != expected_a || body.b != expected_b) {
+        return false;
+    }
+
+    HakoCpp_AddTwoIntsResponse response{};
+    response.sum = body.a + body.b;
+    return service.reply(
+        server,
+        request,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_STATUS_DONE,
+        hakoniwa::pdu::rpc::HAKO_SERVICE_RESULT_CODE_OK,
+        response);
+}
+
+bool expect_response(MuxRuntime& runtime, ClientRuntime& client, long long expected)
+{
+    HakoRpcServiceServerTemplateType(AddTwoInts) service;
+    std::string service_name;
+    RpcResponse response;
+    if (runtime.wait_client_event(client, service_name, response)
+        != ClientEventType::RESPONSE_IN) {
+        return false;
+    }
+    if (service_name != kServiceName) {
+        return false;
+    }
+    HakoCpp_AddTwoIntsResponse body{};
+    return service.get_response_body(response, body) && body.sum == expected;
+}
+
+TEST(RpcMuxServerContractTest, TwoClientsShareOneListenerAndRouteReplies)
+{
+    MuxRuntime runtime;
+    ASSERT_TRUE(runtime.start());
+    ASSERT_EQ(runtime.server().expected_count(), 2U);
+    ASSERT_EQ(runtime.server().connected_count(), 2U);
+    ASSERT_TRUE(runtime.server().is_ready());
+
+    ASSERT_TRUE(call_add(runtime.client0(), 10, 20));
+    ASSERT_TRUE(call_add(runtime.client1(), 40, 2));
+
+    std::map<std::string, RpcMuxRequest> requests;
+    for (int index = 0; index < 2; ++index) {
+        RpcMuxRequest request;
+        ASSERT_EQ(runtime.wait_server_event(request), ServerEventType::REQUEST_IN);
+        requests.emplace(request.request.header.client_name, std::move(request));
+    }
+
+    ASSERT_EQ(requests.size(), 2U);
+    ASSERT_TRUE(requests.contains("TestClient0"));
+    ASSERT_TRUE(requests.contains("TestClient1"));
+
+    const std::set<std::uint64_t> connection_ids = {
+        requests.at("TestClient0").connection_id,
+        requests.at("TestClient1").connection_id,
+    };
+    EXPECT_EQ(connection_ids.size(), 2U);
+
+    ASSERT_TRUE(reply_add(runtime.server(), requests.at("TestClient0"), 10, 20));
+    ASSERT_TRUE(reply_add(runtime.server(), requests.at("TestClient1"), 40, 2));
+
+    EXPECT_TRUE(expect_response(runtime, runtime.client0(), 30));
+    EXPECT_TRUE(expect_response(runtime, runtime.client1(), 42));
+}
+
+TEST(RpcMuxServerContractTest, ReusesAcceptedClientSessionForSequentialCalls)
+{
+    MuxRuntime runtime;
+    ASSERT_TRUE(runtime.start());
+
+    std::uint64_t first_connection = 0;
+    for (const auto& values : {std::pair{5LL, 7LL}, std::pair{11LL, 13LL}}) {
+        ASSERT_TRUE(call_add(runtime.client0(), values.first, values.second));
+        RpcMuxRequest request;
+        ASSERT_EQ(runtime.wait_server_event(request), ServerEventType::REQUEST_IN);
+        ASSERT_EQ(request.request.header.client_name, "TestClient0");
+        if (first_connection == 0) {
+            first_connection = request.connection_id;
+        } else {
+            EXPECT_EQ(request.connection_id, first_connection);
+        }
+        ASSERT_TRUE(reply_add(
+            runtime.server(), request, values.first, values.second));
+        ASSERT_TRUE(expect_response(
+            runtime, runtime.client0(), values.first + values.second));
+    }
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Add reusable server-side TCP multiplexing support to the native PDU-RPC layer.

The existing `RpcServer` path owns one static `EndpointContainer`, so replacing its communication JSON with a mux config is not sufficient. This PR adds the missing mux lifecycle:

- start one `EndpointCommMultiplexer` listener;
- accept multiple TCP client sessions through `take_endpoints()`;
- create one RPC server adapter per accepted Endpoint;
- route replies using an internal connection identity;
- clean up disconnected slots;
- expose the feature through both C++ and C APIs.

## Design

- Keep the existing static `RpcServicesServer` and `hako_pdu_rpc_server_*` APIs unchanged.
- Add an `RpcServicesServer::initialize_services(Endpoint)` overload so accepted endpoints can be used directly without rewriting temporary service JSON.
- Add `RpcServicesMuxServer`, which owns the mux and per-connection adapters.
- Add `hako_pdu_rpc_mux_server_*` as a separate backward-compatible C handle. Request tokens retain the accepted-session identity internally.
- Leave Python/CFFI wrapper changes for the next step; the allocation-capable C entry points are included so the wrapper can remain thin.

## Tests

Native contract coverage uses one listening port with two independent RPC clients and verifies:

- both clients are accepted by one mux listener;
- simultaneous requests are received;
- replies return to the correct TCP session;
- an accepted session is reused for sequential calls;
- the same multi-client contract works through the C API.

## Follow-up

After this native contract is green, `hakoniwa-pdu-rpc` Python `RpcServer` can select the mux C handle, and `hakoniwa-pdu-ros` can use `max_clients > 1` without a test-only server implementation.