### PR TITLE
Document Hakoniwa Action concepts and responsibility boundaries

### DIFF
--- a/.github/workflows/python-cffi-tests.yml
+++ b/.github/workflows/python-cffi-tests.yml
@@ -2,6 +2,9 @@ name: python-cffi-tests
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/rpc-basic-tests.yml
+++ b/.github/workflows/rpc-basic-tests.yml
@@ -2,6 +2,9 @@ name: rpc-basic-tests
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/rpc-cancel-race-tests.yml
+++ b/.github/workflows/rpc-cancel-race-tests.yml
@@ -2,6 +2,9 @@ name: rpc-cancel-race-tests
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/rpc-infinite-wait-tests.yml
+++ b/.github/workflows/rpc-infinite-wait-tests.yml
@@ -2,6 +2,9 @@ name: rpc-infinite-wait-tests
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/rpc-timeout-cancel-tests.yml
+++ b/.github/workflows/rpc-timeout-cancel-tests.yml
@@ -2,6 +2,9 @@ name: rpc-timeout-cancel-tests
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/docs/design/action/01-concepts.md
+++ b/docs/design/action/01-concepts.md
@@ -57,6 +57,33 @@ Goal Execution B
   goal_id = B
 ```
 
+### 3.3 同一Action Typeの複数Goal Execution
+
+同一のAction Typeおよび同一のAction Server Endpointに対して、複数のGoal Executionが同時に存在することをProtocol上許容します。
+
+```text
+ExecuteMission
+  goal_id = A  RUNNING
+  goal_id = B  RUNNING
+  goal_id = C  CANCELING
+```
+
+各Goal Executionは異なる`goal_id`によって独立して識別され、Feedback、Cancel、Result、Terminal StatusもGoalごとに管理されます。
+
+Hakoniwa Action ProtocolおよびRPC Runtimeは、同一Action Typeを単一実行に制限しません。また、1 Clientにつき1 Goalという制限もProtocolの前提にしません。
+
+ただし、実際に複数Goalを受理して並列実行するか、直列化するか、キューへ入れるか、拒否するかはAction Server Applicationの実行ポリシーです。
+
+例えば以下は、いずれも同じProtocol上で実現できるApplication Policyです。
+
+- すべてのGoalを並列に受理する。
+- 最大N件まで受理し、それを超えるGoalを拒否する。
+- 実行中Goalがある場合、新しいGoalをキューへ入れる。
+- 優先度の高いGoalを受理し、既存Goalをpreemptまたはcancelする。
+- 共有資源を使用するため、同時実行を1件に制限する。
+
+`tcp_mux`の`maxClients`はTransportが収容できるClient接続数を表すものであり、Actionの同時実行ポリシーそのものではありません。
+
 ## 4. Goal
 
 Goalは、ClientがServerへ提示する実行要求と、そのAction固有の入力データです。
@@ -74,7 +101,7 @@ Goalの提示は、実行開始そのものを保証しません。ServerはGoal
 
 ## 5. goal_id
 
-`goal_id`は、1回のGoal Executionを識別する128-bitの識別子です。
+`goal_id`は、1回のGoal Executionを識別する128-bit UUIDです。
 
 Goal、Goal Response、Feedback、Cancel、Resultは、同じ`goal_id`によって関連付けます。
 
@@ -85,20 +112,42 @@ Cancel(goal_id = X)
 Result(goal_id = X)
 ```
 
-### 5.1 提案する役割
+### 5.1 役割
 
 - Action Type内でGoal Executionを一意に識別する。
 - ClientとServer間の相関キーとして使用する。
+- 同一Action Typeの複数Goal Executionを独立して管理する。
 - ROS 2 Goal UUIDなど、外部Action実装の識別子と対応付けられるようにする。
 - Service RPCの`client_name + request_id`へ依存しないAction固有の識別子とする。
 
-### 5.2 未確定事項
+### 5.2 生成と管理の責務
 
-- `goal_id`をClientが生成するか、Runtimeが生成するか。
-- 一意性の範囲をAction単位、Endpoint単位、システム全体のどこまで要求するか。
+`goal_id`は、Goal送信前にAction Client RuntimeがUUIDとして生成します。
+
+ROS 2 Bridgeなど、外部Actionシステムが既に互換性のあるUUIDを持つAdapterは、その外部UUIDを`goal_id`として指定できます。
+
+```text
+通常のHakoniwa Client
+  Action Client RuntimeがUUIDを生成
+
+ROS 2 Adapter
+  ROS Goal UUIDをgoal_idとして指定
+```
+
+Action Server Runtimeは受信した`goal_id`について、以下を担当します。
+
+- UUID形式などProtocol上の妥当性確認
+- 実行中Goalとの重複検査
+- Goal Execution状態との対応付け
+- 終了済みGoalの保持と重複再送の検出
+
+したがって、`goal_id`の値を作る責務はClient側にあり、一意性を検査しGoal lifecycleを管理する責務はServer Runtime側にあります。
+
+### 5.3 未確定事項
+
+- 一意性の範囲をAction Endpoint単位、Server単位、システム全体のどこまで要求するか。
 - 終了済み`goal_id`をどれだけ保持し、重複Goalを検出するか。
-
-初稿では、Client側で生成され、少なくとも通信相手との関係において十分に一意であることを前提候補とします。
+- UUIDの特定versionを規定するか。
 
 ## 6. Goal AcceptanceとGoal Rejection
 
@@ -108,7 +157,7 @@ Serverは受信したGoalを受理または拒否します。
 
 Goal Acceptanceは、ServerがそのGoal Executionを管理対象として引き受けたことを表します。
 
-受理後は、ServerはFeedback、Cancel処理、Resultまたは異常終端について責任を持ちます。
+受理後は、Server RuntimeはProtocol上のGoal lifecycleを管理し、Action Server Applicationは実処理、Feedback生成、Result生成、Cancel処理について責任を持ちます。
 
 ### Goal Rejection
 
@@ -118,11 +167,12 @@ Goal Rejectionは、ServerがそのGoalを実行対象として受理しなか�
 
 - Action固有入力が不正
 - 実行に必要な資源が不足
-- 同時実行上限を超過
+- Applicationが定めた同時実行上限を超過
+- Applicationの排他、優先度、運用ポリシー上、実行不可
 - Serverが停止処理中
-- ポリシー上実行不可
+- duplicate `goal_id`やProtocol不正
 
-BUSYをGoal Rejectionの理由として扱うか、独立したProtocol Errorとして扱うかは後続設計で決定します。
+業務上の`BUSY`や同時実行制限はApplication判断です。Protocol不正、duplicate `goal_id`、Runtime shutdownなどはRuntimeが自動拒否できる条件として分離します。
 
 ## 7. Feedback
 
@@ -204,6 +254,8 @@ Client                     Server
 
 Cancel Responseと最終Resultの両方を必須とするか、Cancel Responseが何を保証するかはProtocol設計で決定します。
 
+複数Goal Executionが存在する場合、Cancelは指定された`goal_id`のGoalだけを対象とし、他のGoal Executionへ影響を与えません。ただし、共有資源の停止が他Goalへ影響する場合、その調停はApplication Policyです。
+
 ## 11. ClientとServer
 
 ### Client
@@ -212,11 +264,13 @@ ClientはGoalを提示し、Goal Response、Feedback、Resultを受信し、必�
 
 ClientはAction固有のGoal bodyを生成しますが、Goalを受理するかどうかや業務処理を実行する責任は持ちません。
 
+Action Client RuntimeはGoal送信前にUUID形式の`goal_id`を生成し、複数のGoal Executionをそれぞれ独立して追跡できるようにします。
+
 ### Server
 
-ServerはGoalを受信し、受理または拒否し、受理したGoal Executionのライフサイクルを管理します。
+Server RuntimeはGoalを受信し、Protocol上の妥当性を確認し、各`goal_id`に対応するGoal Executionのライフサイクルを独立して管理します。
 
-ただし、RPC Runtimeそのものが業務処理を実行するわけではありません。受理判断や実際の処理は、Server Runtimeを利用するアプリケーションと協調して行います。
+RPC Runtimeそのものが業務処理や同時実行方針を決定するわけではありません。Goalの業務上の受理判断、並列実行、直列化、キュー、排他、優先度、preemptionは、Server Runtimeを利用するApplicationが所有します。
 
 ## 12. Service RPCとの違い
 
