### PR TITLE
Define Goal lifecycle state model

### DIFF
--- a/docs/design/action/04-state-model.md
+++ b/docs/design/action/04-state-model.md
@@ -5,449 +5,393 @@
 
 ## 1. 目的
 
-本書では、Hakoniwa Action Protocolにおける1つのGoal lifecycleの抽象状態と、その遷移規則を定義します。
+本書では、Hakoniwa Action Protocolにおける、accept済みGoalのRuntime状態とイベント処理規則を定義します。
 
-本状態モデルは、以下に依存しません。
-
-- TCP、共有メモリなどのTransport方式
-- Endpoint、connection、channel、mux client ID
-- C++、PythonなどのAPI表現
-- Application内部のthread、task、queue実装
-
-各Goalは`goal_id`によって独立して状態管理します。
-
-同一Action Typeに複数Goalが存在する場合も、あるGoalの状態遷移が別のGoalを暗黙に変化させることはありません。
-
-## 2. 前提
-
-本状態モデルは、前段の設計判断を前提とします。
-
-- 1回のGoalを128-bit UUIDの`goal_id`で識別する。
-- Goal Request、Goal Response、Feedback、Cancel、Resultを同じ`goal_id`で相関する。
-- 同一Action Typeに対して、異なる`goal_id`を持つ複数Goalを同時に扱える。
-- Protocol上有効で新しい`goal_id`を持つGoal RequestはApplicationへ通知する。
-- Goalをaccept/rejectするかはApplicationが判断する。
-- RuntimeはProtocol上処理不能なGoal Requestだけを自動拒否する。
-- Runtime拒否とApplication拒否を識別可能にする。
-- Goalの並列実行、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
-
-## 3. 状態モデルを二つのフェーズへ分ける
-
-Goal lifecycleは、以下の二つのフェーズへ分けて考えます。
-
-1. Goal Requestの受理判定フェーズ
-2. acceptされたGoalの実行フェーズ
+状態名を先に増やすのではなく、次のマトリクスを中心に設計します。
 
 ```text
-Goal Request lifecycle
-  PENDING_ACCEPTANCE
-    -> REJECTED
-    -> ACCEPTED
-
-Accepted Goal lifecycle
-  ACCEPTED
-    -> EXECUTING
-    -> terminal
+縦軸: 発生し得るイベント
+横軸: Goal Runtime state
+各セル: 判定、Action、次状態
 ```
 
-この分離により、Goal Requestが届いたことと、ApplicationがGoalの実行を引き受けたことを区別します。
+この方法により、正常な状態遷移だけでなく、非同期処理によって生じる重複、競合、遅延イベントを明示的に検討します。
 
-## 4. 受理判定フェーズ
+## 2. 適用範囲
 
-### 4.1 PENDING_ACCEPTANCE
+本状態モデルは、acceptされた1つのGoalを`goal_id`単位で管理するServer Runtimeのモデルです。
 
-`PENDING_ACCEPTANCE`は、Goal RequestがRuntimeへ到達し、accept/rejectがまだ確定していない状態です。
+以下は本状態モデルへ含めません。
 
-概念的な流れは以下です。
+- Action Type全体の状態
+- Application内部のworker、thread、task、queueの状態
+- Goal Requestのaccept/reject判定前の一時Context
+- Client Runtimeのローカルな送受信待ち状態
+- Transport接続そのものの状態
+
+同一Action Typeに複数Goalが存在する場合、それぞれが独立した状態を持ちます。
 
 ```text
-Goal Request received
-  -> Runtime validation
-  -> Application notification
-  -> Application decision
+Action Type A
+  goal_id = X : DOING
+  goal_id = Y : CANCELING
+  goal_id = Z : FINISHING
 ```
 
-Runtimeは、Goal RequestがProtocol上有効で新しい`goal_id`を持つ場合、Applicationへ通知します。
+## 3. Goalインスタンスの生成と破棄
 
-Applicationは、以下のような条件に基づいてaccept/rejectを判断します。
-
-- Goal bodyの妥当性
-- 対象資源の状態
-- 同時実行数
-- queue容量
-- 排他条件
-- 安全条件
-- 権限または運用Policy
-
-### 4.2 REJECTED
-
-`REJECTED`は、Goal Requestを受理しなかったことを表します。
-
-拒否には少なくとも二つのoriginがあります。
-
-```text
-Runtime rejection
-Application rejection
-```
-
-Runtime rejectionの候補は以下です。
-
-- 不正な`goal_id`
-- duplicate `goal_id`
-- 不正message
-- 対応できないProtocol version
-- Goal Contextを生成できないRuntime内部障害
-
-Application rejectionの候補は以下です。
-
-- Goal bodyが業務上不正
-- 必要な資源が使用中
-- Applicationの同時実行上限
-- queue満杯
-- 安全条件を満たさない
-
-Runtime rejectionとApplication rejectionは、同じ拒否理由へ統合しません。
-
-### 4.3 REJECTEDとGoal Execution成立の関係
-
-本初稿では、`REJECTED`を「acceptされたGoal Executionの終端状態」には含めません。
+Goal RequestがRuntimeおよびApplicationの検査を通過し、Applicationがacceptした時点で、Goalインスタンスを生成します。
 
 ```text
 Goal Request
-  -> REJECTED
-  -> accepted Goal Executionは成立しない
+  -> Runtime validation
+  -> Application decision
+       -> reject: Goalインスタンスを生成しない
+       -> accept: GoalインスタンスをDOINGで生成する
 ```
 
-ただし、Clientから見れば、`goal_id`に対するGoal Request lifecycleは`REJECTED`で完了します。
-
-したがって、以下を区別します。
+初期状態を表す実体stateは設けません。状態図上ではinitial pseudo-stateから`DOING`へ遷移します。
 
 ```text
-Goal Request lifecycle terminal
-  REJECTED
-
-Accepted Goal terminal
-  SUCCEEDED / CANCELED / ABORTED / ERROR
+[*] -> DOING
 ```
 
-この整理はレビュー対象です。
-
-### 4.4 ACCEPTED
-
-`ACCEPTED`は、ApplicationがGoalを受理し、そのGoal lifecycleを継続する責任を引き受けたことを表します。
-
-`ACCEPTED`は、必ずしも処理が実行中であることを意味しません。
+Goalの終端Result送信処理が完了し、Runtimeの保持責務が終了した時点でGoalインスタンスを破棄します。
 
 ```text
-ACCEPTED
-  = Application has accepted responsibility for the Goal
-  != necessarily executing now
+FINISHING -> [*]
 ```
 
-この区別により、ApplicationはGoalを受理した後、以下のPolicyを選択できます。
+インスタンス不存在は、`RELEASED`などの状態値では表現しません。
 
-- 直ちに実行する
-- queueへ入れる
-- 資源解放を待つ
-- 優先度制御を行う
+## 4. MUST状態
 
-## 5. 受理後の実行フェーズ
-
-### 5.1 EXECUTING
-
-`EXECUTING`は、ApplicationがGoal bodyに対応する処理を実行している状態です。
+Runtimeはaccept済みGoalについて、少なくとも次の3状態を管理します。
 
 ```text
-ACCEPTED -> EXECUTING
-```
-
-Applicationが実行開始をRuntimeへ明示的に通知する必要があるか、Runtimeがaccept時に自動的に`EXECUTING`へ遷移するかは、後続のAPI設計で決定します。
-
-ただし、Protocol上`ACCEPTED`と`EXECUTING`を区別する場合、Runtimeがその遷移を認識できる経路は必要です。
-
-### 5.2 QUEUEDを独立状態とするか
-
-ApplicationがGoalを受理した後、実行開始までqueueで待機させる場合があります。
-
-候補は二つあります。
-
-#### 案A: ACCEPTEDへ包含する
-
-```text
-ACCEPTED
-  includes accepted-but-not-executing
-```
-
-利点:
-
-- Protocol状態が単純になる。
-- queue方式をApplication内部へ閉じ込められる。
-
-欠点:
-
-- Clientはqueue待ちかどうかを共通状態から判断できない。
-
-#### 案B: QUEUEDを追加する
-
-```text
-ACCEPTED -> QUEUED -> EXECUTING
-```
-
-利点:
-
-- Clientが実行待ちを観測できる。
-
-欠点:
-
-- Application固有の実行PolicyがProtocol状態へ入り込む可能性がある。
-
-初稿では`QUEUED`を確定状態へ含めず、レビュー対象とします。
-
-## 6. Cancelの状態モデル
-
-### 6.1 Cancel Requestは終端状態ではない
-
-Cancel Requestを受信しただけでは、Goalは`CANCELED`になりません。
-
-以下を別の出来事として扱います。
-
-1. Cancel Requestを受信する
-2. ApplicationがCancelをaccept/rejectする
-3. Applicationが実際の処理を停止する
-4. Goalが`CANCELED`で終端する
-
-```text
-Cancel Request
-  != Cancel accepted
-  != execution stopped
-  != CANCELED terminal
-```
-
-### 6.2 Cancelが拒否された場合
-
-CancelがApplicationによって拒否された場合、Goalの実行状態は維持します。
-
-```text
-EXECUTING
-  -> Cancel Request
-  -> Cancel rejected
-  -> EXECUTING
-```
-
-Cancel Responseは、Cancel Requestに対する判断を返しますが、Goal Resultではありません。
-
-### 6.3 Cancelが受理された場合
-
-Cancelが受理された後、Applicationが停止処理を行う期間を表現する必要があります。
-
-候補状態は以下です。
-
-```text
-CANCEL_REQUESTED
+DOING
 CANCELING
+FINISHING
 ```
 
