### PR TITLE
feat: add Python RPC mux server

### DIFF
--- a/python/hakoniwa_pdu_rpc/__init__.py
+++ b/python/hakoniwa_pdu_rpc/__init__.py
@@ -12,6 +12,7 @@ from .cffi_api import (
 )
 from .client import RpcCanceledError, RpcClient, RpcTimeoutError
 from .future import RpcFuture
+from .mux_server import RpcMuxServer
 
 __all__ = [
     "CffiRpcClient",
@@ -21,6 +22,7 @@ __all__ = [
     "RpcClient",
     "RpcError",
     "RpcFuture",
+    "RpcMuxServer",
     "RpcServer",
     "RpcTimeoutError",
     "ServerEvent",

--- a/python/hakoniwa_pdu_rpc/mux_server.py
+++ b/python/hakoniwa_pdu_rpc/mux_server.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cffi import FFI
+
+from .cffi_api import RpcError, ServerEvent, ServerPollResult
+
+
+_CDEF = r"""
+typedef struct hako_pdu_rpc_mux_server_handle hako_pdu_rpc_mux_server_handle_t;
+typedef int hako_pdu_rpc_error_t;
+typedef int hako_pdu_rpc_server_event_t;
+
+typedef struct {
+    uint64_t request_token;
+    char service_name[128];
+    char client_name[128];
+    size_t pdu_size;
+} hako_pdu_rpc_request_info_t;
+
+void hako_pdu_rpc_buffer_free(uint8_t* buffer);
+
+hako_pdu_rpc_mux_server_handle_t* hako_pdu_rpc_mux_server_create(
+    const char*, const char*, const char*, uint64_t, const char*);
+void hako_pdu_rpc_mux_server_destroy(hako_pdu_rpc_mux_server_handle_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_start(
+    hako_pdu_rpc_mux_server_handle_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_stop(
+    hako_pdu_rpc_mux_server_handle_t*);
+hako_pdu_rpc_server_event_t hako_pdu_rpc_mux_server_poll_alloc(
+    hako_pdu_rpc_mux_server_handle_t*, hako_pdu_rpc_request_info_t*,
+    uint8_t**, size_t*, hako_pdu_rpc_error_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_create_reply_buffer_alloc(
+    hako_pdu_rpc_mux_server_handle_t*, uint64_t, uint8_t, int32_t,
+    uint8_t**, size_t*);
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_send_reply(
+    hako_pdu_rpc_mux_server_handle_t*, uint64_t, const uint8_t*, size_t);
+hako_pdu_rpc_error_t hako_pdu_rpc_mux_server_send_cancel_reply(
+    hako_pdu_rpc_mux_server_handle_t*, uint64_t, const uint8_t*, size_t);
+size_t hako_pdu_rpc_mux_server_connected_count(
+    const hako_pdu_rpc_mux_server_handle_t*);
+size_t hako_pdu_rpc_mux_server_expected_count(
+    const hako_pdu_rpc_mux_server_handle_t*);
+int hako_pdu_rpc_mux_server_is_ready(
+    const hako_pdu_rpc_mux_server_handle_t*);
+"""
+
+
+class _MuxBinding:
+    def __init__(self, library_path: str | Path):
+        self.ffi = FFI()
+        self.ffi.cdef(_CDEF)
+        self.lib = self.ffi.dlopen(str(library_path))
+
+    def encode(self, value: str | Path):
+        return self.ffi.new("char[]", str(value).encode("utf-8"))
+
+    def allocated_call(self, function, *args) -> bytes:
+        out_buffer = self.ffi.new("uint8_t **")
+        out_size = self.ffi.new("size_t *")
+        error = int(function(*args, out_buffer, out_size))
+        pointer = out_buffer[0]
+        try:
+            if error != 0:
+                raise RpcError(f"native RPC error: {error}")
+            return b"" if pointer == self.ffi.NULL else bytes(
+                self.ffi.buffer(pointer, int(out_size[0]))
+            )
+        finally:
+            self.lib.hako_pdu_rpc_buffer_free(pointer)
+
+
+def _borrow_bytes(binding: _MuxBinding, data: bytes):
+    if not data:
+        return binding.ffi.NULL
+    return binding.ffi.new("uint8_t[]", data)
+
+
+class RpcMuxServer:
+    """Thin Python wrapper for the native multiplexed RPC server."""
+
+    def __init__(
+        self,
+        library_path: str | Path,
+        node_id: str,
+        service_config_path: str | Path,
+        endpoint_mux_config_path: str | Path,
+        delta_time_usec: int = 1000,
+        time_source_type: str = "real",
+    ):
+        self._binding = _MuxBinding(library_path)
+        binding = self._binding
+        self._handle = binding.lib.hako_pdu_rpc_mux_server_create(
+            binding.encode(node_id),
+            binding.encode(service_config_path),
+            binding.encode(endpoint_mux_config_path),
+            delta_time_usec,
+            binding.encode(time_source_type),
+        )
+        if self._handle == binding.ffi.NULL:
+            raise RpcError("failed to create RPC mux server")
+        self._closed = False
+
+    def start(self) -> None:
+        self._check(
+            self._binding.lib.hako_pdu_rpc_mux_server_start(self._handle)
+        )
+
+    def stop(self) -> None:
+        self._check(
+            self._binding.lib.hako_pdu_rpc_mux_server_stop(self._handle)
+        )
+
+    def poll(self) -> ServerPollResult:
+        binding = self._binding
+        info = binding.ffi.new("hako_pdu_rpc_request_info_t *")
+        out_buffer = binding.ffi.new("uint8_t **")
+        out_size = binding.ffi.new("size_t *")
+        out_error = binding.ffi.new("hako_pdu_rpc_error_t *")
+        event = ServerEvent(
+            int(
+                binding.lib.hako_pdu_rpc_mux_server_poll_alloc(
+                    self._handle,
+                    info,
+                    out_buffer,
+                    out_size,
+                    out_error,
+                )
+            )
+        )
+        pointer = out_buffer[0]
+        try:
+            error = int(out_error[0])
+            if error != 0:
+                raise RpcError(f"native RPC error: {error}")
+            data = b"" if pointer == binding.ffi.NULL else bytes(
+                binding.ffi.buffer(pointer, int(out_size[0]))
+            )
+        finally:
+            binding.lib.hako_pdu_rpc_buffer_free(pointer)
+        return ServerPollResult(
+            event=event,
+            request_token=int(info.request_token),
+            service_name=binding.ffi.string(info.service_name).decode("utf-8"),
+            client_name=binding.ffi.string(info.client_name).decode("utf-8"),
+            pdu=data,
+        )
+
+    def create_reply_buffer(
+        self,
+        request_token: int,
+        status: int,
+        result_code: int,
+    ) -> bytes:
+        binding = self._binding
+        return binding.allocated_call(
+            binding.lib.hako_pdu_rpc_mux_server_create_reply_buffer_alloc,
+            self._handle,
+            request_token,
+            status,
+            result_code,
+        )
+
+    def send_reply(self, request_token: int, pdu: bytes) -> None:
+        binding = self._binding
+        native = _borrow_bytes(binding, pdu)
+        self._check(
+            binding.lib.hako_pdu_rpc_mux_server_send_reply(
+                self._handle,
+                request_token,
+                native,
+                len(pdu),
+            )
+        )
+
+    def send_cancel_reply(self, request_token: int, pdu: bytes) -> None:
+        binding = self._binding
+        native = _borrow_bytes(binding, pdu)
+        self._check(
+            binding.lib.hako_pdu_rpc_mux_server_send_cancel_reply(
+                self._handle,
+                request_token,
+                native,
+                len(pdu),
+            )
+        )
+
+    def connected_count(self) -> int:
+        return int(
+            self._binding.lib.hako_pdu_rpc_mux_server_connected_count(
+                self._handle
+            )
+        )
+
+    def expected_count(self) -> int:
+        return int(
+            self._binding.lib.hako_pdu_rpc_mux_server_expected_count(
+                self._handle
+            )
+        )
+
+    def is_ready(self) -> bool:
+        return bool(
+            self._binding.lib.hako_pdu_rpc_mux_server_is_ready(self._handle)
+        )
+
+    def close(self) -> None:
+        if not self._closed:
+            self._binding.lib.hako_pdu_rpc_mux_server_destroy(self._handle)
+            self._handle = self._binding.ffi.NULL
+            self._closed = True
+
+    def __enter__(self) -> "RpcMuxServer":
+        return self
+
+    def __exit__(self, *_args) -> None:
+        self.close()
+
+    @staticmethod
+    def _check(error: int) -> None:
+        if int(error) != 0:
+            raise RpcError(f"native RPC error: {int(error)}")

--- a/python/test_cffi_mux_server.py
+++ b/python/test_cffi_mux_server.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+from hakoniwa_pdu_rpc import (
+    CffiRpcClient,
+    ClientEvent,
+    RpcMuxServer,
+    ServerEvent,
+    load_service_wire,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hakoniwa-pdu-registry"))
+
+SERVICE_CONFIG = ROOT / "test" / "configs" / "service_config_mux.json"
+CLIENT_ENDPOINT_CONFIG = ROOT / "test" / "configs" / "endpoints_mux_clients.json"
+MUX_ENDPOINT_CONFIG = ROOT / "test" / "configs" / "mux_server_endpoint.json"
+SERVICE = "Service/Add"
+STATUS_DONE = 3
+RESULT_OK = 0
+
+
+def wait_connected(server: RpcMuxServer, expected: int, timeout: float = 3.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        server.poll()
+        if server.connected_count() == expected:
+            return
+        time.sleep(0.001)
+    raise AssertionError(
+        f"mux connection timed out: {server.connected_count()} of {expected}"
+    )
+
+
+def wait_request(server: RpcMuxServer, timeout: float = 3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        incoming = server.poll()
+        if incoming.event == ServerEvent.REQUEST_IN:
+            return incoming
+        time.sleep(0.001)
+    raise AssertionError("mux server request timed out")
+
+
+def wait_response(client: CffiRpcClient, timeout: float = 3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = client.poll()
+        if response.event == ClientEvent.RESPONSE_IN:
+            return response
+        time.sleep(0.001)
+    raise AssertionError("RPC client response timed out")
+
+
+def call_with_retry(
+    client: CffiRpcClient,
+    request_pdu: bytes,
+    timeout: float = 3.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            client.call(SERVICE, request_pdu, timeout_usec=1_000_000)
+            return
+        except Exception:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.01)
+
+
+def create_request(client: CffiRpcClient, wire, a: int, b: int) -> bytes:
+    request_pdu = client.create_request_buffer(SERVICE)
+    packet = wire.request_decode(request_pdu)
+    packet.body.a = a
+    packet.body.b = b
+    return wire.request_encode(packet)
+
+
+def reply(server: RpcMuxServer, wire, incoming, expected_a: int, expected_b: int) -> None:
+    request = wire.request_decode(incoming.pdu)
+    assert request.body.a == expected_a
+    assert request.body.b == expected_b
+
+    reply_pdu = server.create_reply_buffer(
+        incoming.request_token,
+        status=STATUS_DONE,
+        result_code=RESULT_OK,
+    )
+    response = wire.response_decode(reply_pdu)
+    response.body.sum = request.body.a + request.body.b
+    server.send_reply(
+        incoming.request_token,
+        wire.response_encode(response),
+    )
+
+
+def assert_response(client: CffiRpcClient, wire, expected_sum: int) -> None:
+    result = wait_response(client)
+    assert result.service_name == SERVICE
+    response = wire.response_decode(result.pdu)
+    assert response.body.sum == expected_sum
+
+
+def test_python_mux_server_routes_two_clients_on_one_listener() -> None:
+    library = os.environ["HAKO_PDU_RPC_LIBRARY"]
+    wire = load_service_wire("AddTwoInts")
+
+    server = RpcMuxServer(
+        library,
+        "server_node",
+        SERVICE_CONFIG,
+        MUX_ENDPOINT_CONFIG,
+    )
+    client0 = CffiRpcClient(
+        library,
+        "client_node",
+        "TestClient0",
+        SERVICE_CONFIG,
+        CLIENT_ENDPOINT_CONFIG,
+    )
+    client1 = CffiRpcClient(
+        library,
+        "client_node",
+        "TestClient1",
+        SERVICE_CONFIG,
+        CLIENT_ENDPOINT_CONFIG,
+    )
+
+    started = False
+    try:
+        server.start()
+        client0.start()
+        client1.start()
+        started = True
+
+        wait_connected(server, 2)
+        assert server.expected_count() == 2
+        assert server.connected_count() == 2
+        assert server.is_ready()
+
+        call_with_retry(client0, create_request(client0, wire, 10, 20))
+        call_with_retry(client1, create_request(client1, wire, 40, 2))
+
+        requests = {}
+        for _ in range(2):
+            incoming = wait_request(server)
+            requests[incoming.client_name] = incoming
+
+        assert set(requests) == {"TestClient0", "TestClient1"}
+        reply(server, wire, requests["TestClient0"], 10, 20)
+        reply(server, wire, requests["TestClient1"], 40, 2)
+        assert_response(client0, wire, 30)
+        assert_response(client1, wire, 42)
+
+        call_with_retry(client0, create_request(client0, wire, 7, 8))
+        reused = wait_request(server)
+        assert reused.client_name == "TestClient0"
+        reply(server, wire, reused, 7, 8)
+        assert_response(client0, wire, 15)
+    finally:
+        if started:
+            server.stop()
+        client0.close()
+        client1.close()
+        server.close()


### PR DESCRIPTION
## Summary

Expose the merged native TCP mux server through the Python CFFI API.

## Scope

- add `RpcMuxServer` as a thin wrapper over `hako_pdu_rpc_mux_server_*`;
- keep accept, session lifecycle, request routing, and disconnect cleanup in the native layer;
- expose start/stop, poll, reply, cancel reply, connected count, expected count, and ready state;
- export `RpcMuxServer` from `hakoniwa_pdu_rpc`;
- add a Python CFFI contract using one listener and two independent RPC clients.

## Contract

The Python test verifies:

- two clients connect to one TCP mux listener;
- requests from both clients are received and identified correctly;
- replies return to the originating client;
- the same accepted session supports a subsequent RPC;
- native PDU buffers are copied to Python `bytes` and freed immediately.

## Deliberately excluded

- no ROS changes;
- no Python implementation of mux lifecycle;
- no cancel, reconnect, connection-limit, or fairness expansion;
- no changes to the existing static `RpcServer` API.

## Validation

The existing four-platform `python-cffi-tests` workflow discovers `python/test_cffi_mux_server.py` automatically. Local execution was unavailable because the execution environment has no outbound GitHub access, so CI is the merge condition.