### PR TITLE
Define Goal identity and concurrent execution model

### DIFF
--- a/docs/design/action/03-data-model.md
+++ b/docs/design/action/03-data-model.md
@@ -69,7 +69,9 @@ Goal Execution B
   goal_id = UUID-B
 ```
 
-同じAction Type、同じAction Endpoint、同じClient Sessionであっても、`goal_id`が異なれば別のGoal Executionです。
+同じAction Typeに対して、`goal_id`が異なれば別のGoal Executionです。
+
+Action EndpointとClient Sessionは、Goal Executionに関連する配送・通信コンテキストですが、Goal Executionの同一性を決める条件には含めません。
 
 ## 3. goal_id
 
@@ -174,7 +176,7 @@ Server Runtimeは、自身が管理する範囲で重複を検出します。
 
 ### 5.1 Protocol上の原則
 
-同一Action Typeに対して、複数のGoal Executionが同時に存在できる設計とします。
+同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionが同時に存在できる設計とします。
 
 ```text
 MoveRobot
@@ -184,6 +186,8 @@ MoveRobot
 ```
 
 各Goalは、Feedback、Cancel、Result、Terminal Statusを独立して持ちます。
+
+同じ`goal_id`を持つGoal Requestは、新しいGoal Executionとして扱いません。その具体的な扱いを重複エラーとするか、再送または冪等な再照会とするかは後続のProtocol設計で決定します。
 
 ```text
 Goal A
@@ -401,15 +405,17 @@ GoalExecutionContext
 Action Type
   1
   |
-  | exposed by
-  v
-Action Endpoint
-  1
-  |
-  | receives
+  | instantiated as
   v
 Goal Execution (0..N)
   identified by goal_id
+
+Action Endpoint
+  1
+  |
+  | routes
+  v
+Goal Execution (0..N)
 
 Client Session
   1