-候補となる遷移は以下です。
+### 4.1 DOING
+
+ApplicationがGoalを実行している状態です。
+
+この状態では、次の操作が発生し得ます。
+
+- Feedback発行
+- 通常完了
+- 異常終了
+- Cancel Request受信
+- Cancelのaccept/reject判断
+
+### 4.2 CANCELING
+
+ApplicationがCancel Requestをacceptし、非同期の停止処理を行っている状態です。
+
+Cancel Requestを受信しただけでは`CANCELING`へ遷移しません。ApplicationがCancelをacceptした時点で遷移します。
 
 ```text
-EXECUTING
+DOING
+  -> Cancel Request received
+  -> Application notified
+  -> Application accepts cancel
   -> CANCELING
-  -> CANCELED
 ```
 
-ただし、`CANCEL_REQUESTED`または`CANCELING`をProtocol公開状態とするか、Runtime/Application内部状態とするかはレビュー対象です。
+ApplicationがCancelをrejectした場合は`DOING`を維持します。
 
-### 6.4 CANCELEDへの遷移
+### 4.3 FINISHING
 
-`CANCELED`は、Cancel Requestを受理しただけでなく、ApplicationがGoal処理を停止し、Canceled Resultを確定した時点の終端状態です。
+Applicationが終端statusおよびResult bodyを確定し、RuntimeがResult送信とGoalインスタンス破棄を処理している状態です。
 
 ```text
-Cancel accepted
-  -> stop processing
-  -> produce Result
-  -> CANCELED
+DOING      -> FINISHING
+CANCELING  -> FINISHING
 ```
 
-## 7. 終端状態
+`FINISHING`は、Applicationの完了通知とResult送信完了の間に到着するFeedback、Cancel、重複完了などを制御するために必要です。
 
-acceptされたGoalは、最終的に一つの終端状態へ遷移します。
+## 5. 基本状態遷移
 
-初稿では以下を候補とします。
+### 5.1 通常完了
 
 ```text
-SUCCEEDED
-CANCELED
-ABORTED
-ERROR
+[*]
+  -> DOING
+  -> FINISHING
+  -> [*]
 ```
 
-終端後に、別の終端状態へ遷移してはなりません。
+### 5.2 Cancel完了
 
 ```text
-terminal -> terminal transition is forbidden
+[*]
+  -> DOING
+  -> CANCELING
+  -> FINISHING
+  -> [*]
 ```
 
-### 7.1 SUCCEEDED
-
-ApplicationがGoalの意図した処理を正常に完了したことを表します。
-
-### 7.2 CANCELED
-
-Cancel Requestが受理され、Applicationが処理を停止して終端したことを表します。
-
-### 7.3 ABORTED
-
-ApplicationがGoalを受理した後、業務上または実行上の理由により完了できず、処理を終了したことを表します。
-
-例:
-
-- 対象ロボットが実行不能状態になった
-- Goal達成条件を満たせなくなった
-- Applicationが安全上の理由で処理を中止した
-
-### 7.4 ERROR
-
-RuntimeまたはProtocol上の障害により、Goal lifecycleを正常に継続できなくなったことを表す候補です。
-
-例:
-
-- Runtime内部状態の破損
-- ResultをProtocol上生成または配送できない
-- 必須のProtocol invariant違反
-
-`ERROR`をClientへ公開する終端状態とするか、通信エラーとしてGoalの終端状態とは別に扱うかはレビュー対象です。
-
-## 8. 基本状態遷移
-
-初稿の全体像は以下です。
+### 5.3 Cancel拒否
 
 ```text
-                         +-> REJECTED
-                         |
-PENDING_ACCEPTANCE -----+
-                         |
-                         +-> ACCEPTED
-                               |
-                               +-> EXECUTING
-                               |      |
-                               |      +-> SUCCEEDED
-                               |      +-> ABORTED
-                               |      +-> ERROR
-                               |      |
-                               |      +-> Cancel Request
-                               |             |
-                               |             +-> rejected -> EXECUTING
-                               |             |
-                               |             +-> accepted -> CANCELING -> CANCELED
-                               |
-                               +-> terminal before execution?
+DOING
+  -> Cancel Request
+  -> Application rejects cancel
+  -> DOING
 ```
 
-`ACCEPTED`から実行開始前に`ABORTED`または`CANCELED`へ遷移できるかは、レビュー対象です。
+## 6. イベント発生元
 
-例えば、queue待ちのGoalにCancel Requestが届いた場合、実行開始せずに`CANCELED`へ遷移できる可能性があります。
+イベントは、発生元ごとに整理します。
 
-## 9. RuntimeとApplicationの責務
+### 6.1 Server Application起因
 
-### 9.1 Runtime
+- `PUBLISH_FEEDBACK(goal_id, feedback_body)`
+- `COMPLETE_SUCCEEDED(goal_id, result_body)`
+- `COMPLETE_CANCELED(goal_id, result_body)`
+- `COMPLETE_ABORTED(goal_id, result_body)`
+- `ACCEPT_CANCEL(goal_id)`
+- `REJECT_CANCEL(goal_id, reason)`
 
-Runtimeは以下を担当します。
+### 6.2 Client / Protocol起因
 
-- `goal_id`ごとのProtocol状態保持
-- 状態遷移要求の検査
-- 許可されない遷移の拒否
-- Runtime rejectionの処理
-- Applicationのaccept/reject判断をGoal Responseへ反映
-- Feedback、Cancel、Resultを現在状態と相関すること
-- 終端後の状態を変更しないこと
-- 複数Goalの状態を混同しないこと
+- `CANCEL_REQUEST_RECEIVED(goal_id)`
+- `DUPLICATE_CANCEL_REQUEST_RECEIVED(goal_id)`
+- `DUPLICATE_GOAL_REQUEST_RECEIVED(goal_id)`
+- `UNKNOWN_GOAL_ID_REQUEST_RECEIVED(goal_id)`
 
-### 9.2 Application
+### 6.3 Server Runtime / Transport起因
 
-Applicationは以下を判断します。
+- `FEEDBACK_SEND_COMPLETED(goal_id)`
+- `FEEDBACK_SEND_FAILED(goal_id)`
+- `RESULT_SEND_COMPLETED(goal_id)`
+- `RESULT_SEND_FAILED(goal_id)`
+- `TRANSPORT_DISCONNECTED`
+- `APPLICATION_RESPONSE_TIMEOUT(goal_id)`
 
-- Goalをaccept/rejectするか
-- acceptしたGoalをいつ実行開始するか
-- 並列、直列、queue、排他、優先度
-- Cancelをaccept/rejectするか
-- Cancel受理後にどう安全に停止するか
-- SUCCEEDED、CANCELED、ABORTEDのどれで終端するか
+イベント名は説明用の抽象名です。公開APIの関数名やPDU種別をこの文書では確定しません。
 
-RuntimeはApplicationの業務Policyを代わりに決定しません。
+## 7. セルの記述形式
 
-## 10. Client側状態とServer正規状態
-
-Server Runtimeが管理する状態をProtocol上の正規状態とします。
-
-Client Runtimeは、通信上の都合で以下のローカル観測状態を持つ可能性があります。
+各マトリクスセルでは、次の三要素を定義します。
 
 ```text
-NOT_SENT
-SENDING
-WAITING_FOR_RESPONSE
-RESPONSE_LOST
-RESULT_WAIT_TIMEOUT
+Decision:
+  ALLOW / REJECT / IGNORE / IDEMPOTENT / DEFER
+
+Action:
+  RuntimeまたはApplicationが実行する処理
+
+Next:
+  DOING / CANCELING / FINISHING / RELEASE / SAME
 ```
 
-これらはClientローカル状態であり、Server側のGoal状態とは分離します。
+意味は以下です。
 