@@ -227,20 +281,25 @@ ServerはGoalを受信し、受理または拒否し、受理したGoal Executio
 | 中間通知 | 原則なし | 0回以上のFeedback |
 | 終了前操作 | Cancelは既存RPC契約に依存 | Goal Executionに対するCancel |
 | ライフサイクル | 1往復を中心とする | Goal Executionセッションを持つ |
+| 複数実行 | RPC実装のsession構造に依存 | 同一Action Typeの複数GoalをProtocol上許容 |
 | 終端状態 | Responseの成否 | Succeeded / Canceled / Aborted / Error |
 | ROS依存 | なし | なし |
 
 Action対応のために既存Service RPCの意味やPDUレイアウトを変更しません。
 
-## 13. 初稿で提案する概念上の結論
+## 13. 現時点の概念上の設計判断
 
 1. Actionは「長時間RPC」ではなく、RPC基盤上に構築されるGoal Executionセッションとする。
-2. 1回のGoal Executionは128-bitの`goal_id`で識別する。
-3. Goalの送信と受理を区別する。
-4. Feedbackは非終端通知とする。
-5. Result bodyとTerminal Statusを区別する。
-6. Cancel Request、Cancel Response、Canceled終端を区別する。
-7. ROS 2はHakoniwa Actionの利用先・Adapterであり、概念定義の所有者ではない。
+2. 1回のGoal Executionは128-bit UUIDの`goal_id`で識別する。
+3. `goal_id`は原則としてAction Client Runtimeが送信前に生成し、Server Runtimeが重複検査とlifecycle管理を行う。
+4. 同一Action Typeおよび同一Endpointに複数のGoal Executionが同時に存在することをProtocol上許容する。
+5. 並列実行、直列化、キュー、拒否、排他、優先度、preemptionはAction Server Applicationの実行ポリシーとする。
+6. `maxClients`はTransportの接続収容数であり、Actionの同時実行上限とは定義しない。
+7. Goalの送信と受理を区別する。
+8. Feedbackは非終端通知とする。
+9. Result bodyとTerminal Statusを区別する。
+10. Cancel Request、Cancel Response、Canceled終端を区別する。
+11. ROS 2はHakoniwa Actionの利用先・Adapterであり、概念定義の所有者ではない。
 
 ## 14. レビューで問答したい事項
 
@@ -250,4 +309,5 @@ Action対応のために既存Service RPCの意味やPDUレイアウトを変更
 4. Goal Rejectionは終端状態に含めるか、それともGoal Execution成立前として扱うか。
 5. Cancel Responseは「要求を受理した」ことだけを示すのか、「停止可能と判断した」ことまで示すのか。
 6. `ABORTED`と`ERROR`をどの責務境界で分けるか。
-7. `goal_id`の生成責任をClient、Runtime、Adapterのどこへ置くか。
+7. Applicationが複数Goalを管理するために、Runtime APIはどの単位でGoalHandleまたはContextを提供すべきか。
+8. ApplicationのキューイングやpreemptionをProtocolで観測可能にする必要があるか。

--- a/docs/design/action/01-concepts.md
+++ b/docs/design/action/01-concepts.md
@@ -151,26 +151,30 @@ Action Server Runtimeは受信した`goal_id`について、以下を担当し�
 
 ## 6. Goal AcceptanceとGoal Rejection
 
-Serverは受信したGoalを受理または拒否します。
+Action Server Runtimeは受信したGoalのProtocol上の妥当性を確認し、妥当なGoalをAction Server Applicationへ渡します。業務上の受理または拒否はApplicationが判断し、その判断をRuntimeがClientへ返します。
 
 ### Goal Acceptance
 
-Goal Acceptanceは、ServerがそのGoal Executionを管理対象として引き受けたことを表します。
+Goal Acceptanceは、Action Server ApplicationがそのGoalを実行対象として引き受け、Server RuntimeがそのGoal Executionのlifecycle管理を開始したことを表します。
 
 受理後は、Server RuntimeはProtocol上のGoal lifecycleを管理し、Action Server Applicationは実処理、Feedback生成、Result生成、Cancel処理について責任を持ちます。
 
 ### Goal Rejection
 
-Goal Rejectionは、ServerがそのGoalを実行対象として受理しなかったことを表します。
+Goal Rejectionは、ApplicationまたはRuntimeがそのGoalを受理しなかったことを表します。
 
-拒否理由の例は以下です。
+Applicationによる拒否理由の例は以下です。
 
 - Action固有入力が不正
 - 実行に必要な資源が不足
 - Applicationが定めた同時実行上限を超過
 - Applicationの排他、優先度、運用ポリシー上、実行不可
-- Serverが停止処理中
-- duplicate `goal_id`やProtocol不正
+
+Runtimeによる自動拒否の例は以下です。
+
+- duplicate `goal_id`
+- UUIDまたはProtocol形式が不正
+- Runtimeがshutdown中
 
 業務上の`BUSY`や同時実行制限はApplication判断です。Protocol不正、duplicate `goal_id`、Runtime shutdownなどはRuntimeが自動拒否できる条件として分離します。
 