@@ -419,9 +425,9 @@ Client Session
 Goal Execution (0..N)
 ```
 
-Goal Executionは、Action EndpointとClient Sessionの両方に関連しますが、どちらか一方だけでは識別しません。
+Goal Executionの型はAction Typeによって決まり、第一識別子は`goal_id`です。
 
-第一識別子は`goal_id`です。
+Action EndpointとClient SessionはGoal Executionに関連付けられますが、配送・通信コンテキストであり、Goal Executionの同一性を決めません。
 
 ## 12. 今回の設計判断
 
@@ -429,12 +435,13 @@ Goal Executionは、Action EndpointとClient Sessionの両方に関連します�
 2. 通常のClientではAction Client RuntimeがGoal送信前に生成する。
 3. Adapterは外部で生成された互換UUIDを指定できる。
 4. Server RuntimeはUUIDの検査、重複検査、登録、相関、ライフサイクル管理を行う。
-5. 同一Action Type、同一Endpoint、同一Client Sessionに複数Goal Executionが存在できる。
-6. RPC Runtimeは複数Goalを`goal_id`ごとに独立管理できる能力を提供する。
-7. Runtimeは一律のsingle-goal制約をProtocolへ埋め込まない。
-8. Goalの受理、並列実行、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
-9. `tcp_mux.maxClients`はTransport接続容量であり、active Goal数やApplication同時実行数とは別概念とする。
-10. Transport接続失敗、Runtime拒否、Application拒否を別の失敗として扱う。
+5. 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionが同時に存在できる。
+6. Action EndpointおよびClient Sessionは配送・通信コンテキストであり、Goal Executionの識別条件には含めない。
+7. RPC Runtimeは複数Goalを`goal_id`ごとに独立管理できる能力を提供する。
+8. Runtimeは一律のsingle-goal制約をProtocolへ埋め込まない。
+9. Goalの受理、並列実行、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
+10. `tcp_mux.maxClients`はTransport接続容量であり、active Goal数やApplication同時実行数とは別概念とする。
+11. Transport接続失敗、Runtime拒否、Application拒否を別の失敗として扱う。
 
 ## 13. レビューで問答したい事項
 

--- a/docs/design/action/03-data-model.md
+++ b/docs/design/action/03-data-model.md
@@ -1,0 +1,448 @@
+# Hakoniwa Actionのデータモデル
+
+> **Status: Draft**  
+> 本文書はレビューと議論のための初稿です。現時点では確定仕様ではありません。
+
+## 1. 目的
+
+本書では、Hakoniwa Action Protocolで扱う主要なデータ概念と、それらの識別・相関関係を定義します。
+
+特に、以下を明確にします。
+
+- 1回のAction実行をどのように識別するか
+- 同一Action Typeに対する複数のGoal Executionをどう表現するか
+- 同一Client接続上で複数Goalをどう独立管理するか
+- RPC Runtime、Action Server Application、Transportの責務をどう分離するか
+
+具体的なPDUのバイト配置、状態遷移、送受信順序、公開APIは後続文書で定義します。
+
+## 2. データモデルの基本単位
+
+Hakoniwa Actionでは、以下を別の概念として扱います。
+
+### 2.1 Action Type
+
+Action Typeは、実行可能な処理の型です。
+
+少なくとも以下のAction固有データ型を持ちます。
+
+- Goal body
+- Feedback body
+- Result body
+
+Action Type自体は、個別の実行状態を持ちません。
+
+### 2.2 Action Endpoint
+
+Action Endpointは、Action TypeをClientへ公開する論理的な通信先です。
+
+同じAction Typeを複数のEndpointで公開できます。
+
+```text
+robot1/move : MoveRobot
+robot2/move : MoveRobot
+```
+
+EndpointはAction Typeを公開する場所であり、単一のGoal Executionを表すものではありません。
+
+### 2.3 Client Session
+
+Client Sessionは、ClientとServer間のTransportまたはRPC上の接続・通信コンテキストです。
+
+Client SessionはGoal Executionの識別子ではありません。
+
+1つのClient Session上に、複数のGoal Executionが存在できます。
+
+### 2.4 Goal Execution
+
+Goal Executionは、Action Typeに対して行われる1回の具体的な実行です。
+
+各Goal Executionは、一意な`goal_id`によって識別します。
+
+```text
+Action Type: MoveRobot
+
+Goal Execution A
+  goal_id = UUID-A
+
+Goal Execution B
+  goal_id = UUID-B
+```
+
+同じAction Type、同じAction Endpoint、同じClient Sessionであっても、`goal_id`が異なれば別のGoal Executionです。
+
+## 3. goal_id
+
+### 3.1 定義
+
+`goal_id`は、1回のGoal Executionを識別する128-bit UUIDです。
+
+Goal Request、Goal Response、Feedback、Cancel、Resultは、同じ`goal_id`によって相関します。
+
+```text
+Goal Request(goal_id = X)
+Goal Response(goal_id = X)
+Feedback(goal_id = X)
+Cancel Request(goal_id = X)
+Cancel Response(goal_id = X)
+Result(goal_id = X)
+```
+
+### 3.2 生成責任
+
+通常のHakoniwa Action Clientでは、Action Client RuntimeがGoal送信前に`goal_id`を生成します。
+
+```text
+Client Application
+  send_goal(goal_body)
+        |
+        v
+Action Client Runtime
+  generate UUID
+  send Goal Request(goal_id, goal_body)
+```
+
+利用アプリケーションがUUID生成処理を直接実装することは必須としません。
+
+ROS Bridgeなど、外部ActionシステムのAdapterは、外部で既に生成された互換UUIDを`goal_id`として指定できます。
+
+```text
+ROS Goal UUID
+      |
+      v
+Hakoniwa goal_id
+```
+
+### 3.3 Server Runtimeの責務
+
+Action Server Runtimeは、受信した`goal_id`について以下を担当します。
+
+- UUID形式の検査
+- 不正値の拒否
+- 実行中Goalとの重複検査
+- 必要に応じた終了済みGoalとの重複検査
+- Goal Execution Contextへの登録
+- Feedback、Cancel、Resultの相関
+- Goal終了後の破棄または一定期間の保持
+
+`goal_id`の値をClient側で生成することと、Server側で一意性・ライフサイクルを管理することは矛盾しません。
+
+```text
+生成責任
+  Client Runtime / Adapter
+
+検査・登録・管理責任
+  Server Runtime
+```
+
+### 3.4 Server内部IDとの分離
+
+Server実装が、配列index、pointer、handle、database keyなどの内部識別子を必要とする場合、それらはProtocol上の`goal_id`と分離します。
+
+```text
+Protocol identity
+  goal_id = UUID
+
+Server internal identity
+  implementation-specific handle
+```
+
+ClientへServer内部IDを公開することを必須としません。
+
+## 4. goal_idの一意性スコープ
+
+Protocol上は、異なるGoal Executionが同じ`goal_id`を共有しないことを要求します。
+
+初稿では、Client RuntimeまたはAdapterが、実運用上十分なグローバル一意性を持つUUIDを生成することを前提とします。
+
+Server Runtimeは、自身が管理する範囲で重複を検出します。
+
+最低限、以下の重複を検出できる必要があります。
+
+- 現在実行中のGoal Executionとの重複
+- 同じGoal Requestの再送として判定すべき重複
+
+以下は未確定です。
+
+- UUID versionを固定するか
+- zero UUIDを禁止するか
+- Serverが終了済み`goal_id`を保持する期間
+- Server再起動をまたいだ重複検出を要求するか
+- システム全体での永続的一意性をProtocol要件とするか
+
+## 5. 複数Goal Execution
+
+### 5.1 Protocol上の原則
+
+同一Action Typeに対して、複数のGoal Executionが同時に存在できる設計とします。
+
+```text
+MoveRobot
+  Goal A: goal_id = UUID-A
+  Goal B: goal_id = UUID-B
+  Goal C: goal_id = UUID-C
+```
+
+各Goalは、Feedback、Cancel、Result、Terminal Statusを独立して持ちます。
+
+```text
+Goal A
+  Feedback A1
+  Feedback A2
+  Result A
+
+Goal B
+  Cancel B
+  Result B / CANCELED
+```
+
+### 5.2 同一Clientからの複数Goal
+
+同一Client Sessionから送信された複数Goalも、異なる`goal_id`を持つ独立したGoal Executionとして表現できます。
+
+```text
+Client Session A
+  Goal A1: UUID-A1
+  Goal A2: UUID-A2
+  Goal A3: UUID-A3
+```
+
+Runtimeが一律に以下の制限を設ける設計にはしません。
+
+- 1 Action Typeにつき1 active Goal
+- 1 Action Endpointにつき1 active Goal
+- 1 Client Sessionにつき1 active Goal
+
+この制限をProtocolへ埋め込むと、将来の並列実行、多重化、キューイング、複数ロボット操作などの利用形態を妨げるためです。
+
+### 5.3 複数Clientからの複数Goal
+
+異なるClient Sessionから、同じAction Endpointへ複数Goalを送信できます。
+
+```text
+Client A -> Goal A
+Client B -> Goal B
+Client C -> Goal C
+```
+
+これらも`goal_id`ごとに独立して管理します。
+
+## 6. Runtimeの責務
+
+RPC Runtimeは、複数のGoal Executionを扱える共通Protocol能力を提供します。
+
+- `goal_id`ごとのGoal Execution Context管理
+- Goal Response、Feedback、Cancel、Resultの相関
+- 異なるGoal間で状態やデータを混同しないこと
+- あるGoalの終了が、別のGoalを暗黙に終了させないこと
+- 複数Goalから発生するイベントを利用アプリケーションへ識別可能な形で通知すること
+- Protocol不正、重複ID、未知IDなどの検出
+
+概念上、Runtimeは以下のような集合を管理します。
+
+```text
+active_goals: Map<goal_id, GoalExecutionContext>
+```
+
+これは実装データ構造を指定するものではなく、複数Goalを`goal_id`単位で独立管理する必要性を示しています。
+
+## 7. Applicationの責務
+
+同時に何件のGoalを受理し、どのように処理するかは、Action Server ApplicationのPolicyです。
+
+Applicationは、例えば以下を選択できます。
+
+### 7.1 並列実行
+
+```text
+Goal A -> ACCEPT -> EXECUTING
+Goal B -> ACCEPT -> EXECUTING
+```
+
+### 7.2 直列実行・キュー
+
+```text
+Goal A -> ACCEPT -> EXECUTING
+Goal B -> ACCEPT -> QUEUED
+```
+
+### 7.3 排他による拒否
+
+```text
+Goal A -> ACCEPT
+Goal B -> REJECT(resource busy)
+```
+
+### 7.4 優先度またはpreemption
+
+```text
+Goal A -> EXECUTING
+Goal B -> higher priority
+Application decides whether to preempt A
+```
+
+Hakoniwa Action Protocolは、複数Goalを識別し配送できる能力を提供しますが、上記の実行Policyを一律に決定しません。
+
+Application Policyに含まれるものの例は以下です。
+
+- 最大同時実行数
+- Goalの業務上の受理条件
+- 資源排他
+- キュー方式とキュー容量
+- 優先順位
+- preemption
+- 同じ対象物に対する競合解決
+- ロボットやデバイスの安全条件
+
+## 8. Runtime拒否とApplication拒否
+
+Goal Rejectionには、少なくとも二つの異なる原因があります。
+
+### 8.1 RuntimeまたはProtocolによる拒否
+
+RuntimeがApplicationへ渡す前に拒否できる候補です。
+
+- 不正なUUID
+- duplicate `goal_id`
+- Protocol version不整合
+- 破損したPDU
+- Server shutdown中
+- Runtime自身がGoal Contextを生成できない内部資源不足
+
+### 8.2 Application Policyによる拒否
+
+Applicationが業務上の判断として拒否する候補です。
+
+- Goal bodyが業務上不正
+- 対象ロボットが実行可能状態ではない
+- 必要な資源を別Goalが使用中
+- Applicationの同時実行上限に到達
+- キューが満杯
+- 権限または運用Policyにより実行不可
+
+Runtime capacity failureとApplication Policy rejectionは、同じ`BUSY`へ安易に統合せず、後続のデータ契約で識別可能にすることを検討します。
+
+## 9. Transportとの分離
+
+### 9.1 maxClients
+
+`tcp_mux`の`maxClients`は、Transportが同時に収容できるClient接続数の上限です。
+
+```text
+maxClients
+  = transport client connection capacity
+```
+
+これは以下を意味しません。
+
+```text
+maxClients
+  != maximum active goals
+  != application concurrency limit
+```
+
+1つのClient Session上に複数Goalを多重化できるため、active Goal数が`maxClients`を上回ることもProtocol上はあり得ます。
+
+```text
+maxClients = 2
+
+Client A
+  Goal A1
+  Goal A2
+  Goal A3
+
+Client B
+  Goal B1
+  Goal B2
+
+active goals = 5
+```
+
+### 9.2 Transport capacity failure
+
+Transportの接続上限によってClientが接続できない場合、そのClientはGoal Requestを送信する段階へ到達していません。
+
+したがって、これはGoal Rejectionとは別の失敗です。
+
+```text
+Transport connection rejected
+  -> no Goal Execution created
+
+Goal rejected by Application
+  -> Goal Request reached Action Server
+```
+
+## 10. Goal Execution Context
+
+Runtimeは各Goal Executionについて、概念上、以下の情報を関連付けます。
+
+```text
+GoalExecutionContext
+  goal_id
+  action_endpoint
+  action_type
+  client/session reference
+  goal body or its reference
+  protocol state
+  feedback sequence state
+  terminal status
+  result body or its reference
+```
+
+具体的にどのフィールドを保持するか、所有権、コピー方式、永続性は後続設計で決定します。
+
+重要なのは、状態管理の主キーをClient Sessionだけにせず、`goal_id`を中心に各Goalを独立管理することです。
+
+## 11. データ関係
+
+概念上の関係は以下です。
+
+```text
+Action Type
+  1
+  |
+  | exposed by
+  v
+Action Endpoint
+  1
+  |
+  | receives
+  v
+Goal Execution (0..N)
+  identified by goal_id
+
+Client Session
+  1
+  |
+  | submits
+  v
+Goal Execution (0..N)
+```
+
+Goal Executionは、Action EndpointとClient Sessionの両方に関連しますが、どちらか一方だけでは識別しません。
+
+第一識別子は`goal_id`です。
+
+## 12. 今回の設計判断
+
+1. `goal_id`は128-bit UUIDとする。
+2. 通常のClientではAction Client RuntimeがGoal送信前に生成する。
+3. Adapterは外部で生成された互換UUIDを指定できる。
+4. Server RuntimeはUUIDの検査、重複検査、登録、相関、ライフサイクル管理を行う。
+5. 同一Action Type、同一Endpoint、同一Client Sessionに複数Goal Executionが存在できる。
+6. RPC Runtimeは複数Goalを`goal_id`ごとに独立管理できる能力を提供する。
+7. Runtimeは一律のsingle-goal制約をProtocolへ埋め込まない。
+8. Goalの受理、並列実行、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
+9. `tcp_mux.maxClients`はTransport接続容量であり、active Goal数やApplication同時実行数とは別概念とする。
+10. Transport接続失敗、Runtime拒否、Application拒否を別の失敗として扱う。
+
+## 13. レビューで問答したい事項
+
+1. UUID versionをProtocolで固定する必要があるか。
+2. `goal_id`の一意性をシステム全体で要求するか、それともServer管理範囲での重複防止を規範とするか。
+3. 終了済み`goal_id`をどの期間保持する必要があるか。
+4. 同じ`goal_id`を持つGoal Requestの再送を、重複エラーとするか冪等な再照会として扱うか。
+5. Applicationがキューへ入れたGoalを、Protocol上`ACCEPTED`とだけ表現するか、`QUEUED`状態を設けるか。
+6. Runtime内部資源不足とApplication同時実行上限を、Goal Response上で別理由として表現するか。
+7. Client Session切断時に、そのClientが送信したGoalを継続するかCancelするかを、Protocol、設定、Applicationのどこで決めるか。
+8. 1つのClient Session上で複数Goalイベントを配送する際、順序保証をGoal単位に限定するか。

--- a/docs/design/action/03-data-model.md
+++ b/docs/design/action/03-data-model.md
@@ -5,21 +5,22 @@
 
 ## 1. 目的
 
-本書では、Hakoniwa Action Protocolで扱う主要なデータ概念と、それらの識別・相関関係を定義します。
+本書では、Hakoniwa Action Protocolで扱う主要な抽象概念と、それらの識別・相関関係を定義します。
 
 特に、以下を明確にします。
 
-- 1回のAction実行をどのように識別するか
-- 同一Action Typeに対する複数のGoal Executionをどう表現するか
-- Goal、Feedback、Cancel、Resultをどのように相関するか
-- RPC RuntimeとAction Server Applicationの責務をどう分離するか
-- Protocolのデータモデルを通信経路や接続方式からどう独立させるか
+- 1回のAction要求と実行をどのように識別するか
+- 同一Action Typeに対する複数のGoalをどう表現するか
+- Goal、Feedback、Cancel、Resultをどう相関するか
+- Protocol RuntimeとAction Server Applicationの責務をどう分離するか
+- Goal RequestをProtocol側で拒否する条件と、Applicationへ判断を委ねる条件
+- 通信経路や接続方式に依存しないデータモデル
 
 具体的なPDUのバイト配置、状態遷移、送受信順序、公開API、Transport実装は後続文書で定義します。
 
-## 2. データモデルの基本単位
+## 2. 中心となる概念
 
-Hakoniwa Action Protocolの中心となる概念は、Action Type、Goal Execution、`goal_id`です。
+Hakoniwa Action Protocolの中心となる概念は、Action Type、Goal、Goal Execution、`goal_id`です。
 
 ### 2.1 Action Type
 
@@ -33,11 +34,17 @@ Action Typeは、実行可能な処理の型です。
 
 Action Type自体は、個別の実行状態を持ちません。
 
-### 2.2 Goal Execution
+### 2.2 Goal
 
-Goal Executionは、Action Typeに対して行われる1回の具体的な実行です。
+Goalは、ClientがAction Serverへ提示する1回の実行要求です。
 
-各Goal Executionは、一意な`goal_id`によって識別します。
+Goal Requestを送信した時点では、そのGoalが受理されることは保証されません。
+
+### 2.3 Goal Execution
+
+Goal Executionは、受理されたGoalに対する1回の具体的な実行です。
+
+同一Action Typeに対して複数のGoal Executionが存在できます。
 
 ```text
 Action Type: MoveRobot