-例えば、Client側でResult待ちがtimeoutしても、Server側のGoalが自動的に`ABORTED`または`ERROR`になったことを意味しません。
+- `ALLOW`: 現在状態で正規に受理する。
+- `REJECT`: 不正または受理不能としてエラーを返す。
+- `IGNORE`: 副作用を起こさず破棄する。
+- `IDEMPOTENT`: 以前と同じ応答または結果を返し、状態を変えない。
+- `DEFER`: 判断または処理を別主体へ委譲し、現在状態を維持する。
+- `SAME`: 状態を維持する。
+- `RELEASE`: Goalインスタンスを破棄する。
 
-ClientローカルtimeoutとProtocol上のGoal終端を混同しません。
+## 8. Server Applicationイベント × 状態マトリクス
 
-## 11. acceptance timeout
+| Event | DOING | CANCELING | FINISHING |
+| --- | --- | --- | --- |
+| `PUBLISH_FEEDBACK` | `ALLOW`: Feedbackを採番・送信。`SAME` | **レビュー対象**: 原則`REJECT`。停止進捗を許す場合は`ALLOW`。`SAME` | `REJECT`: Result確定後のFeedback。`SAME` |
+| `COMPLETE_SUCCEEDED` | `ALLOW`: terminal statusとResultを確定。`FINISHING` | `REJECT`または競合規約適用。`SAME` | `REJECT`または冪等判定。`SAME` |
+| `COMPLETE_CANCELED` | 原則`REJECT`: Cancel未受理。`SAME` | `ALLOW`: Canceled Resultを確定。`FINISHING` | `REJECT`または冪等判定。`SAME` |
+| `COMPLETE_ABORTED` | `ALLOW`: Aborted Resultを確定。`FINISHING` | `ALLOW`: Cancel処理中のabortを許容。`FINISHING` | `REJECT`または冪等判定。`SAME` |
+| `ACCEPT_CANCEL` | Cancel判断待ちContextが存在する場合に`ALLOW`。Cancel Responseを確定し、`CANCELING` | `IDEMPOTENT`または`REJECT`: 重複accept。`SAME` | `REJECT`: すでにResult確定済み。`SAME` |
+| `REJECT_CANCEL` | Cancel判断待ちContextが存在する場合に`ALLOW`。Cancel Responseを返し、`SAME` | `REJECT`: すでにcancel accept済み。`SAME` | `REJECT`: すでにResult確定済み。`SAME` |
 
-ApplicationがGoal Request通知を受けた後、accept/rejectを返さない場合があります。
+### 8.1 完了イベントの共通Action
 
-候補となる扱いは以下です。
+`COMPLETE_*`を受理する場合、Runtimeは少なくとも以下を一つの論理操作として行います。
 
-1. Runtime設定時間後にRuntime rejectionとする
-2. timeoutをClientローカル観測に限定する
-3. Application応答まで無期限に待つ
+1. terminal statusを確定する。
+2. Result bodyを確定する。
+3. 状態を`FINISHING`へ変更する。
+4. 以降のFeedbackおよび新規Cancelを抑止する。
+5. `RESPONSE_KIND_RESULT`を送信する。
 
-初稿では、acceptance timeoutの有無と責務を確定しません。
+状態を`FINISHING`へ変更してからResultを送信することで、完了処理中に到着するイベントとの競合を閉じます。
 
-ただし、`PENDING_ACCEPTANCE`が無期限に残る可能性を状態モデル上認識し、後続のProtocolおよび設定設計で決定します。
+## 9. Client / Protocolイベント × 状態マトリクス
 
-## 12. 不正な状態遷移
+| Event | DOING | CANCELING | FINISHING |
+| --- | --- | --- | --- |
+| `CANCEL_REQUEST_RECEIVED` | `DEFER`: Applicationへ通知。判断までは`SAME` | **レビュー対象**: 冪等に既存Cancel Responseを返す、または重複として拒否。`SAME` | `REJECT`またはterminal結果を案内。`SAME` |
+| `DUPLICATE_CANCEL_REQUEST_RECEIVED` | Cancel判断中なら重複Policyを適用。`SAME` | 既存のCancel受理結果を再応答する候補。`SAME` | 完了処理中として拒否する候補。`SAME` |
+| `DUPLICATE_GOAL_REQUEST_RECEIVED` | Runtime rejection。既存Goalは`SAME` | Runtime rejection。既存Goalは`SAME` | Runtime rejectionまたは再照会Policy。既存Goalは`SAME` |
+| `UNKNOWN_GOAL_ID_REQUEST_RECEIVED` | 対象インスタンス外のため、現在Goalへ影響なし | 対象インスタンス外のため、現在Goalへ影響なし | 対象インスタンス外のため、現在Goalへ影響なし |
 
-少なくとも以下は不正な遷移候補です。
+### 9.1 Cancel判断待ち
+
+`CANCEL_REQUEST_RECEIVED`からApplicationの`ACCEPT_CANCEL`または`REJECT_CANCEL`まで、Goalの主状態は`DOING`を維持します。
+
+ただしRuntimeは、同じCancel RequestをApplicationへ重複通知しないため、次のような補助情報を保持する可能性があります。
 
 ```text
-REJECTED -> ACCEPTED
-SUCCEEDED -> EXECUTING
-CANCELED -> SUCCEEDED
-ABORTED -> CANCELED
-terminal -> Feedback
-unknown goal_id -> state transition
+cancel_decision_pending = true / false
 ```
 
-Runtimeは、不正な状態遷移をApplication実装の都合で黙って受け入れません。
+これはGoalの実行状態ではなく、未完了のProtocol要求を相関するためのRuntime管理情報です。
 
-具体的なエラー応答と競合規約は`06-error-and-race-semantics.md`で定義します。
+## 10. Runtime / Transportイベント × 状態マトリクス
 
-## 13. 今回の初稿での提案
+| Event | DOING | CANCELING | FINISHING |
+| --- | --- | --- | --- |
+| `FEEDBACK_SEND_COMPLETED` | `ALLOW`: 送信済み情報を更新。`SAME` | 送信開始済みFeedbackについて完了処理。`SAME` | 送信開始済みFeedbackについて完了処理。`SAME` |
+| `FEEDBACK_SEND_FAILED` | Runtime Policyに従いdrop、retry、Application通知。`SAME` | 同左。`SAME` | 同左。ただしResult送信を妨げない。`SAME` |
+| `RESULT_SEND_COMPLETED` | `REJECT`: Result未確定 | `REJECT`: Result未確定 | `ALLOW`: 保持責務完了後に`RELEASE` |
+| `RESULT_SEND_FAILED` | `REJECT`: Result未確定 | `REJECT`: Result未確定 | retry、保持、Runtime error通知のPolicyを適用。`SAME`または`RELEASE`は後続規約で決定 |
+| `TRANSPORT_DISCONNECTED` | Goal実行を継続、abort、保持のいずれかを設定・Protocolで決定 | 停止処理を継続するかを設定・Protocolで決定 | Result保持・再送・破棄Policyを決定 |
+| `APPLICATION_RESPONSE_TIMEOUT` | Goal accept後のCancel判断timeoutとして扱う場合、Cancel ResponseをRuntimeが拒否する候補。`SAME` | 通常は対象外 | 通常は対象外 |
 
-1. Goal lifecycleを受理判定フェーズと受理後実行フェーズへ分ける。
-2. `PENDING_ACCEPTANCE`をaccept/reject未確定状態とする。
-3. `REJECTED`をGoal Request lifecycleの終端とし、accepted Goalの終端状態には含めない。
-4. `ACCEPTED`と`EXECUTING`を区別する。
-5. `ACCEPTED`は受理済みだが実行開始前のGoalを表現できる。
-6. `QUEUED`は初稿では確定状態に含めない。
-7. Cancel Request、Cancel Response、処理停止、`CANCELED`終端を区別する。
-8. Cancel拒否時は元のGoal状態を維持する。
-9. `CANCELING`をProtocol公開状態とするかは未確定とする。
-10. accepted Goalの終端候補を`SUCCEEDED`、`CANCELED`、`ABORTED`、`ERROR`とする。
-11. Clientローカル状態とServer正規状態を分離する。
-12. 各Goalを`goal_id`ごとに独立して状態管理する。
+## 11. イレギュラーケースの洗い出し
 
-## 14. レビューで確認したい事項
+以下は、イベントマトリクスから後続のエラー・競合規約へ送る主要論点です。
 