--- a/docs/design/action/01-concepts.md
+++ b/docs/design/action/01-concepts.md
@@ -1,0 +1,253 @@
+# Hakoniwa Actionの基本概念
+
+> **Status: Draft**  
+> 本文書はレビューと議論のための初稿です。現時点では確定仕様ではありません。
+
+## 1. 目的
+
+本書では、Hakoniwa Action Protocolで使用する基本概念と用語を、特定の実装言語やROS 2 APIに依存せず定義します。
+
+ここでは、状態機械、PDUレイアウト、公開API、エラー処理の詳細には踏み込みません。それらを議論する前提となる意味論を揃えることを目的とします。
+
+## 2. Actionとは何か
+
+Hakoniwa Actionは、ClientがServerへGoalを提示し、ServerがそのGoalを受理または拒否し、受理したGoalについて0回以上のFeedbackを返しながら、最終的にResultと終端状態を返す通信・実行ライフサイクルです。
+
+```text
+Goal
+  -> Accept / Reject
+  -> Feedback (0..N)
+  -> Result + Terminal Status
+```
+
+ActionはRPC基盤上に実装できますが、単に応答時間の長いService RPCとはみなしません。
+
+Service RPCは、原則として1回のRequestと1回のResponseで完結します。一方、Actionは`goal_id`で識別される実行セッションを持ち、そのセッション中にFeedback、Cancel、終端通知が発生します。
+
+## 3. Action TypeとGoal Execution
+
+### 3.1 Action Type
+
+Action Typeは、実行可能な操作の型を表します。
+
+Action Typeは、少なくとも以下のAction固有データ型を持ちます。
+
+- Goal body
+- Result body
+- Feedback body
+
+例えばFibonacci Actionでは、Goal bodyに計算する項数、Feedback bodyに途中の数列、Result bodyに最終的な数列を持ちます。
+
+### 3.2 Goal Execution
+
+Goal Executionは、Action Typeに対して行われる1回の具体的な実行です。
+
+同じAction Typeを複数回実行する場合、それぞれは異なるGoal Executionです。各Goal Executionは`goal_id`によって識別されます。
+
+本設計では、Action Typeと1回のGoal Executionを区別します。
+
+```text
+Action Type
+  ExecuteMission
+
+Goal Execution A
+  goal_id = A
+
+Goal Execution B
+  goal_id = B
+```
+
+## 4. Goal
+
+Goalは、ClientがServerへ提示する実行要求と、そのAction固有の入力データです。
+
+Goalの提示は、実行開始そのものを保証しません。ServerはGoalを受理または拒否します。
+
+したがって、以下を区別します。
+
+- Goalを送信したこと
+- GoalがServerへ到達したこと
+- Goalが受理されたこと
+- Goalの実行が開始されたこと
+
+初期実装でこれらをどこまで個別イベントとして公開するかは、状態モデルおよびAPI設計で決定します。
+
+## 5. goal_id
+
+`goal_id`は、1回のGoal Executionを識別する128-bitの識別子です。
+
+Goal、Goal Response、Feedback、Cancel、Resultは、同じ`goal_id`によって関連付けます。
+
+```text
+Goal(goal_id = X)
+Feedback(goal_id = X)
+Cancel(goal_id = X)
+Result(goal_id = X)
+```
+
+### 5.1 提案する役割
+
+- Action Type内でGoal Executionを一意に識別する。
+- ClientとServer間の相関キーとして使用する。
+- ROS 2 Goal UUIDなど、外部Action実装の識別子と対応付けられるようにする。
+- Service RPCの`client_name + request_id`へ依存しないAction固有の識別子とする。
+
+### 5.2 未確定事項
+
+- `goal_id`をClientが生成するか、Runtimeが生成するか。
+- 一意性の範囲をAction単位、Endpoint単位、システム全体のどこまで要求するか。
+- 終了済み`goal_id`をどれだけ保持し、重複Goalを検出するか。
+
+初稿では、Client側で生成され、少なくとも通信相手との関係において十分に一意であることを前提候補とします。
+
+## 6. Goal AcceptanceとGoal Rejection
+
+Serverは受信したGoalを受理または拒否します。
+
+### Goal Acceptance
+
+Goal Acceptanceは、ServerがそのGoal Executionを管理対象として引き受けたことを表します。
+
+受理後は、ServerはFeedback、Cancel処理、Resultまたは異常終端について責任を持ちます。
+
+### Goal Rejection
+
+Goal Rejectionは、ServerがそのGoalを実行対象として受理しなかったことを表します。
+
+拒否理由の例は以下です。
+
+- Action固有入力が不正
+- 実行に必要な資源が不足
+- 同時実行上限を超過
+- Serverが停止処理中
+- ポリシー上実行不可
+
+BUSYをGoal Rejectionの理由として扱うか、独立したProtocol Errorとして扱うかは後続設計で決定します。
+
+## 7. Feedback
+
+Feedbackは、受理済みかつ未終端のGoal Executionについて、ServerからClientへ送られるAction固有の途中情報です。
+
+Feedbackは非終端です。Feedbackを受信しても、そのGoal Executionは継続します。
+
+```text
+RUNNING
+  -> Feedback
+RUNNING
+```
+
+Feedbackは0回でも複数回でも構いません。
+
+汎用的な進捗率は共通ヘッダに持たせません。進捗率、途中経路、現在の処理対象などの意味はActionごとに異なるため、Action固有のFeedback bodyに定義します。
+
+Feedbackの順序確認には`sequence_no`を使用する案を採用していますが、欠落、重複、逆転をどのように扱うかはProtocol設計で定義します。
+
+## 8. Result
+
+Resultは、Goal Executionが終了した際に返されるAction固有の最終出力データです。
+
+本設計では、Result bodyとTerminal Statusを別概念として扱う案を採用します。
+
+```text
+Result
+  Action固有の最終出力
+
+Terminal Status
+  Goal Executionがどのように終了したか
+```
+
+例えば、同じResult bodyの型を使用しながら、以下の終端状態があり得ます。
+
+- SUCCEEDED
+- CANCELED
+- ABORTED
+- ERROR
+
+Result bodyがどの終端状態でも有効か、成功時のみ有効かはAction TypeまたはProtocol契約で明確にする必要があります。
+
+## 9. Terminal Status
+
+Terminal Statusは、Goal Executionがそれ以上状態遷移しない終端結果を表します。
+
+初期候補は以下です。
+
+- `SUCCEEDED`: Goalが正常に完了した。
+- `CANCELED`: Cancel要求に基づいて実行が終了した。
+- `ABORTED`: Goalは受理されたが、Serverまたは利用アプリケーションの判断で正常完了できなかった。
+- `ERROR`: Protocol、Runtime、通信などの異常により正常なAction結果として完了できなかった。
+
+`ABORTED`と`ERROR`の境界は未確定です。Action業務処理の失敗と通信基盤の失敗を分離できる定義が必要です。
+
+## 10. Cancel
+
+Cancelは、Clientが受理済みまたは処理中のGoal Executionを停止するよう要求する操作です。
+
+Cancel要求を送信しただけでは、Goal Executionが`CANCELED`になったことを意味しません。
+
+以下を区別します。
+
+1. Cancel Request
+2. Cancelの受理または拒否
+3. 実際の停止処理
+4. `CANCELED`としての終端
+
+```text
+Client                     Server
+  | Cancel Request           |
+  |------------------------->|
+  | Cancel Response          |
+  |<-------------------------|
+  |                          | stopping...
+  | Result + CANCELED        |
+  |<-------------------------|
+```
+
+Cancel Responseと最終Resultの両方を必須とするか、Cancel Responseが何を保証するかはProtocol設計で決定します。
+
+## 11. ClientとServer
+
+### Client
+
+ClientはGoalを提示し、Goal Response、Feedback、Resultを受信し、必要に応じてCancelを要求します。
+
+ClientはAction固有のGoal bodyを生成しますが、Goalを受理するかどうかや業務処理を実行する責任は持ちません。
+
+### Server
+
+ServerはGoalを受信し、受理または拒否し、受理したGoal Executionのライフサイクルを管理します。
+
+ただし、RPC Runtimeそのものが業務処理を実行するわけではありません。受理判断や実際の処理は、Server Runtimeを利用するアプリケーションと協調して行います。
+
+## 12. Service RPCとの違い
+
+| 観点 | Service RPC | Action |
+|---|---|---|
+| 相関 | request ID | goal ID |
+| 基本形 | Request / Response | Goal / Feedback / Cancel / Result |
+| 中間通知 | 原則なし | 0回以上のFeedback |
+| 終了前操作 | Cancelは既存RPC契約に依存 | Goal Executionに対するCancel |
+| ライフサイクル | 1往復を中心とする | Goal Executionセッションを持つ |
+| 終端状態 | Responseの成否 | Succeeded / Canceled / Aborted / Error |
+| ROS依存 | なし | なし |
+
+Action対応のために既存Service RPCの意味やPDUレイアウトを変更しません。
+
+## 13. 初稿で提案する概念上の結論
+
+1. Actionは「長時間RPC」ではなく、RPC基盤上に構築されるGoal Executionセッションとする。
+2. 1回のGoal Executionは128-bitの`goal_id`で識別する。
+3. Goalの送信と受理を区別する。
+4. Feedbackは非終端通知とする。
+5. Result bodyとTerminal Statusを区別する。
+6. Cancel Request、Cancel Response、Canceled終端を区別する。
+7. ROS 2はHakoniwa Actionの利用先・Adapterであり、概念定義の所有者ではない。
+
+## 14. レビューで問答したい事項
+
+1. Actionを独立したGoal Executionセッションとして捉える定義でよいか。
+2. GoalとGoal Requestという言葉を分ける必要があるか。
+3. Result bodyとTerminal Statusを常に分離すべきか。
+4. Goal Rejectionは終端状態に含めるか、それともGoal Execution成立前として扱うか。
+5. Cancel Responseは「要求を受理した」ことだけを示すのか、「停止可能と判断した」ことまで示すのか。
+6. `ABORTED`と`ERROR`をどの責務境界で分けるか。
+7. `goal_id`の生成責任をClient、Runtime、Adapterのどこへ置くか。