@@ -49,17 +56,17 @@ Goal Execution B
   goal_id = UUID-B
 ```
 
-同じAction Typeに対して、`goal_id`が異なれば別のGoal Executionです。
+同じAction Typeに対して、`goal_id`が異なれば別のGoalです。
 
-### 2.3 Goal Executionセッション
+### 2.4 Goal lifecycle
 
-Goal Executionは、Goal Requestの送信から終端Resultまで継続する論理的な実行セッションです。
-
-このセッションは`goal_id`によって識別・相関します。
+`goal_id`は、Goal RequestからGoal Responseまでを相関し、Goalが受理された場合はFeedback、Cancel、Resultまで続くライフサイクル全体を相関します。
 
 ```text
 Goal Request(goal_id = X)
   -> Goal Response(goal_id = X)
+
+acceptedの場合:
   -> Feedback(goal_id = X) 0..N
   -> Cancel(goal_id = X) optional
   -> Result(goal_id = X)
@@ -67,13 +74,13 @@ Goal Request(goal_id = X)
 
 本設計では、これとは別に「Client Session」というProtocol概念を導入しません。
 
-TCP接続、共有メモリ接続、mux上のClient識別子などはTransportまたはRuntime実装上の情報であり、Goal ExecutionのProtocol identityではありません。
+TCP接続、共有メモリ接続、Endpoint、channel、mux上のClient識別子などはTransportまたはRuntime実装上の情報であり、GoalのProtocol identityではありません。
 
 ## 3. goal_id
 
 ### 3.1 定義
 
-`goal_id`は、1回のGoal Executionを識別する128-bit UUIDです。
+`goal_id`は、1回のGoalを識別する128-bit UUIDです。
 
 Goal Request、Goal Response、Feedback、Cancel、Resultは、同じ`goal_id`によって相関します。
 
@@ -86,7 +93,7 @@ Cancel Response(goal_id = X)
 Result(goal_id = X)
 ```
 
-`goal_id`は単なるRequest番号ではなく、Goal Executionのライフサイクル全体を束ねる相関キーです。
+`goal_id`は単なるRequest番号ではなく、Goalのライフサイクル全体を束ねる相関キーです。
 
 ### 3.2 生成責任
 
@@ -106,13 +113,6 @@ Action Client Runtime
 
 ROS Bridgeなど、外部ActionシステムのAdapterは、外部で既に生成された互換UUIDを`goal_id`として指定できます。
 
-```text
-ROS Goal UUID
-      |
-      v
-Hakoniwa goal_id
-```
-
 ### 3.3 Server Runtimeの責務
 
 Action Server Runtimeは、受信した`goal_id`について以下を担当します。
@@ -121,23 +121,21 @@ Action Server Runtimeは、受信した`goal_id`について以下を担当し�
 - 不正値の拒否
 - 実行中Goalとの重複検査
 - 必要に応じた終了済みGoalとの重複検査
-- Goal Execution Contextへの登録
+- Goal Contextへの登録
 - Goal Response、Feedback、Cancel、Resultの相関
 - Goal終了後の破棄または一定期間の保持
-
-`goal_id`の値をClient側で生成することと、Server側で一意性・ライフサイクルを管理することは矛盾しません。
 
 ```text
 生成責任
   Client Runtime / Adapter
 
-検査・登録・管理責任
+検査・登録・相関・管理責任
   Server Runtime
 ```
 
 ### 3.4 Server内部IDとの分離
 
-Server実装が、配列index、pointer、handle、database keyなどの内部識別子を必要とする場合、それらはProtocol上の`goal_id`と分離します。
+Server実装が内部handle、pointer、配列index、database keyなどを必要とする場合、それらはProtocol上の`goal_id`と分離します。
 
 ```text
 Protocol identity
@@ -147,34 +145,36 @@ Server internal identity
   implementation-specific handle
 ```
 
-ClientへServer内部IDを公開することを必須としません。
+## 4. goal_idの一意性
 
-## 4. goal_idの一意性スコープ
+Protocol上は、異なるGoalが同じ`goal_id`を共有しないことを要求します。
 
-Protocol上は、異なるGoal Executionが同じ`goal_id`を共有しないことを要求します。
-
-初稿では、Client RuntimeまたはAdapterが、実運用上十分なグローバル一意性を持つUUIDを生成することを前提とします。
+Client RuntimeまたはAdapterは、実運用上十分な一意性を持つUUIDを生成します。
 
 Server Runtimeは、自身が管理する範囲で重複を検出します。
 
 最低限、以下の重複を検出できる必要があります。
 
-- 現在実行中のGoal Executionとの重複
-- 同じGoal Requestの再送として判定すべき重複
+- 現在処理中または実行中のGoalとの重複
+- Runtimeが保持している終了済みGoalとの重複
+
+同じ`goal_id`を持つGoal Requestは、新しいGoalとして扱いません。
+
+同一`goal_id`の再受信を単純な重複エラーとするか、再送または冪等な再照会として扱うかは後続のProtocol設計で決定します。
 
 以下は未確定です。
 
 - UUID versionを固定するか
 - zero UUIDを禁止するか
-- Serverが終了済み`goal_id`を保持する期間
+- 終了済み`goal_id`を保持する期間
 - Server再起動をまたいだ重複検出を要求するか
 - システム全体での永続的一意性をProtocol要件とするか
 
-## 5. 複数Goal Execution
+## 5. 複数Goal
 
 ### 5.1 Protocol上の原則
 
-同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionが同時に存在できる設計とします。
+同一Action Typeに対して、異なる`goal_id`を持つ複数のGoalが同時に存在できる設計とします。
 
 ```text
 MoveRobot
@@ -183,26 +183,13 @@ MoveRobot
   Goal C: goal_id = UUID-C
 ```
 
-各Goal Executionは、Goal Response、Feedback、Cancel、Result、Terminal Statusを独立して持ちます。
+受理された各Goal Executionは、Feedback、Cancel、Result、Terminal Statusを独立して持ちます。
 
-```text
-Goal A
-  Feedback A1
-  Feedback A2
-  Result A
-
-Goal B
-  Cancel B
-  Result B / CANCELED
-```
-
-同じ`goal_id`を持つGoal Requestは、新しいGoal Executionとして扱いません。
-
-その具体的な扱いを重複エラーとするか、再送または冪等な再照会とするかは後続のProtocol設計で決定します。
+あるGoalの状態変化や終了が、別の`goal_id`を持つGoalへ暗黙に影響してはなりません。
 
 ### 5.2 実現方式からの独立
 
-複数Goal Executionをどの通信経路で運ぶかは、Protocol上の同一性とは関係しません。
+複数Goalをどの通信経路で運ぶかは、Protocol上の同一性とは関係しません。
 
 以下はいずれも同じProtocolモデルで扱えます。
 
@@ -212,107 +199,136 @@ Goal B
 TransportがGoalごとに異なる経路を選択する
 ```
 
-Protocolが要求するのは、各メッセージを`goal_id`で正しいGoal Executionへ相関できることです。
+Protocolが要求するのは、各メッセージを`goal_id`で正しいGoalへ相関できることです。
 
-Endpoint、socket、connection、channel、mux client IDなどをGoal Executionの識別条件には含めません。
+Endpoint、socket、connection、channel、mux client IDなどをGoalの識別条件には含めません。
 
-## 6. Runtimeの責務
+## 6. Goal Requestの判定フロー
 
-RPC Runtimeは、複数のGoal Executionを扱える共通Protocol能力を提供します。
+Goal Requestを受信したRuntimeは、まずProtocolとして処理可能かを検査します。
 