-1. `REJECTED`はGoal Request lifecycleの終端であり、accepted Goal Execution未成立と整理してよいか。
-2. `ACCEPTED`と`EXECUTING`をProtocol上区別してよいか。
-3. queue待ちを`ACCEPTED`へ包含し、`QUEUED`を共通Protocol状態に含めない方がよいか。
-4. Cancel受理後の`CANCELING`をProtocol公開状態とする必要があるか。
-5. `ACCEPTED`状態のGoalを、実行開始前に`CANCELED`または`ABORTED`で終端できるか。
-6. `ERROR`をGoalの終端状態として公開するか、Runtime/通信エラーとして別概念にするか。
-7. Client側の観測状態とServer側の正規状態を分離する方針でよいか。
-8. Applicationがaccept/rejectへ応答しない場合、acceptance timeoutをProtocol、設定、Clientローカル観測のどこへ置くか。
+### 11.1 Result確定とFeedback発行の競合
+
+```text
+Application thread A: COMPLETE_SUCCEEDED
+Application thread B: PUBLISH_FEEDBACK
+```
+
+Runtimeが先に受理したイベントによって結果を決めます。
+
+- Feedbackが先に受理された場合、そのFeedback送信後に`FINISHING`へ遷移できる。
+- Completeが先に受理された場合、`FINISHING`へ遷移し、後続Feedbackを拒否する。
+
+具体的な排他・atomicity要件は後続文書で定義します。
+
+### 11.2 通常完了とCancel Requestの競合
+
+```text
+Server Application: COMPLETE_SUCCEEDED
+Client: Cancel Request
+```
+
+- Completeが先に`FINISHING`へ遷移させた場合、Cancel Requestは受理しない。
+- Cancel Requestが先にApplicationへ通知されても、Applicationがacceptする前に通常完了が確定する可能性がある。
+
+Cancel判断待ちと通常完了の優先規則は、後続の競合規約で確定します。
+
+### 11.3 Cancel受理と通常成功の競合
+
+`CANCELING`へ遷移した後の`COMPLETE_SUCCEEDED`は、原則として不正とします。
+
+ただし、停止要求を受けた時点ですでに目的を達成していた場合などを`SUCCEEDED`として許容するかはApplication semanticsに関係するため、レビュー対象です。
+
+### 11.4 重複完了
+
+同じGoalへ複数の`COMPLETE_*`が発行された場合、最初に受理された終端結果だけを有効とします。
+
+後続の完了要求は、次のいずれかとします。
+
+- 同一terminal statusおよび同一Resultなら冪等に成功扱い
+- statusやResultに関係なく重複完了エラー
+
+この選択は後続のAPIおよび競合規約で決定します。
+
+### 11.5 FINISHING中のCancel
+
+Resultがすでに確定しているため、新しいCancelはGoalの終端結果を変更しません。
+
+Cancel Responseとして何を返すかは、次の候補があります。
+
+- `REJECTED`: completion already committed
+- terminal Resultを再通知する
+- unknown/finished Goalとして扱う
+
+### 11.6 Result送信失敗
+
+Result送信に失敗しても、Applicationの処理結果はすでに確定しています。
+
+したがって、`FINISHING`から`DOING`または`CANCELING`へ戻してはなりません。
+
+```text
+FINISHING
+  -> Result send failed
+  -> FINISHINGを維持、またはRuntime Contextをエラー終了
+```
+
+再送および保持期間は、Transport非依存のProtocol規約とRuntime設定の境界を後続文書で整理します。
+
+## 12. Feedback規則
+
+Feedbackの発行契機および周期はServer Applicationが決定します。
+
+Protocolは次のみを規定します。
+
+- Feedbackは0回以上発行できる。
+- Feedbackは非終端通知である。
+- Feedbackは`goal_id`で相関する。
+- `sequence_no`はGoalごとに単調増加する。
+- Runtimeが`sequence_no`を採番することを推奨する。
+- `FINISHING`へ遷移した後、新規Feedbackを受理しない。
+
+`CANCELING`中のFeedbackを許可するかはレビュー対象です。
+
+## 13. 状態をProtocol公開するか
+
+`DOING`、`CANCELING`、`FINISHING`は、まずServer Runtimeがイベント受理可否を判断するための正規状態です。
+
+これらをClientへ明示的に通知するPDUを追加するかは、本状態モデルでは決定しません。
+
+現在のPDU契約では、Clientは次のメッセージからlifecycleを観測します。
+
+```text
+Goal Response(ACCEPTED)
+Feedback 0..N
+Cancel Response(ACCEPTED / REJECTED)
+Result(SUCCEEDED / CANCELED / ABORTED)
+```
+
+Client側が観測する状態とServer Runtimeの内部状態は同一である必要はありません。
+
+## 14. 現時点の設計判断
+
+- Action Type全体の状態はProtocolに持たない。
+- worker状態はApplication実装の責務であり、本状態モデルから除外する。
+- Goal Requestがrejectされた場合、Goalインスタンスを生成しない。
+- GoalインスタンスはApplicationのaccept後、`DOING`で生成する。
+- 初期状態は実体stateにせず、initial pseudo-stateで表現する。
+- accept済みGoalは`DOING`、`CANCELING`、`FINISHING`の3状態をMUSTで持つ。
+- Cancel Request受信だけでは`CANCELING`へ遷移しない。
+- ApplicationがCancelをacceptした時点で`CANCELING`へ遷移する。
+- terminal statusとResult確定時に`FINISHING`へ遷移する。
+- `FINISHING`中は新規Feedback、Cancel、別の完了要求によって終端結果を変更しない。
+- Result送信後のRuntime保持責務が完了した時点でGoalインスタンスを破棄する。
+- イベント処理規則は、イベント×状態マトリクスで定義する。
+
+## 15. レビューで確認する事項
+
+1. `CANCELING`中のFeedbackを許可するか。
+2. `CANCELING`中の`COMPLETE_SUCCEEDED`を常に拒否するか。
+3. `DOING`中の`COMPLETE_CANCELED`を常に拒否するか。
+4. Cancel判断待ち中に通常完了した場合、未回答Cancelへ何を返すか。
+5. `CANCELING`中の重複Cancel Requestを冪等応答にするか。
+6. `FINISHING`中のCancel Requestへ何を返すか。
+7. 重複`COMPLETE_*`を冪等またはエラーのどちらにするか。
+8. Result送信失敗時の保持、再送、解放条件をどこで定義するか。
+9. Transport切断時にApplication実行を継続するかをProtocolが規定するか。
+10. 状態をClientへ明示公開する必要があるか。
+
+## 16. 対象外
+
+- PDUのバイトレイアウト
+- 公開APIの具体的な関数シグネチャ
+- Transport固有のretry実装
+- Application内部のworkerおよびqueue状態
+- 状態・イベント処理の排他実装
+- Resultおよび終了済み`goal_id`の具体的な保持時間
+
+これらは、Protocol、エラー・競合規約、API設計、設定モデルで順に具体化します。

--- a/docs/design/action/04-state-model.md
+++ b/docs/design/action/04-state-model.md
@@ -374,16 +374,18 @@ Client側が観測する状態とServer Runtimeの内部状態は同一である
 
 ## 15. レビューで確認する事項
 
-1. `CANCELING`中のFeedbackを許可するか。
-2. `CANCELING`中の`COMPLETE_SUCCEEDED`を常に拒否するか。
-3. `DOING`中の`COMPLETE_CANCELED`を常に拒否するか。
-4. Cancel判断待ち中に通常完了した場合、未回答Cancelへ何を返すか。
-5. `CANCELING`中の重複Cancel Requestを冪等応答にするか。
-6. `FINISHING`中のCancel Requestへ何を返すか。
-7. 重複`COMPLETE_*`を冪等またはエラーのどちらにするか。
-8. Result送信失敗時の保持、再送、解放条件をどこで定義するか。
-9. Transport切断時にApplication実行を継続するかをProtocolが規定するか。
-10. 状態をClientへ明示公開する必要があるか。
+1. イベントの洗い出しに不足がないか。
+2. 各イベントの発生元と受信側が正しいか。
+3. `CANCELING`中のFeedbackを許可するか。
+4. `CANCELING`中の`COMPLETE_SUCCEEDED`を常に拒否するか。
+5. `DOING`中の`COMPLETE_CANCELED`を常に拒否するか。
+6. Cancel判断待ち中に通常完了した場合、未回答Cancelへ何を返すか。
+7. `CANCELING`中の重複Cancel Requestを冪等応答にするか。
+8. `FINISHING`中のCancel Requestへ何を返すか。
+9. 重複`COMPLETE_*`を冪等またはエラーのどちらにするか。
+10. Result送信失敗時の保持、再送、解放条件をどこで定義するか。
+11. Transport切断時にApplication実行を継続するかをProtocolが規定するか。
+12. 状態をClientへ明示公開する必要があるか。
 
 ## 16. 対象外
 