--- a/docs/design/action/02-responsibility-boundaries.md
+++ b/docs/design/action/02-responsibility-boundaries.md
@@ -1,0 +1,300 @@
+# Hakoniwa Actionの責務境界
+
+> **Status: Draft**  
+> 本文書はレビューと議論のための初稿です。現時点では確定仕様ではありません。
+
+## 1. 目的
+
+本書では、Hakoniwa Action Protocolに関係する各リポジトリおよび利用アプリケーションの責務境界を定義します。
+
+Action対応では、以下の異なる関心事が同時に現れます。
+
+- Action固有データ型とPDUレイアウト
+- Goal Executionの状態と通信ライフサイクル
+- ROS 2 Action APIとの変換
+- Goalを実際に処理する業務ロジック
+- EndpointおよびTransportによる配送
+
+これらを一つの実装へ集約せず、それぞれの層が所有する責務を明確にします。
+
+## 2. 全体構造
+
+```text
+ROS 2 Action Client
+        |
+        | ROS 2 Goal / Feedback / Cancel / Result
+        v
+hakoniwa-pdu-ros
+        |
+        | Hakoniwa Action API
+        v
+hakoniwa-pdu-rpc
+        |
+        | Action Request / Response / Feedback PDU
+        v
+hakoniwa-pdu-endpoint / transport
+        |
+        v
+Hakoniwa Action Server Application
+```
+
+データ型と変換コードは`hakoniwa-pdu-registry`が生成し、各層がその生成物を使用します。
+
+```text
+ROS .action / Hakoniwa Action IDL
+        |
+        v
+hakoniwa-pdu-registry
+        |
+        +--> Goal / Result / Feedback types
+        +--> Action Request / Response / Feedback packet types
+        +--> converters / offsets / size metadata
+```
+
+## 3. hakoniwa-pdu-registry
+
+### 3.1 所有する責務
+
+`hakoniwa-pdu-registry`は、Action通信で使用するデータ契約と生成物を所有します。
+
+- ROS 2 `.action`定義のGoal、Result、Feedbackへの分解
+- Action Request、Action Response、Action FeedbackのPDU定義生成
+- Action共通ヘッダの定義
+- `request_kind`、`response_kind`、`status`などの数値契約
+- `goal_id`、`sequence_no`などのフィールドレイアウト
+- 通常のPDU生成パイプラインによる各言語型とconverterの生成
+- offset、aligned size、CDR size、type metadataの生成
+- 生成物の決定性と既存Service生成物との互換性
+
+### 3.2 所有しない責務
+
+- Goalを受理または拒否する判断
+- ClientおよびServerの状態機械
+- Feedbackの送信タイミング
+- CancelとResultの競合解決
+- Action APIの実行時挙動
+- ROS 2 Goal UUIDとの対応管理
+- Action固有の業務処理
+
+Registryはデータを表現できるようにしますが、そのデータをいつ送るか、受信後にどう状態遷移するかは決定しません。
+
+## 4. hakoniwa-pdu-rpc
+
+### 4.1 所有する責務
+
+`hakoniwa-pdu-rpc`は、Hakoniwa Actionの通信ライフサイクルと実行時Protocolを所有します。
+
+- Goal送信、Goal Response受信、および相関
+- `goal_id`によるGoal Execution管理
+- Feedbackの非終端配送
+- Cancel RequestおよびCancel Responseの配送
+- ResultおよびTerminal Statusの配送
+- ClientおよびServerの状態機械
+- 許可された状態遷移と不正操作の検出
+- 重複、遅延、未知の`goal_id`の扱い
+- CancelとResultなどの競合規約
+- 同時Goal数、BUSY、キューなどのRuntime Policy
+- timeout、shutdown、transport errorをProtocol/APIへ反映する方法
+- C++ APIとPython Bindingが共有すべき意味論
+- 既存Service RPCとの後方互換性
+
+### 4.2 所有しない責務
+
+- `.action`ファイルの解析とPDUコード生成
+- ROS 2 Node、Action Server、GoalHandleの実装
+- ROS 2固有ステータスへの変換
+- Goalの業務上の妥当性判断
+- ロボット制御、経路計画、計算処理などAction固有の実処理
+- Transport固有のSocket、共有メモリ、再接続処理の詳細
+
+RPC Runtimeは通信とライフサイクルを管理しますが、Goalを実際に達成する処理は行いません。
+
+## 5. hakoniwa-pdu-ros
+
+### 5.1 所有する責務
+
+`hakoniwa-pdu-ros`は、ROS 2 Action APIとHakoniwa Action APIのAdapterを所有します。
+
+- ROS 2 Action Serverの生成と実行
+- ROS 2 Goal messageから生成済みHakoniwa Goal PDU bodyへの変換
+- Hakoniwa Feedback PDU bodyからROS 2 Feedback messageへの変換
+- Hakoniwa Result PDU bodyからROS 2 Result messageへの変換
+- ROS 2 Goal UUIDとHakoniwa `goal_id`の対応付け
+- ROS 2 cancel callbackとHakoniwa Cancel APIの接続
+- ROS 2 GoalHandleの状態とHakoniwa terminal statusの対応
+- ROS executorおよび`rclpy` Futureへの非同期完了通知
+- ROS Binding設定の読み込みとHakoniwa Action Runtime設定への接続
+- ROS固有の変換失敗やNode lifecycleの診断
+
+### 5.2 所有しない責務
+
+- Hakoniwa Action Protocolそのものの状態機械
+- FeedbackキューやCancel/Result競合の独自実装
+- Action共通PDUレイアウトの定義
+- Action固有の業務処理
+- ROS 2以外の利用者に対するProtocol仕様
+
+ROS BridgeがAction状態機械を再実装すると、C++、Python、ROSの各利用者で意味論が分岐します。そのため、状態と競合規約は可能な限り`hakoniwa-pdu-rpc`へ集約します。
+
+## 6. Action Server Application
+
+### 6.1 所有する責務
+
+Action Server Applicationは、Goalを実際に処理するドメインロジックを所有します。
+
+- Goal bodyの業務上の検証
+- Goalを受理または拒否するアプリケーション判断
+- 受理したGoalの実処理
+- Action固有Feedbackの生成
+- 成功時のResult body生成
+- 業務上の中断、失敗、abort判断
+- Cancel要求を受けた後の安全な停止処理
+- 資源競合や優先度に関するアプリケーションPolicy
+
+### 6.2 Runtimeとの境界
+
+RuntimeとApplicationの境界では、少なくとも以下の操作が必要になる想定です。
+
+```text
+Runtime -> Application
+  on_goal(goal_id, goal_body)
+  on_cancel(goal_id)
+
+Application -> Runtime
+  accept(goal_id)
+  reject(goal_id, reason)
+  publish_feedback(goal_id, feedback_body)
+  succeed(goal_id, result_body)
+  abort(goal_id, result_body or error)
+  canceled(goal_id, result_body)
+```
+
+このAPI形状は未確定です。ここでは責務の方向だけを示します。
+
+### 6.3 所有しない責務
+
+- PDUヘッダの直接構築
+- `sequence_no`の採番方法
+- transport送受信
+- Clientとの相関管理
+- Protocol上の不正状態検出
+- ROS 2 APIへの直接変換
+
+アプリケーションはAction固有のbodyと意味を扱い、共通ヘッダや通信Protocolの詳細から分離されることが望まれます。
+
+## 7. hakoniwa-pdu-endpointとTransport
+
+EndpointおよびTransportは、PDUを通信相手へ配送する責務を持ちます。
+
+- Request、Response、Feedback経路の接続
+- TCP、UDP、共有メモリなどのtransport実装
+- PDUサイズとバッファ管理
+- 送受信、切断、再接続、shutdownの低レベルイベント
+- RPC Runtimeが利用できるpollまたはwait primitive
+
+Endpoint/TransportはActionのGoal、Feedback、Resultの意味や状態遷移を理解しません。
+
+`requestChannelId`や`feedbackChannelId`などの物理配置情報をRPC設定とEndpoint設定のどちらが所有するかは、既存の設定分離Issueと整合させて後続設計で決定します。
+
+## 8. 責務分担表
+
+| 項目 | Registry | RPC | ROS Bridge | Application | Endpoint/Transport |
+|---|---:|---:|---:|---:|---:|
+| `.action`解析 | 主 |  |  |  |  |
+| PDU型・レイアウト | 主 | 利用 | 利用 | 利用 | 配送 |
+| `goal_id`相関 | データ定義 | 主 | ROS UUID対応 | 利用 | 透過 |
+| Goal受理Protocol |  | 主 | Adapter | 判断 | 透過 |
+| 業務上の受理判断 |  | 支援 | 透過 | 主 |  |
+| Feedback配送 | データ定義 | 主 | ROS変換 | 生成 | 配送 |
+| Cancel状態遷移 |  | 主 | ROS変換 | 停止処理 | 配送 |
+| Result配送 | データ定義 | 主 | ROS変換 | 生成 | 配送 |
+| terminal status意味論 | 数値契約 | 主 | ROS対応 | 選択 | 透過 |
+| ROS GoalHandle |  |  | 主 |  |  |
+| Action固有処理 |  |  |  | 主 |  |
+| transport接続 |  | 利用 | 利用 | 利用 | 主 |
+
+## 9. 横断的な設計原則
+
+### 9.1 Protocolと業務処理を分離する
+
+RPC RuntimeはGoal Executionを正しく管理しますが、そのGoalが何を意味し、どのように達成されるかはApplicationが所有します。
+
+### 9.2 データ契約と状態遷移を分離する
+
+RegistryはPDUを生成します。RPCは生成されたPDUを使って状態遷移を実現します。RegistryへRuntime固有分岐を持ち込みません。
+
+### 9.3 ROS 2を仕様の中心に置かない
+
+ROS 2 Actionは重要な接続先ですが、Hakoniwa Actionの唯一の利用形態ではありません。ROS固有概念はAdapter層へ閉じ込めます。
+
+### 9.4 状態機械をBridgeへ複製しない
+
+Cancel、timeout、late feedback、terminal raceの規約をBridgeごとに実装すると意味論が分岐します。共通化できる状態管理はRPC Runtimeへ置きます。
+
+### 9.5 既存Service RPCを変更しない
+
+ActionのためにService Request/Responseヘッダや既存APIの意味を拡張しません。Actionは独立したデータ契約と明示的な設定で追加します。
+
+## 10. 境界上の未確定事項
+
+### 10.1 Goal受理判断の分割
+
+Runtimeが自動的に拒否すべき条件と、Applicationへ判断を委ねる条件を分ける必要があります。
+
+Runtime側候補:
+
+- duplicate `goal_id`
+- protocol version不正
+- 同時実行上限超過
+- shutdown中
+
+Application側候補:
+
+- Goal bodyの業務上の不正
+- ロボット状態が実行条件を満たさない
+- ドメイン上の優先度や排他
+
+### 10.2 goal_id生成責任
+
+候補は以下です。
+
+- Action Client Application
+- RPC Client Runtime
+- ROS BridgeなどのAdapter
+
+ROS Goal UUIDをそのまま使用する場合と、ROSを使わないClientの場合を共通に説明できる規約が必要です。
+
+### 10.3 Timeoutの所有者
+
+以下を分離する必要があります。
+
+- transport timeout
+- Goal acceptance timeout
+- Action execution deadline
+- Bridge側のROS request deadline
+- Application固有の処理期限
+
+すべてを一つのtimeoutへ統合すると、どの層がGoalを終了させたのか不明確になります。
+
+### 10.4 Feedback保持方針
+
+FeedbackをRuntimeがキューイングするか、Endpointイベントをそのまま通知するか、最新値だけを保持するかは、RPCと利用APIの境界に関わります。
+
+## 11. 初稿で提案する責務上の結論
+
+1. Registryはデータ契約を所有し、状態機械を所有しない。
+2. RPCはHakoniwa ActionのProtocolとGoal Execution lifecycleを所有する。
+3. ROS BridgeはROS 2との変換を所有し、Action状態機械を独自に実装しない。
+4. ApplicationはGoalの業務処理、Feedback生成、Result生成、安全なCancel処理を所有する。
+5. Endpoint/Transportは配送を所有し、Action意味論を所有しない。
+6. Goalの受理判断は、Protocol上の自動拒否とApplication判断に分割する。
+
+## 12. レビューで問答したい事項
+
+1. Goalのaccept/reject判断をRuntimeとApplicationでどこまで分けるか。
+2. `goal_id`生成をRPC Client Runtimeの責務とするべきか。
+3. Feedbackの`sequence_no`採番はRuntimeが所有すべきか。
+4. Result bodyの有効性をProtocolで規定するか、Action Typeの契約へ委ねるか。
+5. `ABORTED`をApplication判断、`ERROR`をRuntime判断として分けられるか。
+6. Action execution deadlineをRPC共通機能に含めるか。
+7. ROS Bridgeに残さざるを得ない状態管理はどこまでか。