-- `goal_id`ごとのGoal Execution Context管理
+```text
+Client
+  |
+  | Goal Request(goal_id, goal_body)
+  v
+Server Runtime
+  |
+  +-- Protocol上処理不能
+  |      -> RuntimeがGoal Response(REJECTED)を返す
+  |
+  +-- Protocol上有効かつ新しいgoal_id
+         -> ApplicationへGoal Requestを通知
+                 |
+                 +-- accept
+                 |     -> RuntimeがGoal Response(ACCEPTED)を返す
+                 |
+                 +-- reject(reason)
+                       -> RuntimeがGoal Response(REJECTED)を返す
+```
+
+この構造により、Protocol RuntimeとApplicationは同じGoal Response経路を使用しながら、拒否判断の責務を分離できます。
+
+## 7. Protocol Runtimeによる自動拒否
+
+RuntimeがApplicationへ通知する前に拒否するのは、Goal Requestを正常な判断対象として成立させられない場合です。
+
+Protocol上の自動拒否条件には、少なくとも以下を含めます。
+
+- `goal_id`の形式が不正
+- `goal_id`が禁止値
+- 同じ`goal_id`が既に処理中、実行中、または保持中
+- Protocol versionまたはmessage kindが不正
+- 必須データが欠落している
+- PDUが破損している、またはdecodeできない
+- Runtimeがshutdown中など、ApplicationへGoal Requestを引き渡せない
+- RuntimeがGoal判断用Contextを確保できない内部障害
+
+これらはApplicationの業務判断ではありません。
+
+特に、同一`goal_id`の重複はRuntimeが検出し、Applicationへ新しいGoal Requestとして通知しません。
+
+## 8. Applicationによる受理・拒否
+
+Protocol上有効で、かつ新しい`goal_id`を持つGoal Requestは、Applicationへ通知します。
+
+Applicationは、Goal bodyおよび現在の実行状況に基づいて受理または拒否します。
+
+Applicationによる判断例は以下です。
+
+- Goal bodyが業務上妥当か
+- 対象ロボットやデバイスが実行可能状態か
+- 同時に何件のGoalを受理するか
+- 並列実行するか
+- 直列化またはキューへ入れるか
+- 必要な資源を確保できるか
+- 優先度やpreemptionをどう扱うか
+- 安全条件や権限条件を満たしているか
+
+Runtimeは、異なる`goal_id`を持つGoalを一律にsingle-goal制約で拒否しません。
+
+同時実行数、排他、BUSY、キュー容量などはApplication Policyです。
+
+## 9. RuntimeとApplicationの抽象境界
+
+具体的なAPIシグネチャは後続設計で決定しますが、Protocol上は次の双方向経路を必要とします。
+
+```text
+Runtime -> Application
+  Goal Request received(goal_id, goal_body)
+
+Application -> Runtime
+  accept(goal_id)
+  reject(goal_id, reason)
+```
+
+Applicationが`accept`または`reject`を返した後、Runtimeは同じ`goal_id`を持つGoal ResponseをClientへ返します。
+
+ApplicationがGoalを受理した場合、以後のFeedback、Cancel、Resultも同じ`goal_id`で処理します。
+
+## 10. Rejectionの識別
+
+Clientから見て、Protocol Runtimeによる拒否とApplicationによる拒否は、どちらもGoal Responseの`REJECTED`です。
+
+ただし、少なくとも次の二種類を識別できるデータ契約が必要です。
+
+```text
+Protocol / Runtime rejection
+  Goal Requestを正常なApplication判断へ渡せなかった
+
+Application rejection
+  Goal Requestは正常にApplicationへ届いたが、Applicationが受理しなかった
+```
+
+具体的に`reject_origin`を持たせるか、reject reason codeの名前空間を分けるかは後続のデータ契約で決定します。
+
+少なくとも、duplicate `goal_id`とApplicationのresource busyを同じ理由へ統合しません。
+
+## 11. Runtimeの責務
+
+RPC Runtimeは、複数Goalを扱える共通Protocol能力を提供します。
+
+- `goal_id`ごとのGoal Context管理
+- Goal RequestのProtocol検査
+- duplicate `goal_id`の検出
+- 有効なGoal RequestのApplicationへの通知
+- Applicationのaccept/reject応答のClientへの配送
 - Goal Response、Feedback、Cancel、Resultの相関
 - 異なるGoal間で状態やデータを混同しないこと
-- あるGoalの終了が、別のGoalを暗黙に終了させないこと
-- 複数Goalから発生するイベントを利用アプリケーションへ識別可能な形で通知すること
-- Protocol不正、重複ID、未知IDなどの検出
 - Transport固有の識別子をProtocol identityとして要求しないこと
 
 概念上、Runtimeは以下のような集合を管理します。
 
 ```text
-active_goals: Map<goal_id, GoalExecutionContext>
+pending_goals: Map<goal_id, PendingGoalContext>
+active_goals:  Map<goal_id, GoalExecutionContext>
 ```
 
-これは実装データ構造を指定するものではなく、複数Goalを`goal_id`単位で独立管理する必要性を示しています。
+これは実装データ構造を指定するものではありません。
 
-## 7. Applicationの責務
+Applicationの判断待ちと、受理後の実行中Goalを`goal_id`単位で相関できることを示しています。
 
-同時に何件のGoalを受理し、どのように処理するかは、Action Server ApplicationのPolicyです。
-
-Applicationは、例えば以下を選択できます。
-
-### 7.1 並列実行
-
-```text
-Goal A -> ACCEPT -> EXECUTING
-Goal B -> ACCEPT -> EXECUTING
-```
-
-### 7.2 直列実行・キュー
-
-```text
-Goal A -> ACCEPT -> EXECUTING
-Goal B -> ACCEPT -> QUEUED
-```
-
-### 7.3 排他による拒否
-
-```text
-Goal A -> ACCEPT
-Goal B -> REJECT(resource busy)
-```
-
-### 7.4 優先度またはpreemption
-
-```text
-Goal A -> EXECUTING
-Goal B -> higher priority
-Application decides whether to preempt A
-```
-
-Hakoniwa Action Protocolは、複数Goalを識別・相関・配送できる能力を提供しますが、上記の実行Policyを一律に決定しません。
-
-Application Policyに含まれるものの例は以下です。
-
-- 最大同時実行数
-- Goalの業務上の受理条件
-- 資源排他
-- キュー方式とキュー容量
-- 優先順位
-- preemption
-- 同じ対象物に対する競合解決
-- ロボットやデバイスの安全条件
-
-## 8. Runtime拒否とApplication拒否
-
-Goal Rejectionには、少なくとも二つの異なる原因があります。
-
-### 8.1 RuntimeまたはProtocolによる拒否
-
-RuntimeがApplicationへ渡す前に拒否できる候補です。
-
-- 不正なUUID
-- duplicate `goal_id`
-- Protocol version不整合
-- 破損したPDU
-- Server shutdown中
-- Runtime自身がGoal Contextを生成できない内部資源不足
-
-### 8.2 Application Policyによる拒否
-
-Applicationが業務上の判断として拒否する候補です。
-
-- Goal bodyが業務上不正
-- 対象ロボットが実行可能状態ではない
-- 必要な資源を別Goalが使用中
-- Applicationの同時実行上限に到達
-- キューが満杯
-- 権限または運用Policyにより実行不可
-
-Runtime capacity failureとApplication Policy rejectionは、同じ`BUSY`へ安易に統合せず、後続のデータ契約で識別可能にすることを検討します。
-
-## 9. Transportとの境界
+## 12. Transportとの境界
 
 Transportは、Goal Request、Goal Response、Feedback、Cancel、Resultを配送します。
 
@@ -326,73 +342,31 @@ Protocolは、Transportに以下を要求しません。
 
 Transportが使用するEndpoint、connection、channel、client IDなどは、配送を実現するための情報です。
 
-それらをGoal ExecutionのProtocol identityへ含めません。
+それらをGoalのProtocol identityへ含めません。
 
-Transport上の接続失敗は、Goal RequestがAction Runtimeへ到達した後のGoal Rejectionとは別の失敗です。
-
-## 10. Goal Execution Context
-
-Runtimeは各Goal Executionについて、概念上、以下の情報を関連付けます。
-
-```text
-GoalExecutionContext
-  goal_id
-  action_type
-  goal body or its reference
-  protocol state
-  feedback sequence state
-  terminal status
-  result body or its reference
-```
-
-具体的にどのフィールドを保持するか、所有権、コピー方式、永続性は後続設計で決定します。
-
-重要なのは、`goal_id`を主キーとしてGoal Executionのライフサイクル全体を独立管理することです。
-
-Transport固有のrouteやconnection情報をRuntime内部で関連付けることはできますが、それは実装情報であり、Protocol上のGoal Execution identityではありません。
-
-## 11. データ関係
-
-概念上の中心関係は以下です。
-
-```text
-Action Type
-  1
-  |
-  | instantiated as
-  v
-Goal Execution (0..N)
-  identified by goal_id
-```
-
-Goal Executionの型はAction Typeによって決まり、Goal Executionそのものは`goal_id`で識別します。
-
-Goal、Feedback、Cancel、Resultは、同じ`goal_id`を使用してそのGoal Executionへ関連付けます。
-
-通信経路、Endpoint、接続、Client識別子は、この中心関係へ含めません。
-
-## 12. 今回の設計判断
+## 13. 今回の設計判断
 
 1. `goal_id`は128-bit UUIDとする。
 2. 通常のClientではAction Client RuntimeがGoal送信前に生成する。
 3. Adapterは外部で生成された互換UUIDを指定できる。
-4. Server RuntimeはUUIDの検査、重複検査、登録、相関、ライフサイクル管理を行う。
-5. `goal_id`はGoal Requestから終端Resultまで続くGoal Executionセッション全体の相関キーとする。
-6. 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionが同時に存在できる。
-7. 同じ`goal_id`を持つGoal Requestは新しいGoal Executionとして扱わない。
-8. Protocol上の独立したClient Session概念は導入しない。
-9. Endpoint、connection、channel、mux client IDなどの実現方式をGoal Executionの識別条件に含めない。
-10. RPC Runtimeは複数Goalを`goal_id`ごとに独立管理できる能力を提供する。
-11. Runtimeは一律のsingle-goal制約をProtocolへ埋め込まない。
-12. Goalの受理、並列実行、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
-13. Transport接続失敗、Runtime拒否、Application拒否を別の失敗として扱う。
+4. `goal_id`はGoal RequestからGoal Responseまで、受理後は終端Resultまで続くライフサイクル全体の相関キーとする。
+5. Server RuntimeはUUIDの検査、重複検査、登録、相関、ライフサイクル管理を行う。
+6. 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoalを同時に扱える。
+7. 同じ`goal_id`を持つGoal Requestは新しいGoalとして扱わない。
+8. Protocol上有効で新しい`goal_id`を持つGoal RequestはApplicationへ通知する。
+9. RuntimeはProtocol上処理不能なGoal Requestだけを自動拒否する。
+10. Goalの業務上の受理、並列実行、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
+11. Runtime拒否とApplication拒否を識別可能にする。
+12. Protocol上の独立したClient Session概念は導入しない。
+13. Endpoint、connection、channel、mux client IDなどの実現方式をGoalの識別条件に含めない。
 