--- a/docs/design/action/04-state-model.md
+++ b/docs/design/action/04-state-model.md
@@ -1,0 +1,453 @@
+# Hakoniwa Actionの状態モデル
+
+> **Status: Draft**  
+> 本文書はレビューと議論のための初稿です。現時点では確定仕様ではありません。
+
+## 1. 目的
+
+本書では、Hakoniwa Action Protocolにおける1つのGoal lifecycleの抽象状態と、その遷移規則を定義します。
+
+本状態モデルは、以下に依存しません。
+
+- TCP、共有メモリなどのTransport方式
+- Endpoint、connection、channel、mux client ID
+- C++、PythonなどのAPI表現
+- Application内部のthread、task、queue実装
+
+各Goalは`goal_id`によって独立して状態管理します。
+
+同一Action Typeに複数Goalが存在する場合も、あるGoalの状態遷移が別のGoalを暗黙に変化させることはありません。
+
+## 2. 前提
+
+本状態モデルは、前段の設計判断を前提とします。
+
+- 1回のGoalを128-bit UUIDの`goal_id`で識別する。
+- Goal Request、Goal Response、Feedback、Cancel、Resultを同じ`goal_id`で相関する。
+- 同一Action Typeに対して、異なる`goal_id`を持つ複数Goalを同時に扱える。
+- Protocol上有効で新しい`goal_id`を持つGoal RequestはApplicationへ通知する。
+- Goalをaccept/rejectするかはApplicationが判断する。
+- RuntimeはProtocol上処理不能なGoal Requestだけを自動拒否する。
+- Runtime拒否とApplication拒否を識別可能にする。
+- Goalの並列実行、直列化、キュー、排他、優先度、preemptionはApplication Policyとする。
+
+## 3. 状態モデルを二つのフェーズへ分ける
+
+Goal lifecycleは、以下の二つのフェーズへ分けて考えます。
+
+1. Goal Requestの受理判定フェーズ
+2. acceptされたGoalの実行フェーズ
+
+```text
+Goal Request lifecycle
+  PENDING_ACCEPTANCE
+    -> REJECTED
+    -> ACCEPTED
+
+Accepted Goal lifecycle
+  ACCEPTED
+    -> EXECUTING
+    -> terminal
+```
+
+この分離により、Goal Requestが届いたことと、ApplicationがGoalの実行を引き受けたことを区別します。
+
+## 4. 受理判定フェーズ
+
+### 4.1 PENDING_ACCEPTANCE
+
+`PENDING_ACCEPTANCE`は、Goal RequestがRuntimeへ到達し、accept/rejectがまだ確定していない状態です。
+
+概念的な流れは以下です。
+
+```text
+Goal Request received
+  -> Runtime validation
+  -> Application notification
+  -> Application decision
+```
+
+Runtimeは、Goal RequestがProtocol上有効で新しい`goal_id`を持つ場合、Applicationへ通知します。
+
+Applicationは、以下のような条件に基づいてaccept/rejectを判断します。
+
+- Goal bodyの妥当性
+- 対象資源の状態
+- 同時実行数
+- queue容量
+- 排他条件
+- 安全条件
+- 権限または運用Policy
+
+### 4.2 REJECTED
+
+`REJECTED`は、Goal Requestを受理しなかったことを表します。
+
+拒否には少なくとも二つのoriginがあります。
+
+```text
+Runtime rejection
+Application rejection
+```
+
+Runtime rejectionの候補は以下です。
+
+- 不正な`goal_id`
+- duplicate `goal_id`
+- 不正message
+- 対応できないProtocol version
+- Goal Contextを生成できないRuntime内部障害
+
+Application rejectionの候補は以下です。
+
+- Goal bodyが業務上不正
+- 必要な資源が使用中
+- Applicationの同時実行上限
+- queue満杯
+- 安全条件を満たさない
+
+Runtime rejectionとApplication rejectionは、同じ拒否理由へ統合しません。
+
+### 4.3 REJECTEDとGoal Execution成立の関係
+
+本初稿では、`REJECTED`を「acceptされたGoal Executionの終端状態」には含めません。
+
+```text
+Goal Request
+  -> REJECTED
+  -> accepted Goal Executionは成立しない
+```
+
+ただし、Clientから見れば、`goal_id`に対するGoal Request lifecycleは`REJECTED`で完了します。
+
+したがって、以下を区別します。
+
+```text
+Goal Request lifecycle terminal
+  REJECTED
+
+Accepted Goal terminal
+  SUCCEEDED / CANCELED / ABORTED / ERROR
+```
+
+この整理はレビュー対象です。
+
+### 4.4 ACCEPTED
+
+`ACCEPTED`は、ApplicationがGoalを受理し、そのGoal lifecycleを継続する責任を引き受けたことを表します。
+
+`ACCEPTED`は、必ずしも処理が実行中であることを意味しません。
+
+```text
+ACCEPTED
+  = Application has accepted responsibility for the Goal
+  != necessarily executing now
+```
+
+この区別により、ApplicationはGoalを受理した後、以下のPolicyを選択できます。
+
+- 直ちに実行する
+- queueへ入れる
+- 資源解放を待つ
+- 優先度制御を行う
+
+## 5. 受理後の実行フェーズ
+
+### 5.1 EXECUTING
+
+`EXECUTING`は、ApplicationがGoal bodyに対応する処理を実行している状態です。
+
+```text
+ACCEPTED -> EXECUTING
+```
+
+Applicationが実行開始をRuntimeへ明示的に通知する必要があるか、Runtimeがaccept時に自動的に`EXECUTING`へ遷移するかは、後続のAPI設計で決定します。
+
+ただし、Protocol上`ACCEPTED`と`EXECUTING`を区別する場合、Runtimeがその遷移を認識できる経路は必要です。
+
+### 5.2 QUEUEDを独立状態とするか
+
+ApplicationがGoalを受理した後、実行開始までqueueで待機させる場合があります。
+
+候補は二つあります。
+
+#### 案A: ACCEPTEDへ包含する
+
+```text
+ACCEPTED
+  includes accepted-but-not-executing
+```
+
+利点:
+
+- Protocol状態が単純になる。
+- queue方式をApplication内部へ閉じ込められる。
+
+欠点:
+
+- Clientはqueue待ちかどうかを共通状態から判断できない。
+
+#### 案B: QUEUEDを追加する
+
+```text
+ACCEPTED -> QUEUED -> EXECUTING
+```
+
+利点:
+
+- Clientが実行待ちを観測できる。
+
+欠点:
+
+- Application固有の実行PolicyがProtocol状態へ入り込む可能性がある。
+
+初稿では`QUEUED`を確定状態へ含めず、レビュー対象とします。
+
+## 6. Cancelの状態モデル
+
+### 6.1 Cancel Requestは終端状態ではない
+
+Cancel Requestを受信しただけでは、Goalは`CANCELED`になりません。
+
+以下を別の出来事として扱います。
+
+1. Cancel Requestを受信する
+2. ApplicationがCancelをaccept/rejectする
+3. Applicationが実際の処理を停止する
+4. Goalが`CANCELED`で終端する
+
+```text
+Cancel Request
+  != Cancel accepted
+  != execution stopped
+  != CANCELED terminal
+```
+
+### 6.2 Cancelが拒否された場合
+
+CancelがApplicationによって拒否された場合、Goalの実行状態は維持します。
+
+```text
+EXECUTING
+  -> Cancel Request
+  -> Cancel rejected
+  -> EXECUTING
+```
+
+Cancel Responseは、Cancel Requestに対する判断を返しますが、Goal Resultではありません。
+
+### 6.3 Cancelが受理された場合
+
+Cancelが受理された後、Applicationが停止処理を行う期間を表現する必要があります。
+
+候補状態は以下です。
+
+```text
+CANCEL_REQUESTED
+CANCELING
+```
+
+候補となる遷移は以下です。
+
+```text
+EXECUTING
+  -> CANCELING
+  -> CANCELED
+```
+
+ただし、`CANCEL_REQUESTED`または`CANCELING`をProtocol公開状態とするか、Runtime/Application内部状態とするかはレビュー対象です。
+
+### 6.4 CANCELEDへの遷移
+
+`CANCELED`は、Cancel Requestを受理しただけでなく、ApplicationがGoal処理を停止し、Canceled Resultを確定した時点の終端状態です。
+
+```text
+Cancel accepted
+  -> stop processing
+  -> produce Result
+  -> CANCELED
+```
+
+## 7. 終端状態
+
+acceptされたGoalは、最終的に一つの終端状態へ遷移します。
+
+初稿では以下を候補とします。
+
+```text
+SUCCEEDED
+CANCELED
+ABORTED
+ERROR
+```
+
+終端後に、別の終端状態へ遷移してはなりません。
+
+```text
+terminal -> terminal transition is forbidden
+```
+
+### 7.1 SUCCEEDED
+
+ApplicationがGoalの意図した処理を正常に完了したことを表します。
+
+### 7.2 CANCELED
+
+Cancel Requestが受理され、Applicationが処理を停止して終端したことを表します。
+
+### 7.3 ABORTED
+
+ApplicationがGoalを受理した後、業務上または実行上の理由により完了できず、処理を終了したことを表します。
+
+例:
+
+- 対象ロボットが実行不能状態になった
+- Goal達成条件を満たせなくなった
+- Applicationが安全上の理由で処理を中止した
+
+### 7.4 ERROR
+
+RuntimeまたはProtocol上の障害により、Goal lifecycleを正常に継続できなくなったことを表す候補です。
+
+例:
+
+- Runtime内部状態の破損
+- ResultをProtocol上生成または配送できない
+- 必須のProtocol invariant違反
+
+`ERROR`をClientへ公開する終端状態とするか、通信エラーとしてGoalの終端状態とは別に扱うかはレビュー対象です。
+
+## 8. 基本状態遷移
+
+初稿の全体像は以下です。
+
+```text
+                         +-> REJECTED
+                         |
+PENDING_ACCEPTANCE -----+
+                         |
+                         +-> ACCEPTED
+                               |
+                               +-> EXECUTING
+                               |      |
+                               |      +-> SUCCEEDED
+                               |      +-> ABORTED
+                               |      +-> ERROR
+                               |      |
+                               |      +-> Cancel Request
+                               |             |
+                               |             +-> rejected -> EXECUTING
+                               |             |
+                               |             +-> accepted -> CANCELING -> CANCELED
+                               |
+                               +-> terminal before execution?
+```
+
+`ACCEPTED`から実行開始前に`ABORTED`または`CANCELED`へ遷移できるかは、レビュー対象です。
+
+例えば、queue待ちのGoalにCancel Requestが届いた場合、実行開始せずに`CANCELED`へ遷移できる可能性があります。
+
+## 9. RuntimeとApplicationの責務
+
+### 9.1 Runtime
+
+Runtimeは以下を担当します。
+
+- `goal_id`ごとのProtocol状態保持
+- 状態遷移要求の検査
+- 許可されない遷移の拒否
+- Runtime rejectionの処理
+- Applicationのaccept/reject判断をGoal Responseへ反映
+- Feedback、Cancel、Resultを現在状態と相関すること
+- 終端後の状態を変更しないこと
+- 複数Goalの状態を混同しないこと
+
+### 9.2 Application
+
+Applicationは以下を判断します。
+
+- Goalをaccept/rejectするか
+- acceptしたGoalをいつ実行開始するか
+- 並列、直列、queue、排他、優先度
+- Cancelをaccept/rejectするか
+- Cancel受理後にどう安全に停止するか
+- SUCCEEDED、CANCELED、ABORTEDのどれで終端するか
+
+RuntimeはApplicationの業務Policyを代わりに決定しません。
+
+## 10. Client側状態とServer正規状態
+
+Server Runtimeが管理する状態をProtocol上の正規状態とします。
+
+Client Runtimeは、通信上の都合で以下のローカル観測状態を持つ可能性があります。
+
+```text
+NOT_SENT
+SENDING
+WAITING_FOR_RESPONSE
+RESPONSE_LOST
+RESULT_WAIT_TIMEOUT
+```
+
+これらはClientローカル状態であり、Server側のGoal状態とは分離します。
+
+例えば、Client側でResult待ちがtimeoutしても、Server側のGoalが自動的に`ABORTED`または`ERROR`になったことを意味しません。
+
+ClientローカルtimeoutとProtocol上のGoal終端を混同しません。
+
+## 11. acceptance timeout
+
+ApplicationがGoal Request通知を受けた後、accept/rejectを返さない場合があります。
+
+候補となる扱いは以下です。
+
+1. Runtime設定時間後にRuntime rejectionとする
+2. timeoutをClientローカル観測に限定する
+3. Application応答まで無期限に待つ
+
+初稿では、acceptance timeoutの有無と責務を確定しません。
+
+ただし、`PENDING_ACCEPTANCE`が無期限に残る可能性を状態モデル上認識し、後続のProtocolおよび設定設計で決定します。
+
+## 12. 不正な状態遷移
+
+少なくとも以下は不正な遷移候補です。
+
+```text
+REJECTED -> ACCEPTED
+SUCCEEDED -> EXECUTING
+CANCELED -> SUCCEEDED
+ABORTED -> CANCELED
+terminal -> Feedback
+unknown goal_id -> state transition
+```
+
+Runtimeは、不正な状態遷移をApplication実装の都合で黙って受け入れません。
+
+具体的なエラー応答と競合規約は`06-error-and-race-semantics.md`で定義します。
+
+## 13. 今回の初稿での提案
+
+1. Goal lifecycleを受理判定フェーズと受理後実行フェーズへ分ける。
+2. `PENDING_ACCEPTANCE`をaccept/reject未確定状態とする。
+3. `REJECTED`をGoal Request lifecycleの終端とし、accepted Goalの終端状態には含めない。
+4. `ACCEPTED`と`EXECUTING`を区別する。
+5. `ACCEPTED`は受理済みだが実行開始前のGoalを表現できる。
+6. `QUEUED`は初稿では確定状態に含めない。
+7. Cancel Request、Cancel Response、処理停止、`CANCELED`終端を区別する。
+8. Cancel拒否時は元のGoal状態を維持する。
+9. `CANCELING`をProtocol公開状態とするかは未確定とする。
+10. accepted Goalの終端候補を`SUCCEEDED`、`CANCELED`、`ABORTED`、`ERROR`とする。
+11. Clientローカル状態とServer正規状態を分離する。
+12. 各Goalを`goal_id`ごとに独立して状態管理する。
+
+## 14. レビューで確認したい事項
+
+1. `REJECTED`はGoal Request lifecycleの終端であり、accepted Goal Execution未成立と整理してよいか。
+2. `ACCEPTED`と`EXECUTING`をProtocol上区別してよいか。
+3. queue待ちを`ACCEPTED`へ包含し、`QUEUED`を共通Protocol状態に含めない方がよいか。
+4. Cancel受理後の`CANCELING`をProtocol公開状態とする必要があるか。
+5. `ACCEPTED`状態のGoalを、実行開始前に`CANCELED`または`ABORTED`で終端できるか。
+6. `ERROR`をGoalの終端状態として公開するか、Runtime/通信エラーとして別概念にするか。
+7. Client側の観測状態とServer側の正規状態を分離する方針でよいか。
+8. Applicationがaccept/rejectへ応答しない場合、acceptance timeoutをProtocol、設定、Clientローカル観測のどこへ置くか。