--- a/docs/design/action/02-responsibility-boundaries.md
+++ b/docs/design/action/02-responsibility-boundaries.md
@@ -185,7 +185,7 @@ Action Server Applicationは、Goalを実際に処理するドメインロジッ
 
 ### 6.2 Runtimeとの境界
 
-RuntimeとApplicationの境界では、少なくとも以下の操作が必要になる想定です。
+RuntimeはProtocol上妥当なGoalをApplicationへ渡し、Applicationが返したaccept/reject判断をClientへ通知します。
 
 ```text
 Runtime -> Application

--- a/docs/design/action/02-responsibility-boundaries.md
+++ b/docs/design/action/02-responsibility-boundaries.md
@@ -13,6 +13,7 @@ Action対応では、以下の異なる関心事が同時に現れます。
 - Goal Executionの状態と通信ライフサイクル
 - ROS 2 Action APIとの変換
 - Goalを実際に処理する業務ロジック
+- 同一Action Typeに対する複数Goalの実行ポリシー
 - EndpointおよびTransportによる配送
 
 これらを一つの実装へ集約せず、それぞれの層が所有する責務を明確にします。
@@ -61,19 +62,21 @@ hakoniwa-pdu-registry
 - Action Request、Action Response、Action FeedbackのPDU定義生成
 - Action共通ヘッダの定義
 - `request_kind`、`response_kind`、`status`などの数値契約
-- `goal_id`、`sequence_no`などのフィールドレイアウト
+- UUID形式の`goal_id`、`sequence_no`などのフィールドレイアウト
 - 通常のPDU生成パイプラインによる各言語型とconverterの生成
 - offset、aligned size、CDR size、type metadataの生成
 - 生成物の決定性と既存Service生成物との互換性
 
 ### 3.2 所有しない責務
 
+- `goal_id`の生成
 - Goalを受理または拒否する判断
 - ClientおよびServerの状態機械
 - Feedbackの送信タイミング
 - CancelとResultの競合解決
 - Action APIの実行時挙動
 - ROS 2 Goal UUIDとの対応管理
+- 同一Action Typeの並列実行、直列化、キュー、排他判断
 - Action固有の業務処理
 
 Registryはデータを表現できるようにしますが、そのデータをいつ送るか、受信後にどう状態遷移するかは決定しません。
@@ -84,19 +87,23 @@ Registryはデータを表現できるようにしますが、そのデータを
 
 `hakoniwa-pdu-rpc`は、Hakoniwa Actionの通信ライフサイクルと実行時Protocolを所有します。
 
+- Action Client RuntimeによるUUID形式の`goal_id`生成
+- 外部Adapterが指定した互換UUIDの受け入れ
 - Goal送信、Goal Response受信、および相関
-- `goal_id`によるGoal Execution管理
+- `goal_id`による複数Goal Executionの独立管理
+- 同一Action Typeおよび同一Endpointに存在する複数Goalの状態管理
 - Feedbackの非終端配送
 - Cancel RequestおよびCancel Responseの配送
 - ResultおよびTerminal Statusの配送
-- ClientおよびServerの状態機械
+- GoalごとのClientおよびServer状態機械
 - 許可された状態遷移と不正操作の検出
-- 重複、遅延、未知の`goal_id`の扱い
+- duplicate、遅延、未知の`goal_id`の扱い
 - CancelとResultなどの競合規約
-- 同時Goal数、BUSY、キューなどのRuntime Policy
 - timeout、shutdown、transport errorをProtocol/APIへ反映する方法
 - C++ APIとPython Bindingが共有すべき意味論
 - 既存Service RPCとの後方互換性
+
+RPC Runtimeは、各Goal Executionを独立して識別し、配送し、状態管理できなければなりません。ProtocolまたはRuntime APIを、同一Action Typeにつき1 Goal、1 Clientにつき1 Goalという前提へ固定しません。
 
 ### 4.2 所有しない責務
 
@@ -104,10 +111,14 @@ Registryはデータを表現できるようにしますが、そのデータを
 - ROS 2 Node、Action Server、GoalHandleの実装
 - ROS 2固有ステータスへの変換
 - Goalの業務上の妥当性判断
+- 同一Action TypeのGoalを何件受理するかの判断
+- Goalの並列実行、直列化、キューイング、優先度、排他、preemption方針
 - ロボット制御、経路計画、計算処理などAction固有の実処理
 - Transport固有のSocket、共有メモリ、再接続処理の詳細
 
-RPC Runtimeは通信とライフサイクルを管理しますが、Goalを実際に達成する処理は行いません。
+RPC Runtimeは通信とGoal lifecycleを管理しますが、Goalを実際に達成する処理や、その実行資源の配分を決定しません。
+
+Runtime自身のメモリ、接続、バッファなどの技術的な資源枯渇はRuntime Errorとして扱えますが、それをActionの業務上の同時実行ポリシーとは定義しません。
 
 ## 5. hakoniwa-pdu-ros
 
@@ -119,9 +130,10 @@ RPC Runtimeは通信とライフサイクルを管理しますが、Goalを実�
 - ROS 2 Goal messageから生成済みHakoniwa Goal PDU bodyへの変換
 - Hakoniwa Feedback PDU bodyからROS 2 Feedback messageへの変換
 - Hakoniwa Result PDU bodyからROS 2 Result messageへの変換
-- ROS 2 Goal UUIDとHakoniwa `goal_id`の対応付け
+- ROS 2 Goal UUIDをHakoniwa `goal_id`として指定する処理
 - ROS 2 cancel callbackとHakoniwa Cancel APIの接続
 - ROS 2 GoalHandleの状態とHakoniwa terminal statusの対応
+- 複数のROS GoalHandleと複数のHakoniwa Goal Executionの対応管理
 - ROS executorおよび`rclpy` Futureへの非同期完了通知
 - ROS Binding設定の読み込みとHakoniwa Action Runtime設定への接続
 - ROS固有の変換失敗やNode lifecycleの診断
@@ -131,6 +143,7 @@ RPC Runtimeは通信とライフサイクルを管理しますが、Goalを実�
 - Hakoniwa Action Protocolそのものの状態機械
 - FeedbackキューやCancel/Result競合の独自実装
 - Action共通PDUレイアウトの定義
+- 同一Action Typeの業務上の同時実行方針
 - Action固有の業務処理
 - ROS 2以外の利用者に対するProtocol仕様
 
@@ -140,16 +153,35 @@ ROS BridgeがAction状態機械を再実装すると、C++、Python、ROSの各�
 
 ### 6.1 所有する責務
 
-Action Server Applicationは、Goalを実際に処理するドメインロジックを所有します。
+Action Server Applicationは、Goalを実際に処理するドメインロジックと実行ポリシーを所有します。
 
 - Goal bodyの業務上の検証
 - Goalを受理または拒否するアプリケーション判断
+- 同一Action Typeの複数Goalを受理するかどうかの判断
+- Goalの並列実行、直列化、キューイング
+- 同時実行数の上限
+- 共有資源の排他、優先度、fairness
+- 既存Goalと新規Goalのpreemption方針
 - 受理したGoalの実処理
 - Action固有Feedbackの生成
 - 成功時のResult body生成
 - 業務上の中断、失敗、abort判断
 - Cancel要求を受けた後の安全な停止処理
-- 資源競合や優先度に関するアプリケーションPolicy
+
+同じAction Typeであっても、Applicationによって適切なPolicyは異なります。
+
+```text
+画像変換Action
+  複数Goalを並列実行
+
+ロボットアーム操作Action
+  共有実機のため1 Goalだけ受理
+
+経路計画Action
+  最大N件を並列実行し、残りをキューへ格納
+```
+
+これらはProtocol差ではなくApplication Policyの差です。
 
 ### 6.2 Runtimeとの境界
 
@@ -169,18 +201,21 @@ Application -> Runtime
   canceled(goal_id, result_body)
 ```
 