-## 13. レビューで問答したい事項
+## 14. レビューで問答したい事項
 
 1. UUID versionをProtocolで固定する必要があるか。
-2. `goal_id`の一意性をシステム全体で要求するか、それともServer管理範囲での重複防止を規範とするか。
+2. `goal_id`の一意性をどの範囲まで要求するか。
 3. 終了済み`goal_id`をどの期間保持する必要があるか。
 4. 同じ`goal_id`を持つGoal Requestの再送を、重複エラーとするか冪等な再照会として扱うか。
-5. Applicationがキューへ入れたGoalを、Protocol上`ACCEPTED`とだけ表現するか、`QUEUED`状態を設けるか。
-6. Runtime内部資源不足とApplication同時実行上限を、Goal Response上で別理由として表現するか。
-7. TransportがGoalごとに経路を変更した場合でも、`goal_id`だけで相関できることをProtocol要件とするか。
+5. Protocol Runtimeによる拒否理由をどこまで標準化するか。
+6. Application rejection reasonをProtocol上どの形式で表現するか。
+7. `reject_origin`を明示的に持たせるか、reason codeによって区別するか。
+8. Applicationが応答しない場合のacceptance timeoutを、状態モデルまたはProtocolでどう扱うか。

--- a/docs/design/action/03-data-model.md
+++ b/docs/design/action/03-data-model.md
@@ -11,14 +11,15 @@
 
 - 1回のAction実行をどのように識別するか
 - 同一Action Typeに対する複数のGoal Executionをどう表現するか
-- 同一Client接続上で複数Goalをどう独立管理するか
-- RPC Runtime、Action Server Application、Transportの責務をどう分離するか
+- Goal、Feedback、Cancel、Resultをどのように相関するか
+- RPC RuntimeとAction Server Applicationの責務をどう分離するか
+- Protocolのデータモデルを通信経路や接続方式からどう独立させるか
 
-具体的なPDUのバイト配置、状態遷移、送受信順序、公開APIは後続文書で定義します。
+具体的なPDUのバイト配置、状態遷移、送受信順序、公開API、Transport実装は後続文書で定義します。
 
 ## 2. データモデルの基本単位
 
-Hakoniwa Actionでは、以下を別の概念として扱います。
+Hakoniwa Action Protocolの中心となる概念は、Action Type、Goal Execution、`goal_id`です。
 
 ### 2.1 Action Type
 
@@ -32,28 +33,7 @@ Action Typeは、実行可能な処理の型です。
 
 Action Type自体は、個別の実行状態を持ちません。
 
-### 2.2 Action Endpoint
-
-Action Endpointは、Action TypeをClientへ公開する論理的な通信先です。
-
-同じAction Typeを複数のEndpointで公開できます。
-
-```text
-robot1/move : MoveRobot
-robot2/move : MoveRobot
-```
-
-EndpointはAction Typeを公開する場所であり、単一のGoal Executionを表すものではありません。
-
-### 2.3 Client Session
-
-Client Sessionは、ClientとServer間のTransportまたはRPC上の接続・通信コンテキストです。
-
-Client SessionはGoal Executionの識別子ではありません。
-
-1つのClient Session上に、複数のGoal Executionが存在できます。
-
-### 2.4 Goal Execution
+### 2.2 Goal Execution
 
 Goal Executionは、Action Typeに対して行われる1回の具体的な実行です。
 
@@ -71,7 +51,23 @@ Goal Execution B
 
 同じAction Typeに対して、`goal_id`が異なれば別のGoal Executionです。
 
-Action EndpointとClient Sessionは、Goal Executionに関連する配送・通信コンテキストですが、Goal Executionの同一性を決める条件には含めません。
+### 2.3 Goal Executionセッション
+
+Goal Executionは、Goal Requestの送信から終端Resultまで継続する論理的な実行セッションです。
+
+このセッションは`goal_id`によって識別・相関します。
+
+```text
+Goal Request(goal_id = X)
+  -> Goal Response(goal_id = X)
+  -> Feedback(goal_id = X) 0..N
+  -> Cancel(goal_id = X) optional
+  -> Result(goal_id = X)
+```
+
+本設計では、これとは別に「Client Session」というProtocol概念を導入しません。
+
+TCP接続、共有メモリ接続、mux上のClient識別子などはTransportまたはRuntime実装上の情報であり、Goal ExecutionのProtocol identityではありません。
 
 ## 3. goal_id
 
@@ -89,6 +85,8 @@ Cancel Request(goal_id = X)
 Cancel Response(goal_id = X)
 Result(goal_id = X)
 ```
+
+`goal_id`は単なるRequest番号ではなく、Goal Executionのライフサイクル全体を束ねる相関キーです。
 
 ### 3.2 生成責任
 
@@ -124,7 +122,7 @@ Action Server Runtimeは、受信した`goal_id`について以下を担当し�
 - 実行中Goalとの重複検査
 - 必要に応じた終了済みGoalとの重複検査
 - Goal Execution Contextへの登録
-- Feedback、Cancel、Resultの相関
+- Goal Response、Feedback、Cancel、Resultの相関
 - Goal終了後の破棄または一定期間の保持
 
 `goal_id`の値をClient側で生成することと、Server側で一意性・ライフサイクルを管理することは矛盾しません。
@@ -185,9 +183,7 @@ MoveRobot
   Goal C: goal_id = UUID-C
 ```
 
-各Goalは、Feedback、Cancel、Result、Terminal Statusを独立して持ちます。
-
-同じ`goal_id`を持つGoal Requestは、新しいGoal Executionとして扱いません。その具体的な扱いを重複エラーとするか、再送または冪等な再照会とするかは後続のProtocol設計で決定します。
+各Goal Executionは、Goal Response、Feedback、Cancel、Result、Terminal Statusを独立して持ちます。
 
 ```text
 Goal A
@@ -200,36 +196,25 @@ Goal B
   Result B / CANCELED
 ```
 
-### 5.2 同一Clientからの複数Goal
+同じ`goal_id`を持つGoal Requestは、新しいGoal Executionとして扱いません。
 
-同一Client Sessionから送信された複数Goalも、異なる`goal_id`を持つ独立したGoal Executionとして表現できます。
+その具体的な扱いを重複エラーとするか、再送または冪等な再照会とするかは後続のProtocol設計で決定します。
 
-```text
-Client Session A
-  Goal A1: UUID-A1
-  Goal A2: UUID-A2
-  Goal A3: UUID-A3
-```
+### 5.2 実現方式からの独立
 
-Runtimeが一律に以下の制限を設ける設計にはしません。
+複数Goal Executionをどの通信経路で運ぶかは、Protocol上の同一性とは関係しません。
 
-- 1 Action Typeにつき1 active Goal
-- 1 Action Endpointにつき1 active Goal
-- 1 Client Sessionにつき1 active Goal
-
-この制限をProtocolへ埋め込むと、将来の並列実行、多重化、キューイング、複数ロボット操作などの利用形態を妨げるためです。
-
-### 5.3 複数Clientからの複数Goal
-
-異なるClient Sessionから、同じAction Endpointへ複数Goalを送信できます。
+以下はいずれも同じProtocolモデルで扱えます。
 
 ```text
-Client A -> Goal A
-Client B -> Goal B
-Client C -> Goal C
+1つの通信経路で複数Goalを配送する
+複数の通信経路からGoalを配送する
+TransportがGoalごとに異なる経路を選択する
 ```
 
-これらも`goal_id`ごとに独立して管理します。
+Protocolが要求するのは、各メッセージを`goal_id`で正しいGoal Executionへ相関できることです。
+
+Endpoint、socket、connection、channel、mux client IDなどをGoal Executionの識別条件には含めません。
 
 ## 6. Runtimeの責務
 
@@ -241,6 +226,7 @@ RPC Runtimeは、複数のGoal Executionを扱える共通Protocol能力を提�
 - あるGoalの終了が、別のGoalを暗黙に終了させないこと
 - 複数Goalから発生するイベントを利用アプリケーションへ識別可能な形で通知すること
 - Protocol不正、重複ID、未知IDなどの検出
+- Transport固有の識別子をProtocol identityとして要求しないこと
 
 概念上、Runtimeは以下のような集合を管理します。
 
@@ -285,7 +271,7 @@ Goal B -> higher priority
 Application decides whether to preempt A
 ```
 
-Hakoniwa Action Protocolは、複数Goalを識別し配送できる能力を提供しますが、上記の実行Policyを一律に決定しません。
+Hakoniwa Action Protocolは、複数Goalを識別・相関・配送できる能力を提供しますが、上記の実行Policyを一律に決定しません。
 
 Application Policyに含まれるものの例は以下です。
 
@@ -326,55 +312,23 @@ Applicationが業務上の判断として拒否する候補です。
 
 Runtime capacity failureとApplication Policy rejectionは、同じ`BUSY`へ安易に統合せず、後続のデータ契約で識別可能にすることを検討します。
 
-## 9. Transportとの分離
+## 9. Transportとの境界
 
-### 9.1 maxClients
+Transportは、Goal Request、Goal Response、Feedback、Cancel、Resultを配送します。
 
-`tcp_mux`の`maxClients`は、Transportが同時に収容できるClient接続数の上限です。
+Protocolは、Transportに以下を要求しません。
 
-```text
-maxClients
-  = transport client connection capacity
-```
+- 1 Goalにつき1接続
+- 1 Clientにつき1接続
+- 1 Action Typeにつき1 Endpoint
+- 特定のmultiplex方式
+- 特定の接続上限
 
-これは以下を意味しません。
+Transportが使用するEndpoint、connection、channel、client IDなどは、配送を実現するための情報です。
 
-```text
-maxClients
-  != maximum active goals
-  != application concurrency limit
-```
+それらをGoal ExecutionのProtocol identityへ含めません。
 
-1つのClient Session上に複数Goalを多重化できるため、active Goal数が`maxClients`を上回ることもProtocol上はあり得ます。
-
-```text
-maxClients = 2
-
-Client A
-  Goal A1
-  Goal A2
-  Goal A3
-
-Client B
-  Goal B1
-  Goal B2
-
-active goals = 5
-```
-
-### 9.2 Transport capacity failure
-
-Transportの接続上限によってClientが接続できない場合、そのClientはGoal Requestを送信する段階へ到達していません。
-
-したがって、これはGoal Rejectionとは別の失敗です。
-
-```text
-Transport connection rejected
-  -> no Goal Execution created
-
-Goal rejected by Application
-  -> Goal Request reached Action Server
-```
+Transport上の接続失敗は、Goal RequestがAction Runtimeへ到達した後のGoal Rejectionとは別の失敗です。
 
 ## 10. Goal Execution Context
 
@@ -383,9 +337,7 @@ Runtimeは各Goal Executionについて、概念上、以下の情報を関連�
 ```text
 GoalExecutionContext
   goal_id