--- a/docs/design/action/README.md
+++ b/docs/design/action/README.md
@@ -170,6 +170,8 @@ DEFER
 
 ## 現在の主要な未確定事項
 
+- イベントの洗い出しに不足がないか
+- イベント発生元と受信側の分類が正しいか
 - `CANCELING`中のFeedbackを許可するか
 - `CANCELING`中の`COMPLETE_SUCCEEDED`を許可するか
 - `DOING`中の`COMPLETE_CANCELED`を許可するか

--- a/docs/design/action/README.md
+++ b/docs/design/action/README.md
@@ -12,7 +12,7 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - 基本概念と用語
 - リポジトリおよびレイヤ間の責務境界
 - PDUデータ契約
-- ClientおよびServerの状態機械
+- Goal lifecycleの状態機械
 - Goal、Feedback、Cancel、Resultの通信規約
 - エラー、競合、遅延メッセージの扱い
 - 公開API、設定、ファイル配置、ビルド契約
@@ -46,11 +46,11 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 1. [基本概念](01-concepts.md)
 2. [責務境界](02-responsibility-boundaries.md)
 3. [データモデル](03-data-model.md)
+4. [状態モデル](04-state-model.md)
 
 ### 後続で追加する文書
 
 ```text
-04-state-model.md
 05-protocol.md
 06-error-and-race-semantics.md
 07-api-design.md
@@ -87,21 +87,50 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - 汎用的な進捗率を共通ヘッダへ入れず、Action固有のFeedback bodyへ置く。
 - 既存Service Request/Responseのバイナリ契約を変更しない。
 
+## 状態モデル初稿の提案
+
+今回のレビューでは、Goal lifecycleを二つのフェーズへ分けます。
+
+```text
+Goal Request lifecycle
+  PENDING_ACCEPTANCE
+    -> REJECTED
+    -> ACCEPTED
+
+Accepted Goal lifecycle
+  ACCEPTED
+    -> EXECUTING
+    -> terminal
+```
+
+初稿では以下を提案します。
+
+- `REJECTED`はGoal Request lifecycleの終端であり、accepted Goalの終端状態には含めない。
+- `ACCEPTED`と`EXECUTING`を区別する。
+- `ACCEPTED`は受理済みだが実行開始前のGoalを表現できる。
+- `QUEUED`を共通Protocol状態へ含めるかは未確定とする。
+- Cancel Request、Cancel Response、実際の停止、`CANCELED`終端を区別する。
+- Cancel拒否時は元のGoal状態を維持する。
+- accepted Goalの終端候補を`SUCCEEDED`、`CANCELED`、`ABORTED`、`ERROR`とする。
+- Clientローカル状態とServer正規状態を分離する。
+
 ## 現在の主要な未確定事項
 
+- `REJECTED`をGoal Request lifecycleの終端として整理してよいか
+- `ACCEPTED`と`EXECUTING`をProtocol上区別するか
+- queue待ちを`ACCEPTED`へ包含するか、`QUEUED`を追加するか
+- Cancel受理後の`CANCELING`をProtocol公開状態とするか
+- `ACCEPTED`状態から実行開始前に`CANCELED`または`ABORTED`へ遷移できるか
+- `ERROR`をGoal終端状態とするか、Runtime/通信エラーとして分離するか
+- ApplicationがGoal Requestへ応答しない場合のacceptance timeout
 - UUID versionと一意性を要求する範囲
 - 終了済み`goal_id`を保持する期間
 - 同じ`goal_id`を持つGoal Request再送の扱い
 - Protocol Runtimeによる拒否理由の標準化範囲
 - Application rejection reasonの表現方法
-- `reject_origin`を明示的に持たせるか、reason codeで区別するか
-- ApplicationがGoal Requestへ応答しない場合のacceptance timeout
-- Goalの受理前に届いたCancelの扱い
-- Applicationがキューへ入れたGoalについて、`ACCEPTED`、`QUEUED`、`EXECUTING`をProtocol上区別するか
 - Cancel ResponseとCanceled Resultの役割分担
 - Resultとterminal statusをAPI上でどのように返すか
 - Feedbackのキュー方式、容量、欠落および順序の扱い
-- タイムアウトをProtocol終端として扱うか、ローカル観測結果として扱うか
 - Applicationへ公開するGoalHandleまたはContextの責務
 
 未確定事項を確定仕様へ混在させず、各文書内で「設計判断」と「未決定」を明示します。
@@ -112,22 +141,21 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - 設計文書全体: #44
 - 概念と責務境界: #45
 - Goal identityと複数Goalデータモデル: #48
+- Goal lifecycle状態モデル: #50
 - Registry Action生成: hakoniwalab/hakoniwa-pdu-registry#17
 - ROS 2 Service/Action Bridge: hakoniwalab/hakoniwa-pdu-ros#1
 
 ## 現在のレビュー方針
 
-今回のレビューでは、前段で合意した概念と責務境界を、実現方式に依存しない複数Goalのデータモデルとして具体化します。
+今回のレビューでは、前段で合意したデータモデルを前提として、1つのGoalが受理判定から終端までどのように状態遷移するかを整理します。
 
 主な確認事項は以下です。
 
-1. `goal_id`をClient Runtime生成、Server Runtime管理とする責務分担。
-2. `goal_id`をGoal lifecycle全体の相関キーとすること。
-3. 同一Action Typeに対して、異なる`goal_id`を持つ複数のGoalを許容すること。
-4. 重複`goal_id`などProtocol上の不正はRuntimeが自動拒否すること。
-5. Protocol上有効で新しい`goal_id`を持つGoal RequestはApplicationへ通知すること。
-6. ApplicationがGoalの受理・拒否と実行Policyを決定すること。
-7. Runtime拒否とApplication拒否を識別可能にすること。
-8. EndpointやClient接続などの実現方式をProtocolの識別モデルへ持ち込まないこと。
+1. Goal Requestの受理判定フェーズと、accept後の実行フェーズを分けること。
+2. `REJECTED`をaccepted Goalの終端状態へ含めないこと。
+3. `ACCEPTED`と`EXECUTING`を区別すること。
+4. queue、Cancel、終端状態をProtocolとApplication Policyの境界で整理すること。
+5. Clientローカル状態とServer正規状態を分離すること。
+6. 各Goalが`goal_id`ごとに独立して状態遷移すること。
 
-このデータモデルが合意できた後、各Goalがどのように状態遷移するかを`04-state-model.md`で設計します。
+この状態モデルが合意できた後、各状態遷移をどのmessage交換で成立させるかを`05-protocol.md`で設計します。

--- a/docs/design/action/README.md
+++ b/docs/design/action/README.md
@@ -12,7 +12,7 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - 基本概念と用語
 - リポジトリおよびレイヤ間の責務境界
 - PDUデータ契約
-- Goal lifecycleの状態機械
+- Goal lifecycleの状態とイベント処理規則
 - Goal、Feedback、Cancel、Resultの通信規約
 - エラー、競合、遅延メッセージの扱い
 - 公開API、設定、ファイル配置、ビルド契約
@@ -34,8 +34,8 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - Endpoint、接続、multiplex、transport capacityなどの実現方式はProtocolの識別モデルから分離します。
 - Protocol上の独立したClient Session概念は導入しません。
 - Feedbackは0回以上送信できる非終端通知とします。
-- Resultのデータと、Succeeded、Canceled、Abortedなどの終端状態を区別します。
-- Cancel要求、Cancel受理、Canceled終端を同一概念として扱いません。
+- Resultのデータと、Succeeded、Canceled、Abortedなどのterminal statusを区別します。
+- Cancel要求、Cancel受理、停止完了、Canceled Resultを同一概念として扱いません。
 - 既存Service RPCのPDUレイアウト、設定、状態遷移、API挙動を変更しません。
 - Action対応は追加機能かつ明示的なopt-inとします。
 
@@ -65,7 +65,7 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 
 ## 現時点の設計判断
 
-以下は、これまでのレビューで合意した方向性です。後続の状態モデル、Protocol、API設計では、この前提を狭めない形で具体化します。
+以下は、これまでのレビューで合意した方向性です。後続のProtocol、競合規約、API設計では、この前提を狭めない形で具体化します。
 
 - 1回のGoalを128-bit UUIDの`goal_id`で識別する。
 - 通常のHakoniwa ClientではAction Client Runtimeが`goal_id`を生成する。
@@ -84,52 +84,107 @@ Action対応を実装から逆算して定義するのではなく、先に以�
 - Transport接続失敗、Runtime拒否、Application拒否を異なる失敗として扱う。
 - Action Request、Action Response、Action FeedbackをServiceとは独立したPDU契約として定義する。
 - Feedbackに`sequence_no`を持たせる。
+- Feedbackの発行契機と周期はServer Applicationが決定する。
 - 汎用的な進捗率を共通ヘッダへ入れず、Action固有のFeedback bodyへ置く。
 - 既存Service Request/Responseのバイナリ契約を変更しない。
 
-## 状態モデル初稿の提案
+## 状態モデルの設計判断
 
-今回のレビューでは、Goal lifecycleを二つのフェーズへ分けます。
+状態モデルは、Action Typeやworkerではなく、accept済みの`goal_id`インスタンスだけを対象とします。
 
 ```text