-このAPI形状は未確定です。ここでは責務の方向だけを示します。
+複数Goalを扱うため、Applicationへ渡すContextまたはGoalHandleは`goal_id`ごとに独立していなければなりません。
+
+Applicationがキューへ入れたGoalを、Protocol上で`ACCEPTED`、`QUEUED`、`EXECUTING`のどこまで区別するかは、状態モデルで決定します。
 
 ### 6.3 所有しない責務
 
 - PDUヘッダの直接構築
 - `sequence_no`の採番方法
 - transport送受信
-- Clientとの相関管理
+- Clientとの通信相関管理
 - Protocol上の不正状態検出
+- duplicate `goal_id`のProtocol検査
 - ROS 2 APIへの直接変換
 
-アプリケーションはAction固有のbodyと意味を扱い、共通ヘッダや通信Protocolの詳細から分離されることが望まれます。
+アプリケーションはAction固有のbody、実行資源、同時実行Policyを扱い、共通ヘッダや通信Protocolの詳細から分離されることが望まれます。
 
 ## 7. hakoniwa-pdu-endpointとTransport
 
@@ -191,8 +226,14 @@ EndpointおよびTransportは、PDUを通信相手へ配送する責務を持ち
 - PDUサイズとバッファ管理
 - 送受信、切断、再接続、shutdownの低レベルイベント
 - RPC Runtimeが利用できるpollまたはwait primitive
+- `tcp_mux`による複数Client接続の収容
+- `maxClients`による接続数上限の管理
 
 Endpoint/TransportはActionのGoal、Feedback、Resultの意味や状態遷移を理解しません。
+
+`maxClients`はTransportが同時に収容できるClient接続数であり、同一Action Typeの同時Goal数やApplicationの実行能力を表しません。
+
+1 Clientが複数Goalを送信する場合も、複数Clientが同じAction TypeへGoalを送信する場合も、Goalの意味上の並列性は`goal_id`とApplication Policyで管理します。
 
 `requestChannelId`や`feedbackChannelId`などの物理配置情報をRPC設定とEndpoint設定のどちらが所有するかは、既存の設定分離Issueと整合させて後続設計で決定します。
 
@@ -202,9 +243,15 @@ Endpoint/TransportはActionのGoal、Feedback、Resultの意味や状態遷移�
 |---|---:|---:|---:|---:|---:|
 | `.action`解析 | 主 |  |  |  |  |
 | PDU型・レイアウト | 主 | 利用 | 利用 | 利用 | 配送 |
-| `goal_id`相関 | データ定義 | 主 | ROS UUID対応 | 利用 | 透過 |
+| `goal_id`データ定義 | 主 | 利用 | 利用 | 利用 | 透過 |
+| `goal_id`生成 |  | Client Runtime | ROS UUID指定 |  |  |
+| `goal_id`相関・状態管理 |  | 主 | ROS GoalHandle対応 | 利用 | 透過 |
 | Goal受理Protocol |  | 主 | Adapter | 判断 | 透過 |
+| Protocol上の自動拒否 |  | 主 | 透過 |  | 透過 |
 | 業務上の受理判断 |  | 支援 | 透過 | 主 |  |
+| 複数Goalの独立管理 | データ定義 | 主 | 対応管理 | 実行 | 配送 |
+| 並列・直列・キュー・排他 |  |  | 透過 | 主 |  |
+| Client接続数上限 |  | 利用 | 利用 |  | 主 |
 | Feedback配送 | データ定義 | 主 | ROS変換 | 生成 | 配送 |
 | Cancel状態遷移 |  | 主 | ROS変換 | 停止処理 | 配送 |
 | Result配送 | データ定義 | 主 | ROS変換 | 生成 | 配送 |
@@ -235,6 +282,16 @@ Cancel、timeout、late feedback、terminal raceの規約をBridgeごとに実�
 
 ActionのためにService Request/Responseヘッダや既存APIの意味を拡張しません。Actionは独立したデータ契約と明示的な設定で追加します。
 
+### 9.6 複数GoalをProtocol上で制限しない
+
+同一Action Typeおよび同一Endpointに複数のGoal Executionが同時に存在することを許容します。
+
+RuntimeはGoalごとに状態を独立管理しますが、それらを実際に並列実行するかどうかは決定しません。実行資源、排他、優先度、同時実行数はApplicationの責務です。
+
+### 9.7 Transport容量とAction実行能力を分離する
+
+`maxClients`はClient接続数の上限です。Actionの同時Goal数、Applicationのworker数、共有資源の数とは別の設定・概念として扱います。
+
 ## 10. 境界上の未確定事項
 
 ### 10.1 Goal受理判断の分割