-  action_endpoint
   action_type
-  client/session reference
   goal body or its reference
   protocol state
   feedback sequence state
@@ -395,11 +347,13 @@ GoalExecutionContext
 
 具体的にどのフィールドを保持するか、所有権、コピー方式、永続性は後続設計で決定します。
 
-重要なのは、状態管理の主キーをClient Sessionだけにせず、`goal_id`を中心に各Goalを独立管理することです。
+重要なのは、`goal_id`を主キーとしてGoal Executionのライフサイクル全体を独立管理することです。
+
+Transport固有のrouteやconnection情報をRuntime内部で関連付けることはできますが、それは実装情報であり、Protocol上のGoal Execution identityではありません。
 
 ## 11. データ関係
 
-概念上の関係は以下です。
+概念上の中心関係は以下です。
 
 ```text
 Action Type
@@ -409,25 +363,13 @@ Action Type
   v
 Goal Execution (0..N)
   identified by goal_id
-
-Action Endpoint
-  1
-  |
-  | routes
-  v
-Goal Execution (0..N)
-
-Client Session
-  1
-  |
-  | submits
-  v
-Goal Execution (0..N)
 ```
 
-Goal Executionの型はAction Typeによって決まり、第一識別子は`goal_id`です。
+Goal Executionの型はAction Typeによって決まり、Goal Executionそのものは`goal_id`で識別します。
 
-Action EndpointとClient SessionはGoal Executionに関連付けられますが、配送・通信コンテキストであり、Goal Executionの同一性を決めません。
+Goal、Feedback、Cancel、Resultは、同じ`goal_id`を使用してそのGoal Executionへ関連付けます。
+
+通信経路、Endpoint、接続、Client識別子は、この中心関係へ含めません。
 
 ## 12. 今回の設計判断
 
@@ -435,13 +377,15 @@ Action EndpointとClient SessionはGoal Executionに関連付けられますが�
 2. 通常のClientではAction Client RuntimeがGoal送信前に生成する。
 3. Adapterは外部で生成された互換UUIDを指定できる。
 4. Server RuntimeはUUIDの検査、重複検査、登録、相関、ライフサイクル管理を行う。
-5. 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionが同時に存在できる。
-6. Action EndpointおよびClient Sessionは配送・通信コンテキストであり、Goal Executionの識別条件には含めない。
-7. RPC Runtimeは複数Goalを`goal_id`ごとに独立管理できる能力を提供する。
-8. Runtimeは一律のsingle-goal制約をProtocolへ埋め込まない。
-9. Goalの受理、並列実行、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
-10. `tcp_mux.maxClients`はTransport接続容量であり、active Goal数やApplication同時実行数とは別概念とする。
-11. Transport接続失敗、Runtime拒否、Application拒否を別の失敗として扱う。
+5. `goal_id`はGoal Requestから終端Resultまで続くGoal Executionセッション全体の相関キーとする。
+6. 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionが同時に存在できる。
+7. 同じ`goal_id`を持つGoal Requestは新しいGoal Executionとして扱わない。
+8. Protocol上の独立したClient Session概念は導入しない。
+9. Endpoint、connection、channel、mux client IDなどの実現方式をGoal Executionの識別条件に含めない。
+10. RPC Runtimeは複数Goalを`goal_id`ごとに独立管理できる能力を提供する。
+11. Runtimeは一律のsingle-goal制約をProtocolへ埋め込まない。
+12. Goalの受理、並列実行、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
+13. Transport接続失敗、Runtime拒否、Application拒否を別の失敗として扱う。
 
 ## 13. レビューで問答したい事項
 
@@ -451,5 +395,4 @@ Action EndpointとClient SessionはGoal Executionに関連付けられますが�
 4. 同じ`goal_id`を持つGoal Requestの再送を、重複エラーとするか冪等な再照会として扱うか。
 5. Applicationがキューへ入れたGoalを、Protocol上`ACCEPTED`とだけ表現するか、`QUEUED`状態を設けるか。
 6. Runtime内部資源不足とApplication同時実行上限を、Goal Response上で別理由として表現するか。
-7. Client Session切断時に、そのClientが送信したGoalを継続するかCancelするかを、Protocol、設定、Applicationのどこで決めるか。
-8. 1つのClient Session上で複数Goalイベントを配送する際、順序保証をGoal単位に限定するか。
+7. TransportがGoalごとに経路を変更した場合でも、`goal_id`だけで相関できることをProtocol要件とするか。

--- a/docs/design/action/README.md
+++ b/docs/design/action/README.md
@@ -23,8 +23,10 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - Actionは単に応答時間の長いService RPCではなく、`goal_id`で識別されるGoal実行セッションとして扱います。
 - 1回のGoal Executionは128-bit UUIDの`goal_id`で識別します。
 - `goal_id`は原則としてAction Client RuntimeがGoal送信前に生成し、Server Runtimeが重複検査とlifecycle管理を行います。
-- 同一Action Typeおよび同一Endpointに、複数のGoal Executionが同時に存在することをProtocol上許容します。
+- 同一Action Type、同一Endpoint、同一Client Sessionに、複数のGoal Executionが同時に存在することをProtocol上許容します。
+- RPC Runtimeは、複数Goalを`goal_id`ごとに独立して相関・配送・状態管理できる能力を提供します。
 - Goalを並列実行するか、直列化するか、キューへ入れるか、拒否するかはAction Server Applicationの実行ポリシーとします。
+- Runtimeは一律の「1 Actionにつき1 Goal」または「1 Clientにつき1 Goal」という制約をProtocolへ埋め込みません。
 - `tcp_mux`の`maxClients`はTransportのClient接続数上限であり、Actionの同時実行数とは定義しません。
 - Feedbackは0回以上送信できる非終端通知とします。
 - Resultのデータと、Succeeded、Canceled、Abortedなどの終端状態を区別します。
@@ -38,11 +40,11 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 
 1. [基本概念](01-concepts.md)
 2. [責務境界](02-responsibility-boundaries.md)