-Goal Request lifecycle
-  PENDING_ACCEPTANCE
-    -> REJECTED
-    -> ACCEPTED
-
-Accepted Goal lifecycle
-  ACCEPTED
-    -> EXECUTING
-    -> terminal
+Goal Request
+  -> reject: Goalインスタンスを生成しない
+  -> accept: DOINGでGoalインスタンスを生成
 ```
 
-初稿では以下を提案します。
+Action Type全体の状態、およびApplication内部workerの状態はProtocolへ持ち込みません。
 
-- `REJECTED`はGoal Request lifecycleの終端であり、accepted Goalの終端状態には含めない。
-- `ACCEPTED`と`EXECUTING`を区別する。
-- `ACCEPTED`は受理済みだが実行開始前のGoalを表現できる。
-- `QUEUED`を共通Protocol状態へ含めるかは未確定とする。
-- Cancel Request、Cancel Response、実際の停止、`CANCELED`終端を区別する。
-- Cancel拒否時は元のGoal状態を維持する。
-- accepted Goalの終端候補を`SUCCEEDED`、`CANCELED`、`ABORTED`、`ERROR`とする。
-- Clientローカル状態とServer正規状態を分離する。
+accept済みGoalは、非同期イベント競合を制御するため、次の3状態をMUSTで持ちます。
+
+```text
+DOING
+CANCELING
+FINISHING
+```
+
+基本遷移は次のとおりです。
+
+```text
+normal:
+  [*] -> DOING -> FINISHING -> [*]
+
+cancel:
+  [*] -> DOING -> CANCELING -> FINISHING -> [*]
+```
+
+- 初期状態は実体stateにせず、initial pseudo-stateで表現する。
+- Goal Requestをrejectした場合、Goalインスタンスを生成しない。
+- Cancel Requestを受信しただけでは`CANCELING`へ遷移しない。
+- ApplicationがCancelをacceptした時点で`CANCELING`へ遷移する。
+- terminal statusとResultを確定した時点で`FINISHING`へ遷移する。
+- `FINISHING`では新規Feedback、Cancel、重複完了によって終端結果を変更しない。
+- Result送信後のRuntime保持責務が完了した時点でGoalインスタンスを破棄する。
+
+## イベント×状態マトリクス
+
+今回の状態モデルは、状態図だけではなく、イベント×状態マトリクスを正規の設計手法とします。
+
+```text
+縦軸: イベント
+横軸: DOING / CANCELING / FINISHING
+各セル:
+  Decision
+  Action
+  Next state
+```
+
+イベント発生元は、主に次へ分けます。
+
+```text
+Server Application
+Client / Protocol
+Server Runtime / Transport
+```
+
+各セルでは、次のいずれかを選択します。
+
+```text
+ALLOW
+REJECT
+IGNORE
+IDEMPOTENT
+DEFER
+```
+
+これにより、次のような非同期競合を網羅的に検討します。
+
+- Result確定とFeedback発行の競合
+- 通常完了とCancel Requestの競合
+- Cancel受理と通常成功の競合
+- 重複Cancel
+- 重複完了
+- FINISHING中のCancel
+- Result送信失敗
+- Transport切断
 
 ## 現在の主要な未確定事項
 
-- `REJECTED`をGoal Request lifecycleの終端として整理してよいか
-- `ACCEPTED`と`EXECUTING`をProtocol上区別するか
-- queue待ちを`ACCEPTED`へ包含するか、`QUEUED`を追加するか
-- Cancel受理後の`CANCELING`をProtocol公開状態とするか
-- `ACCEPTED`状態から実行開始前に`CANCELED`または`ABORTED`へ遷移できるか
-- `ERROR`をGoal終端状態とするか、Runtime/通信エラーとして分離するか
-- ApplicationがGoal Requestへ応答しない場合のacceptance timeout
+- `CANCELING`中のFeedbackを許可するか
+- `CANCELING`中の`COMPLETE_SUCCEEDED`を許可するか
+- `DOING`中の`COMPLETE_CANCELED`を許可するか
+- Cancel判断待ち中に通常完了した場合のCancel Response
+- `CANCELING`中の重複Cancelを冪等応答にするか
+- `FINISHING`中のCancel Requestへの応答
+- 重複完了を冪等またはエラーのどちらにするか
+- Result送信失敗時の保持、再送、解放条件
+- Transport切断時にApplication実行を継続するか
+- Server Runtime状態をClientへ明示公開する必要があるか
 - UUID versionと一意性を要求する範囲
 - 終了済み`goal_id`を保持する期間
 - 同じ`goal_id`を持つGoal Request再送の扱い
 - Protocol Runtimeによる拒否理由の標準化範囲
 - Application rejection reasonの表現方法
-- Cancel ResponseとCanceled Resultの役割分担
-- Resultとterminal statusをAPI上でどのように返すか
 - Feedbackのキュー方式、容量、欠落および順序の扱い
 - Applicationへ公開するGoalHandleまたはContextの責務
 
@@ -147,15 +202,13 @@ Accepted Goal lifecycle
 
 ## 現在のレビュー方針
 
-今回のレビューでは、前段で合意したデータモデルを前提として、1つのGoalが受理判定から終端までどのように状態遷移するかを整理します。
+今回のレビューでは、以下を順に確認します。
 
-主な確認事項は以下です。
+1. `DOING`、`CANCELING`、`FINISHING`の3状態で必要十分か。
+2. 発生し得るイベントを発生元ごとに網羅できているか。
+3. イベント×状態マトリクスの各セルについて、許可、拒否、無視、冪等、委譲のどれにするか。
+4. 各セルで必要な副作用と次状態が明確か。
+5. 競合、重複、遅延、送信失敗などのイレギュラーケースが漏れていないか。
+6. 状態モデルで確定する事項と、後続のProtocol・競合規約へ送る事項を分離できているか。
 
-1. Goal Requestの受理判定フェーズと、accept後の実行フェーズを分けること。
-2. `REJECTED`をaccepted Goalの終端状態へ含めないこと。
-3. `ACCEPTED`と`EXECUTING`を区別すること。
-4. queue、Cancel、終端状態をProtocolとApplication Policyの境界で整理すること。
-5. Clientローカル状態とServer正規状態を分離すること。
-6. 各Goalが`goal_id`ごとに独立して状態遷移すること。
-
-この状態モデルが合意できた後、各状態遷移をどのmessage交換で成立させるかを`05-protocol.md`で設計します。
+この状態・イベントモデルが合意できた後、各イベントをどのmessage交換で成立させるかを`05-protocol.md`で設計します。


### PR DESCRIPTION
Closes #50
Related: #44, #21, #48

## 概要

Hakoniwa Action Protocolの状態モデル初稿として、以下を追加・更新します。

```text
docs/design/action/
    README.md
    04-state-model.md