@@ -244,27 +301,39 @@ Runtimeが自動的に拒否すべき条件と、Applicationへ判断を委ね�
 Runtime側候補:
 
 - duplicate `goal_id`
-- protocol version不正
-- 同時実行上限超過
-- shutdown中
+- UUIDまたはprotocol version不正
+- Runtime shutdown中
+- Runtime自身の技術的資源枯渇
 
 Application側候補:
 
 - Goal bodyの業務上の不正
 - ロボット状態が実行条件を満たさない
-- ドメイン上の優先度や排他
+- 同時実行数上限
+- workerまたは共有資源の不足
+- ドメイン上の優先度、排他、キュー、preemption
 
 ### 10.2 goal_id生成責任
 
-候補は以下です。
+現時点では以下を設計判断とします。
 
-- Action Client Application
-- RPC Client Runtime
-- ROS BridgeなどのAdapter
+- 通常のHakoniwa ClientではAction Client Runtimeが送信前にUUIDを生成する。
+- ROS BridgeなどのAdapterは、外部で生成された互換UUIDを指定できる。
+- Action Server Runtimeは重複検査、登録、状態管理、終了済みID保持を担当する。
 
-ROS Goal UUIDをそのまま使用する場合と、ROSを使わないClientの場合を共通に説明できる規約が必要です。
+UUID version、一意性の要求範囲、終了済みIDの保持期間は未確定です。
 
-### 10.3 Timeoutの所有者
+### 10.3 Application実行状態の公開範囲
+
+ApplicationがGoalを受理後にキューへ入れる場合、Protocol上で以下を区別するか決定する必要があります。
+
+- ACCEPTED
+- QUEUED
+- EXECUTING
+
+Application内部状態を過剰にProtocolへ露出すると汎用性を損なう一方、Clientが実行待ちを観測できないと運用上不便になる可能性があります。
+
+### 10.4 Timeoutの所有者
 
 以下を分離する必要があります。
 
@@ -273,28 +342,35 @@ ROS Goal UUIDをそのまま使用する場合と、ROSを使わないClientの�
 - Action execution deadline
 - Bridge側のROS request deadline
 - Application固有の処理期限
+- Application queue wait timeout
 
 すべてを一つのtimeoutへ統合すると、どの層がGoalを終了させたのか不明確になります。
 
-### 10.4 Feedback保持方針
+### 10.5 Feedback保持方針
 
 FeedbackをRuntimeがキューイングするか、Endpointイベントをそのまま通知するか、最新値だけを保持するかは、RPCと利用APIの境界に関わります。
 
-## 11. 初稿で提案する責務上の結論
+複数Goalを扱うため、Feedback保持は少なくとも`goal_id`単位で独立している必要があります。
+
+## 11. 現時点の責務上の設計判断
 
 1. Registryはデータ契約を所有し、状態機械を所有しない。
 2. RPCはHakoniwa ActionのProtocolとGoal Execution lifecycleを所有する。
-3. ROS BridgeはROS 2との変換を所有し、Action状態機械を独自に実装しない。
-4. ApplicationはGoalの業務処理、Feedback生成、Result生成、安全なCancel処理を所有する。
-5. Endpoint/Transportは配送を所有し、Action意味論を所有しない。
-6. Goalの受理判断は、Protocol上の自動拒否とApplication判断に分割する。
+3. RPCは同一Action Typeの複数Goal Executionを`goal_id`ごとに独立管理できる設計とする。
+4. ROS BridgeはROS 2との変換を所有し、Action状態機械を独自に実装しない。
+5. ApplicationはGoalの業務処理、受理判断、並列実行、直列化、キュー、排他、優先度、preemption、Feedback生成、Result生成、安全なCancel処理を所有する。
+6. Endpoint/Transportは配送とClient接続収容を所有し、Action意味論を所有しない。
+7. `maxClients`はTransportの接続数上限であり、Actionの同時実行数とは定義しない。
+8. `goal_id`はClient RuntimeまたはAdapterがUUIDとして送信前に用意し、Server Runtimeが重複検査とlifecycle管理を行う。
+9. Goalの受理判断は、Protocol上の自動拒否とApplication判断に分割する。
 
 ## 12. レビューで問答したい事項
 
 1. Goalのaccept/reject判断をRuntimeとApplicationでどこまで分けるか。
-2. `goal_id`生成をRPC Client Runtimeの責務とするべきか。
-3. Feedbackの`sequence_no`採番はRuntimeが所有すべきか。
-4. Result bodyの有効性をProtocolで規定するか、Action Typeの契約へ委ねるか。
-5. `ABORTED`をApplication判断、`ERROR`をRuntime判断として分けられるか。
-6. Action execution deadlineをRPC共通機能に含めるか。
-7. ROS Bridgeに残さざるを得ない状態管理はどこまでか。
+2. Applicationへ渡すGoalHandleまたはContextの最小責務は何か。
+3. ApplicationのQUEUEDとEXECUTINGをProtocol状態として区別するか。
+4. Feedbackの`sequence_no`採番はRuntimeが所有すべきか。
+5. Result bodyの有効性をProtocolで規定するか、Action Typeの契約へ委ねるか。
+6. `ABORTED`をApplication判断、`ERROR`をRuntime判断として分けられるか。
+7. Action execution deadlineとqueue wait timeoutをどの層が所有するか。
+8. ROS Bridgeに残さざるを得ない状態管理はどこまでか。

--- a/docs/design/action/README.md
+++ b/docs/design/action/README.md
@@ -21,6 +21,11 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 
 - ActionはROS 2固有機能ではなく、箱庭で利用できる独立した通信・実行ライフサイクルとして定義します。
 - Actionは単に応答時間の長いService RPCではなく、`goal_id`で識別されるGoal実行セッションとして扱います。
+- 1回のGoal Executionは128-bit UUIDの`goal_id`で識別します。
+- `goal_id`は原則としてAction Client RuntimeがGoal送信前に生成し、Server Runtimeが重複検査とlifecycle管理を行います。
+- 同一Action Typeおよび同一Endpointに、複数のGoal Executionが同時に存在することをProtocol上許容します。
+- Goalを並列実行するか、直列化するか、キューへ入れるか、拒否するかはAction Server Applicationの実行ポリシーとします。
+- `tcp_mux`の`maxClients`はTransportのClient接続数上限であり、Actionの同時実行数とは定義しません。
 - Feedbackは0回以上送信できる非終端通知とします。
 - Resultのデータと、Succeeded、Canceled、Abortedなどの終端状態を区別します。
 - Cancel要求、Cancel受理、Canceled終端を同一概念として扱いません。
@@ -51,11 +56,18 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 
 推奨する読み順は、概念、責務境界、データモデル、状態モデル、通信プロトコル、競合規約、実装契約の順です。
 
-## 確定に近い前提
+## 現時点の設計判断
 
-以下はRegistry側のAction PDU設計および関連Issueで採用されている前提です。ただし、本設計文書のレビューによって表現や責務境界を調整する可能性があります。
+以下は、今回のレビューで合意した方向性です。後続のデータモデル、状態モデル、API設計では、この前提を狭めない形で具体化します。
 
-- 1回のAction実行を128-bitの`goal_id`で識別する。
+- 1回のAction実行を128-bit UUIDの`goal_id`で識別する。
+- 通常のHakoniwa ClientではAction Client Runtimeが`goal_id`を生成する。
+- ROS BridgeなどのAdapterは、外部で生成された互換UUIDを指定できる。
+- Server Runtimeは`goal_id`の重複検査、登録、状態管理を担当する。
+- 同一Action Typeの複数Goal ExecutionをProtocol上許容する。
+- RPC Runtimeは各Goalを`goal_id`ごとに独立管理する。
+- 同時実行数、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
+- `maxClients`とAction同時実行能力を分離する。
 - Action Request、Action Response、Action FeedbackをServiceとは独立したPDU契約として定義する。
 - Feedbackに`sequence_no`を持たせる。
 - 汎用的な進捗率を共通ヘッダへ入れず、Action固有のFeedback bodyへ置く。