+3. [データモデル](03-data-model.md)
 
 ### 後続で追加する文書
 
 ```text
-03-data-model.md
 04-state-model.md
 05-protocol.md
 06-error-and-race-semantics.md
@@ -58,16 +60,17 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 
 ## 現時点の設計判断
 
-以下は、今回のレビューで合意した方向性です。後続のデータモデル、状態モデル、API設計では、この前提を狭めない形で具体化します。
+以下は、これまでのレビューで合意した方向性です。後続の状態モデル、Protocol、API設計では、この前提を狭めない形で具体化します。
 
 - 1回のAction実行を128-bit UUIDの`goal_id`で識別する。
 - 通常のHakoniwa ClientではAction Client Runtimeが`goal_id`を生成する。
 - ROS BridgeなどのAdapterは、外部で生成された互換UUIDを指定できる。
-- Server Runtimeは`goal_id`の重複検査、登録、状態管理を担当する。
-- 同一Action Typeの複数Goal ExecutionをProtocol上許容する。
+- Server Runtimeは`goal_id`の形式検査、重複検査、登録、相関、状態管理を担当する。
+- 同一Action Type、同一Endpoint、同一Client Sessionの複数Goal ExecutionをProtocol上許容する。
 - RPC Runtimeは各Goalを`goal_id`ごとに独立管理する。
 - 同時実行数、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
 - `maxClients`とAction同時実行能力を分離する。
+- Transport接続失敗、Runtime拒否、Application拒否を異なる失敗として扱う。
 - Action Request、Action Response、Action FeedbackをServiceとは独立したPDU契約として定義する。
 - Feedbackに`sequence_no`を持たせる。
 - 汎用的な進捗率を共通ヘッダへ入れず、Action固有のFeedback bodyへ置く。
@@ -77,8 +80,11 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 
 - UUID versionと一意性を要求する範囲
 - 終了済み`goal_id`を保持する期間
+- 同じ`goal_id`を持つGoal Request再送の扱い
 - Goalの受理前に届いたCancelの扱い
 - Applicationがキューへ入れたGoalについて、`ACCEPTED`、`QUEUED`、`EXECUTING`をProtocol上区別するか
+- Client Session切断時にGoal Executionを継続するかCancelするか
+- 同一Client Session上の複数Goalイベントに対する順序保証
 - Cancel ResponseとCanceled Resultの役割分担
 - Resultとterminal statusをAPI上でどのように返すか
 - Feedbackのキュー方式、容量、欠落および順序の扱い
@@ -92,17 +98,20 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - RPC Action対応: #21
 - 設計文書全体: #44
 - 概念と責務境界: #45
+- Goal identityと複数Goalデータモデル: #48
 - Registry Action生成: hakoniwalab/hakoniwa-pdu-registry#17
 - ROS 2 Service/Action Bridge: hakoniwalab/hakoniwa-pdu-ros#1
 
-## レビュー方針
+## 現在のレビュー方針
 
-今回の初稿では、実装APIや具体的な状態遷移を確定しません。まず、以下について合意することを目的とします。
+今回のレビューでは、前段で合意した概念と責務境界を、複数Goalを狭めないデータモデルとして具体化します。
 
-1. Actionをどのような抽象概念として扱うか。
-2. Goal、Feedback、Result、Cancelをどのように区別するか。
-3. Registry、RPC、ROS Bridge、利用アプリケーションの責務をどこで分けるか。
-4. 同一Action Typeの複数GoalをProtocolとRuntimeでどのように独立管理するか。
-5. Goalの実行ポリシーをApplication境界へどのように渡すか。
+主な確認事項は以下です。
 
-これらが合意できた後、データモデルと状態モデルの設計へ進みます。
+1. `goal_id`をClient Runtime生成、Server Runtime管理とする責務分担。
+2. 同一Action Type、同一Endpoint、同一Client Sessionで複数Goal Executionを許容すること。
+3. RPC Runtimeが複数Goalを独立管理できる共通能力を持つこと。
+4. Goalの並列実行、直列化、キュー、排他、優先度、preemptionをApplication Policyとすること。
+5. `tcp_mux.maxClients`をTransport接続容量として、active Goal数と分離すること。
+
+このデータモデルが合意できた後、各Goal Executionがどのように状態遷移するかを`04-state-model.md`で設計します。

--- a/docs/design/action/README.md
+++ b/docs/design/action/README.md
@@ -20,15 +20,15 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 ## 基本方針
 
 - ActionはROS 2固有機能ではなく、箱庭で利用できる独立した通信・実行ライフサイクルとして定義します。
-- Actionは単に応答時間の長いService RPCではなく、`goal_id`で識別されるGoal実行セッションとして扱います。
+- Actionは単に応答時間の長いService RPCではなく、`goal_id`で識別されるGoal Executionセッションとして扱います。
 - 1回のGoal Executionは128-bit UUIDの`goal_id`で識別します。
 - `goal_id`は原則としてAction Client RuntimeがGoal送信前に生成し、Server Runtimeが重複検査とlifecycle管理を行います。
 - 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionが同時に存在することをProtocol上許容します。
-- Action EndpointおよびClient Sessionは配送・通信コンテキストであり、Goal Executionの同一性を決める条件には使用しません。
+- Goal、Goal Response、Feedback、Cancel、Resultは、通信経路や接続方法に依存せず`goal_id`で相関します。
 - RPC Runtimeは、複数Goalを`goal_id`ごとに独立して相関・配送・状態管理できる能力を提供します。
 - Goalを並列実行するか、直列化するか、キューへ入れるか、拒否するかはAction Server Applicationの実行ポリシーとします。
-- Runtimeは一律の「1 Actionにつき1 Goal」または「1 Clientにつき1 Goal」という制約をProtocolへ埋め込みません。
-- `tcp_mux`の`maxClients`はTransportのClient接続数上限であり、Actionの同時実行数とは定義しません。
+- Runtimeは一律の「1 Action Typeにつき1 Goal」という制約をProtocolへ埋め込みません。
+- Endpoint、接続、multiplex、transport capacityなどの実現方式はProtocolの識別モデルから分離します。
 - Feedbackは0回以上送信できる非終端通知とします。
 - Resultのデータと、Succeeded、Canceled、Abortedなどの終端状態を区別します。
 - Cancel要求、Cancel受理、Canceled終端を同一概念として扱いません。
@@ -67,11 +67,12 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - 通常のHakoniwa ClientではAction Client Runtimeが`goal_id`を生成する。
 - ROS BridgeなどのAdapterは、外部で生成された互換UUIDを指定できる。
 - Server Runtimeは`goal_id`の形式検査、重複検査、登録、相関、状態管理を担当する。
+- `goal_id`は、Goal Requestから終端Resultまで続くGoal Executionセッションの相関キーである。
 - 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal ExecutionをProtocol上許容する。
-- Action EndpointおよびClient SessionはGoal Executionの配送・通信コンテキストとして関連付けるが、識別条件には含めない。
+- 同じ`goal_id`を持つGoal Requestは、新しいGoal Executionとして扱わない。
 - RPC Runtimeは各Goalを`goal_id`ごとに独立管理する。
 - 同時実行数、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
-- `maxClients`とAction同時実行能力を分離する。
+- Endpoint、Client接続、multiplex、transport capacityはProtocolの識別モデルに含めない。
 - Transport接続失敗、Runtime拒否、Application拒否を異なる失敗として扱う。
 - Action Request、Action Response、Action FeedbackをServiceとは独立したPDU契約として定義する。
 - Feedbackに`sequence_no`を持たせる。
@@ -85,8 +86,6 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - 同じ`goal_id`を持つGoal Request再送の扱い
 - Goalの受理前に届いたCancelの扱い
 - Applicationがキューへ入れたGoalについて、`ACCEPTED`、`QUEUED`、`EXECUTING`をProtocol上区別するか
-- Client Session切断時にGoal Executionを継続するかCancelするか
-- 同一Client Session上の複数Goalイベントに対する順序保証
 - Cancel ResponseとCanceled Resultの役割分担
 - Resultとterminal statusをAPI上でどのように返すか
 - Feedbackのキュー方式、容量、欠落および順序の扱い
@@ -106,15 +105,15 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 
 ## 現在のレビュー方針
 
-今回のレビューでは、前段で合意した概念と責務境界を、複数Goalを狭めないデータモデルとして具体化します。
+今回のレビューでは、前段で合意した概念と責務境界を、実現方式に依存しない複数Goalのデータモデルとして具体化します。
 
 主な確認事項は以下です。
 
 1. `goal_id`をClient Runtime生成、Server Runtime管理とする責務分担。
-2. 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionを許容すること。
-3. Action EndpointおよびClient Sessionを、Goal Executionの識別条件ではなく配送・通信コンテキストとして扱うこと。
-4. RPC Runtimeが複数Goalを独立管理できる共通能力を持つこと。
-5. Goalの並列実行、直列化、キュー、排他、優先度、preemptionをApplication Policyとすること。
-6. `tcp_mux.maxClients`をTransport接続容量として、active Goal数と分離すること。
+2. `goal_id`をGoal Executionセッション全体の相関キーとすること。
+3. 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionを許容すること。
+4. EndpointやClient接続などの実現方式をProtocolの識別モデルへ持ち込まないこと。
+5. RPC Runtimeが複数Goalを独立管理できる共通能力を持つこと。
+6. Goalの並列実行、直列化、キュー、排他、優先度、preemptionをApplication Policyとすること。
 
 このデータモデルが合意できた後、各Goal Executionがどのように状態遷移するかを`04-state-model.md`で設計します。

--- a/docs/design/action/README.md
+++ b/docs/design/action/README.md
@@ -23,7 +23,8 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - Actionは単に応答時間の長いService RPCではなく、`goal_id`で識別されるGoal実行セッションとして扱います。
 - 1回のGoal Executionは128-bit UUIDの`goal_id`で識別します。
 - `goal_id`は原則としてAction Client RuntimeがGoal送信前に生成し、Server Runtimeが重複検査とlifecycle管理を行います。
-- 同一Action Type、同一Endpoint、同一Client Sessionに、複数のGoal Executionが同時に存在することをProtocol上許容します。
+- 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionが同時に存在することをProtocol上許容します。
+- Action EndpointおよびClient Sessionは配送・通信コンテキストであり、Goal Executionの同一性を決める条件には使用しません。
 - RPC Runtimeは、複数Goalを`goal_id`ごとに独立して相関・配送・状態管理できる能力を提供します。
 - Goalを並列実行するか、直列化するか、キューへ入れるか、拒否するかはAction Server Applicationの実行ポリシーとします。
 - Runtimeは一律の「1 Actionにつき1 Goal」または「1 Clientにつき1 Goal」という制約をProtocolへ埋め込みません。
@@ -66,7 +67,8 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - 通常のHakoniwa ClientではAction Client Runtimeが`goal_id`を生成する。
 - ROS BridgeなどのAdapterは、外部で生成された互換UUIDを指定できる。
 - Server Runtimeは`goal_id`の形式検査、重複検査、登録、相関、状態管理を担当する。
-- 同一Action Type、同一Endpoint、同一Client Sessionの複数Goal ExecutionをProtocol上許容する。
+- 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal ExecutionをProtocol上許容する。
+- Action EndpointおよびClient SessionはGoal Executionの配送・通信コンテキストとして関連付けるが、識別条件には含めない。
 - RPC Runtimeは各Goalを`goal_id`ごとに独立管理する。
 - 同時実行数、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
 - `maxClients`とAction同時実行能力を分離する。
@@ -109,9 +111,10 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 主な確認事項は以下です。
 
 1. `goal_id`をClient Runtime生成、Server Runtime管理とする責務分担。
-2. 同一Action Type、同一Endpoint、同一Client Sessionで複数Goal Executionを許容すること。
-3. RPC Runtimeが複数Goalを独立管理できる共通能力を持つこと。
-4. Goalの並列実行、直列化、キュー、排他、優先度、preemptionをApplication Policyとすること。
-5. `tcp_mux.maxClients`をTransport接続容量として、active Goal数と分離すること。
+2. 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionを許容すること。
+3. Action EndpointおよびClient Sessionを、Goal Executionの識別条件ではなく配送・通信コンテキストとして扱うこと。
+4. RPC Runtimeが複数Goalを独立管理できる共通能力を持つこと。
+5. Goalの並列実行、直列化、キュー、排他、優先度、preemptionをApplication Policyとすること。
+6. `tcp_mux.maxClients`をTransport接続容量として、active Goal数と分離すること。
 
 このデータモデルが合意できた後、各Goal Executionがどのように状態遷移するかを`04-state-model.md`で設計します。

--- a/docs/design/action/README.md
+++ b/docs/design/action/README.md
@@ -20,15 +20,19 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 ## 基本方針
 
 - ActionはROS 2固有機能ではなく、箱庭で利用できる独立した通信・実行ライフサイクルとして定義します。
-- Actionは単に応答時間の長いService RPCではなく、`goal_id`で識別されるGoal Executionセッションとして扱います。
-- 1回のGoal Executionは128-bit UUIDの`goal_id`で識別します。
+- Actionは単に応答時間の長いService RPCではなく、`goal_id`で識別されるGoal lifecycleとして扱います。
+- 1回のGoalは128-bit UUIDの`goal_id`で識別します。
 - `goal_id`は原則としてAction Client RuntimeがGoal送信前に生成し、Server Runtimeが重複検査とlifecycle管理を行います。
-- 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionが同時に存在することをProtocol上許容します。
-- Goal、Goal Response、Feedback、Cancel、Resultは、通信経路や接続方法に依存せず`goal_id`で相関します。
+- 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoalを同時に扱えるProtocolとします。
+- Goal Request、Goal Response、Feedback、Cancel、Resultは、通信経路や接続方法に依存せず`goal_id`で相関します。
 - RPC Runtimeは、複数Goalを`goal_id`ごとに独立して相関・配送・状態管理できる能力を提供します。
-- Goalを並列実行するか、直列化するか、キューへ入れるか、拒否するかはAction Server Applicationの実行ポリシーとします。
+- Protocol上有効で新しい`goal_id`を持つGoal RequestはApplicationへ通知します。
+- Runtimeが自動拒否するのは、重複`goal_id`や不正messageなど、Applicationへ正常に引き渡せないProtocol上の理由に限定します。
+- Goalを受理するか、並列実行するか、直列化するか、キューへ入れるか、拒否するかはAction Server Applicationの実行ポリシーとします。
 - Runtimeは一律の「1 Action Typeにつき1 Goal」という制約をProtocolへ埋め込みません。
+- Protocol Runtimeによる拒否とApplicationによる拒否を識別可能にします。
 - Endpoint、接続、multiplex、transport capacityなどの実現方式はProtocolの識別モデルから分離します。
+- Protocol上の独立したClient Session概念は導入しません。
 - Feedbackは0回以上送信できる非終端通知とします。
 - Resultのデータと、Succeeded、Canceled、Abortedなどの終端状態を区別します。
 - Cancel要求、Cancel受理、Canceled終端を同一概念として扱いません。
@@ -63,16 +67,20 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 
 以下は、これまでのレビューで合意した方向性です。後続の状態モデル、Protocol、API設計では、この前提を狭めない形で具体化します。
 
-- 1回のAction実行を128-bit UUIDの`goal_id`で識別する。
+- 1回のGoalを128-bit UUIDの`goal_id`で識別する。
 - 通常のHakoniwa ClientではAction Client Runtimeが`goal_id`を生成する。
 - ROS BridgeなどのAdapterは、外部で生成された互換UUIDを指定できる。
 - Server Runtimeは`goal_id`の形式検査、重複検査、登録、相関、状態管理を担当する。
-- `goal_id`は、Goal Requestから終端Resultまで続くGoal Executionセッションの相関キーである。
-- 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal ExecutionをProtocol上許容する。
-- 同じ`goal_id`を持つGoal Requestは、新しいGoal Executionとして扱わない。
+- `goal_id`は、Goal RequestからGoal Responseまで、受理後は終端Resultまで続くGoal lifecycleの相関キーである。
+- 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoalをProtocol上許容する。
+- 同じ`goal_id`を持つGoal Requestは、新しいGoalとして扱わない。
 - RPC Runtimeは各Goalを`goal_id`ごとに独立管理する。
+- Protocol上有効で新しい`goal_id`を持つGoal RequestはApplicationへ通知する。
+- RuntimeはProtocol上処理不能なGoal Requestだけを自動拒否する。
 - 同時実行数、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
+- Runtime拒否とApplication拒否を識別可能にする。
 - Endpoint、Client接続、multiplex、transport capacityはProtocolの識別モデルに含めない。
+- Protocol上の独立したClient Session概念は導入しない。
 - Transport接続失敗、Runtime拒否、Application拒否を異なる失敗として扱う。
 - Action Request、Action Response、Action FeedbackをServiceとは独立したPDU契約として定義する。
 - Feedbackに`sequence_no`を持たせる。
@@ -84,6 +92,10 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - UUID versionと一意性を要求する範囲
 - 終了済み`goal_id`を保持する期間
 - 同じ`goal_id`を持つGoal Request再送の扱い
+- Protocol Runtimeによる拒否理由の標準化範囲
+- Application rejection reasonの表現方法
+- `reject_origin`を明示的に持たせるか、reason codeで区別するか
+- ApplicationがGoal Requestへ応答しない場合のacceptance timeout
 - Goalの受理前に届いたCancelの扱い
 - Applicationがキューへ入れたGoalについて、`ACCEPTED`、`QUEUED`、`EXECUTING`をProtocol上区別するか
 - Cancel ResponseとCanceled Resultの役割分担
@@ -110,10 +122,12 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 主な確認事項は以下です。
 
 1. `goal_id`をClient Runtime生成、Server Runtime管理とする責務分担。
-2. `goal_id`をGoal Executionセッション全体の相関キーとすること。
-3. 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoal Executionを許容すること。
-4. EndpointやClient接続などの実現方式をProtocolの識別モデルへ持ち込まないこと。
-5. RPC Runtimeが複数Goalを独立管理できる共通能力を持つこと。
-6. Goalの並列実行、直列化、キュー、排他、優先度、preemptionをApplication Policyとすること。
+2. `goal_id`をGoal lifecycle全体の相関キーとすること。
+3. 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoalを許容すること。
+4. 重複`goal_id`などProtocol上の不正はRuntimeが自動拒否すること。
+5. Protocol上有効で新しい`goal_id`を持つGoal RequestはApplicationへ通知すること。
+6. ApplicationがGoalの受理・拒否と実行Policyを決定すること。
+7. Runtime拒否とApplication拒否を識別可能にすること。
+8. EndpointやClient接続などの実現方式をProtocolの識別モデルへ持ち込まないこと。
 
-このデータモデルが合意できた後、各Goal Executionがどのように状態遷移するかを`04-state-model.md`で設計します。
+このデータモデルが合意できた後、各Goalがどのように状態遷移するかを`04-state-model.md`で設計します。


### PR DESCRIPTION
Closes #48
Related: #44, #21

## 概要

Hakoniwa Action Protocolのデータモデル初稿として、以下を追加・更新します。

```text
docs/design/action/
    README.md
    03-data-model.md