```

前回までに確定した`goal_id`、複数Goal、Runtime/Application境界を前提として、accept済みGoalの非同期イベント競合を整理します。

## 今回の設計判断

Action Type全体の状態、およびApplication内部workerの状態はProtocolへ持ち込みません。

Goal Requestをrejectした場合はGoalインスタンスを生成せず、Applicationがacceptした時点で`DOING`として生成します。

```text
Goal Request
  -> reject: no Goal instance
  -> accept: [*] -> DOING
```

accept済みGoalは、少なくとも次の3状態をMUSTで持ちます。

```text
DOING
CANCELING
FINISHING
```

基本状態遷移は次のとおりです。

```text
normal:
  [*] -> DOING -> FINISHING -> [*]

cancel:
  [*] -> DOING -> CANCELING -> FINISHING -> [*]
```

- 初期状態は実体stateにせず、initial pseudo-stateで表現する。
- Cancel Request受信だけでは`CANCELING`へ遷移しない。
- ApplicationがCancelをacceptした時点で`CANCELING`へ遷移する。
- terminal statusとResultを確定した時点で`FINISHING`へ遷移する。
- `FINISHING`中はFeedback、Cancel、重複完了によって終端結果を変更しない。
- Result送信後のRuntime保持責務が完了した時点でGoalインスタンスを破棄する。

## イベント×状態マトリクス

状態図だけでなく、次のマトリクスを中心にレビューします。

```text
縦軸: 発生し得るイベント
横軸: DOING / CANCELING / FINISHING
各セル:
  Decision
  Action
  Next state
```

イベント発生元は、次の3分類で整理しています。

```text
Server Application
Client / Protocol
Server Runtime / Transport
```

各セルの判断候補は次のとおりです。

```text
ALLOW
REJECT
IGNORE
IDEMPOTENT
DEFER
```

## 主なイベント

Server Application起因:

- `PUBLISH_FEEDBACK`
- `COMPLETE_SUCCEEDED`
- `COMPLETE_CANCELED`
- `COMPLETE_ABORTED`
- `ACCEPT_CANCEL`
- `REJECT_CANCEL`

Client / Protocol起因:

- `CANCEL_REQUEST_RECEIVED`
- duplicate Cancel / Goal Request
- unknown `goal_id` request

Server Runtime / Transport起因:

- Feedback送信完了・失敗
- Result送信完了・失敗
- Transport切断
- Application応答timeout

## イレギュラーケース

本文書では、特に以下をマトリクスから洗い出しています。

- Result確定とFeedback発行の競合
- 通常完了とCancel Requestの競合
- Cancel受理と通常成功の競合
- Cancel判断待ち中の通常完了
- 重複Cancel
- 重複完了
- `FINISHING`中のCancel
- Result送信失敗
- Transport切断

## レビューで相談したい点

1. イベントの洗い出しに不足がないか。
2. 各イベントの発生元と受信側が正しいか。
3. `CANCELING`中のFeedbackを許可するか。
4. `CANCELING`中の`COMPLETE_SUCCEEDED`を常に拒否するか。
5. `DOING`中の`COMPLETE_CANCELED`を常に拒否するか。
6. Cancel判断待ち中に通常完了した場合、未回答Cancelへ何を返すか。
7. `CANCELING`中の重複Cancel Requestを冪等応答にするか。
8. `FINISHING`中のCancel Requestへ何を返すか。
9. 重複`COMPLETE_*`を冪等またはエラーのどちらにするか。
10. Result送信失敗時の保持、再送、解放条件をどこで定義するか。
11. Transport切断時にApplication実行を継続するかをProtocolが規定するか。
12. 状態をClientへ明示公開する必要があるか。

## 対象外

- PDUのバイトレイアウト
- 公開APIの具体的な関数シグネチャ
- Transport固有のretry実装
- Application内部のworkerおよびqueue状態
- 状態・イベント処理の排他実装
- Resultおよび終了済み`goal_id`の具体的な保持時間

本文書は議論用の初稿です。イベントを順に確認しながら、各セルの判断とActionを確定します。