@@ -63,15 +75,17 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 
 ## 現在の主要な未確定事項
 
-- 同一Actionに複数の同時Goalを許可する範囲
+- UUID versionと一意性を要求する範囲
+- 終了済み`goal_id`を保持する期間
 - Goalの受理前に届いたCancelの扱い
+- Applicationがキューへ入れたGoalについて、`ACCEPTED`、`QUEUED`、`EXECUTING`をProtocol上区別するか
 - Cancel ResponseとCanceled Resultの役割分担
 - Resultとterminal statusをAPI上でどのように返すか
 - Feedbackのキュー方式、容量、欠落および順序の扱い
-- 終了済み`goal_id`を保持する期間
 - タイムアウトをProtocol終端として扱うか、ローカル観測結果として扱うか
+- Applicationへ公開するGoalHandleまたはContextの責務
 
-未確定事項を確定仕様へ混在させず、各文書内で「提案」「決定」「未決定」を明示します。
+未確定事項を確定仕様へ混在させず、各文書内で「設計判断」と「未決定」を明示します。
 
 ## 関連Issue
 
@@ -88,5 +102,7 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 1. Actionをどのような抽象概念として扱うか。
 2. Goal、Feedback、Result、Cancelをどのように区別するか。
 3. Registry、RPC、ROS Bridge、利用アプリケーションの責務をどこで分けるか。
+4. 同一Action Typeの複数GoalをProtocolとRuntimeでどのように独立管理するか。
+5. Goalの実行ポリシーをApplication境界へどのように渡すか。
 
 これらが合意できた後、データモデルと状態モデルの設計へ進みます。

--- a/docs/design/action/README.md
+++ b/docs/design/action/README.md
@@ -1,0 +1,92 @@
+# Hakoniwa Action Protocol 設計
+
+> **Status: Draft**  
+> 本文書群はレビューと議論のための初稿です。現時点では確定仕様ではありません。
+
+## 目的
+
+このディレクトリでは、`hakoniwa-pdu-rpc` におけるHakoniwa Action Protocolの設計仕様を管理します。
+
+Action対応を実装から逆算して定義するのではなく、先に以下を明文化し、C++ Runtime、Python Binding、`hakoniwa-pdu-ros`、利用アプリケーションが共通に参照できる仕様とします。
+
+- 基本概念と用語
+- リポジトリおよびレイヤ間の責務境界
+- PDUデータ契約
+- ClientおよびServerの状態機械
+- Goal、Feedback、Cancel、Resultの通信規約
+- エラー、競合、遅延メッセージの扱い
+- 公開API、設定、ファイル配置、ビルド契約
+
+## 基本方針
+
+- ActionはROS 2固有機能ではなく、箱庭で利用できる独立した通信・実行ライフサイクルとして定義します。
+- Actionは単に応答時間の長いService RPCではなく、`goal_id`で識別されるGoal実行セッションとして扱います。
+- Feedbackは0回以上送信できる非終端通知とします。
+- Resultのデータと、Succeeded、Canceled、Abortedなどの終端状態を区別します。
+- Cancel要求、Cancel受理、Canceled終端を同一概念として扱いません。
+- 既存Service RPCのPDUレイアウト、設定、状態遷移、API挙動を変更しません。
+- Action対応は追加機能かつ明示的なopt-inとします。
+
+## 文書構成
+
+### 現在のレビュー対象
+
+1. [基本概念](01-concepts.md)
+2. [責務境界](02-responsibility-boundaries.md)
+
+### 後続で追加する文書
+
+```text
+03-data-model.md
+04-state-model.md
+05-protocol.md
+06-error-and-race-semantics.md
+07-api-design.md
+08-configuration.md
+09-file-layout.md
+10-build-contract.md
+11-ros2-mapping.md
+12-open-questions.md
+```
+
+推奨する読み順は、概念、責務境界、データモデル、状態モデル、通信プロトコル、競合規約、実装契約の順です。
+
+## 確定に近い前提
+
+以下はRegistry側のAction PDU設計および関連Issueで採用されている前提です。ただし、本設計文書のレビューによって表現や責務境界を調整する可能性があります。
+
+- 1回のAction実行を128-bitの`goal_id`で識別する。
+- Action Request、Action Response、Action FeedbackをServiceとは独立したPDU契約として定義する。
+- Feedbackに`sequence_no`を持たせる。
+- 汎用的な進捗率を共通ヘッダへ入れず、Action固有のFeedback bodyへ置く。
+- 既存Service Request/Responseのバイナリ契約を変更しない。
+
+## 現在の主要な未確定事項
+
+- 同一Actionに複数の同時Goalを許可する範囲
+- Goalの受理前に届いたCancelの扱い
+- Cancel ResponseとCanceled Resultの役割分担
+- Resultとterminal statusをAPI上でどのように返すか
+- Feedbackのキュー方式、容量、欠落および順序の扱い
+- 終了済み`goal_id`を保持する期間
+- タイムアウトをProtocol終端として扱うか、ローカル観測結果として扱うか
+
+未確定事項を確定仕様へ混在させず、各文書内で「提案」「決定」「未決定」を明示します。
+
+## 関連Issue
+
+- RPC Action対応: #21
+- 設計文書全体: #44
+- 概念と責務境界: #45
+- Registry Action生成: hakoniwalab/hakoniwa-pdu-registry#17
+- ROS 2 Service/Action Bridge: hakoniwalab/hakoniwa-pdu-ros#1
+
+## レビュー方針
+
+今回の初稿では、実装APIや具体的な状態遷移を確定しません。まず、以下について合意することを目的とします。
+
+1. Actionをどのような抽象概念として扱うか。
+2. Goal、Feedback、Result、Cancelをどのように区別するか。
+3. Registry、RPC、ROS Bridge、利用アプリケーションの責務をどこで分けるか。
+
+これらが合意できた後、データモデルと状態モデルの設計へ進みます。


### PR DESCRIPTION
Closes #45
Related: #44, #21

## 概要

Hakoniwa Action Protocol設計の最初のドラフトとして、以下を追加します。

```text
docs/design/action/
    README.md
    01-concepts.md
    02-responsibility-boundaries.md
```

このPRでは、状態機械や通信シーケンスを確定する前に、基本概念と各レイヤの責務境界を整理しています。

## 主な提案

- Actionを単なる長時間Service RPCではなく、`goal_id`で識別されるGoal Executionセッションとして扱う。
- Goalの送信と受理を区別する。
- Feedbackを非終端通知とする。
- Result bodyとTerminal Statusを区別する。
- Cancel Request、Cancel Response、Canceled終端を区別する。
- Registry、RPC、ROS Bridge、Application、Endpoint/Transportの責務を分離する。
- Action状態機械をROS Bridgeへ重複実装せず、RPC Runtimeへ集約する。

## GitHub Actions

ドキュメント更新だけで重いマルチプラットフォームテストが起動しないよう、PR向けWorkflowのパスフィルタを統一します。

`package-contract`には既に同等の設定があったため、未対応だった以下の5つへ`paths-ignore`を追加しました。

- `rpc-basic-tests`
- `rpc-infinite-wait-tests`
- `rpc-timeout-cancel-tests`
- `rpc-cancel-race-tests`
- `python-cffi-tests`

以下だけが変更されたPRでは、これらのWorkflowを起動しません。

```text
docs/**
**/*.md
```

コード、設定、Workflowなど、上記以外の変更が一つでも含まれる場合は従来どおり実行されます。`workflow_dispatch`による手動実行も維持します。

## レビューで相談したい点

- Actionを独立したGoal Executionセッションとする定義でよいか。
- `goal_id`の生成責任をどこへ置くか。
- Result bodyとTerminal Statusを常に分離すべきか。
- Goal accept/reject判断をRuntimeとApplicationでどう分けるか。
- Cancel Responseが保証する範囲をどこまでとするか。
- `ABORTED`と`ERROR`をApplication/Runtimeの境界で分けられるか。

## 対象外

- PDUデータモデルの詳細確定
- Client/Server状態機械
- 通信シーケンスと競合規約
- C++およびPython API
- Runtime実装

本文書は議論用の初稿であり、レビュー結果を受けて更新します。