```

前回の概念・責務境界の議論を受けて、`goal_id`の生成・管理責任、同一Action Typeに対する複数Goal、およびGoal Requestの受理・拒否責務を、通信実現方式に依存しない形で具体化します。

## このPRで確定した設計判断

- 1回のGoalを128-bit UUIDの`goal_id`で識別する。
- 通常のClientではAction Client RuntimeがGoal送信前にUUIDを生成する。
- ROS BridgeなどのAdapterは外部生成UUIDを指定できる。
- Server RuntimeはUUIDの検査、重複検査、登録、相関、ライフサイクル管理を担当する。
- `goal_id`はGoal RequestからGoal Responseまで、受理後は終端Resultまで続くGoal lifecycle全体の相関キーとする。
- 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoalを同時に扱える。
- 同じ`goal_id`を持つGoal Requestは、新しいGoalとして扱わない。
- Protocol上有効で新しい`goal_id`を持つGoal RequestはApplicationへ通知する。
- Runtimeが自動拒否するのは、不正UUID、duplicate `goal_id`、不正messageなど、Applicationへ正常に引き渡せないProtocol上の理由に限定する。
- ApplicationはGoal body、資源状態、同時実行Policy、安全条件などに基づいてaccept/rejectを返す。
- Runtime拒否とApplication拒否を識別可能にする。
- duplicate `goal_id`とApplicationのresource busyを同じ拒否理由へ統合しない。
- Goalの並列実行、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
- Protocol上の独立したClient Session概念は導入しない。
- Endpoint、connection、channel、mux client IDなどの実現方式をGoal identityへ含めない。

## 抽象的な受理・拒否フロー

```text
Runtime -> Application
  Goal Request received(goal_id, goal_body)

Application -> Runtime
  accept(goal_id)
  reject(goal_id, reason)
```

RuntimeはApplicationの判断を、同じ`goal_id`を持つGoal ResponseとしてClientへ返します。

## 後続設計へ送る事項

以下は今回のデータモデルを変更せずに後続文書で決定できるため、本PRのマージ条件には含めません。

- UUID versionをProtocolで固定するか。
- `goal_id`の一意性を要求する具体的な範囲。
- 終了済み`goal_id`の保持期間。
- 同じ`goal_id`を持つGoal Request再送を、重複エラーまたは冪等な再照会のどちらとして扱うか。
- Runtime拒否とApplication拒否を`reject_origin`またはreason codeのどちらで表現するか。
- Applicationが応答しない場合のacceptance timeout。

## 対象外

- 状態機械の確定
- PDUのバイトレイアウト
- 通信メッセージの送受信順序
- Application向けAPIの具体的な関数シグネチャ
- キュー、優先度、preemptionの標準Policy
- RuntimeおよびTransport実装

今回のデータモデルと責務境界についてレビュー合意済みです。後続事項は状態モデル、Protocol、エラー・競合規約、API設計で具体化します。