### PR TITLE
Align Action server state model with ROS semantics

### DIFF
--- a/docs/design/action/04-state-model.md
+++ b/docs/design/action/04-state-model.md
@@ -34,7 +34,7 @@
 
 ```text
 Action Type A
-  goal_id = X : DOING
+  goal_id = X : EXECUTING
   goal_id = Y : CANCELING
   goal_id = Z : FINISHING
 ```
@@ -48,13 +48,13 @@ Goal Request
   -> Runtime validation
   -> Application decision
        -> reject: Goalインスタンスを生成しない
-       -> accept: GoalインスタンスをDOINGで生成する
+       -> accept: GoalインスタンスをEXECUTINGで生成する
 ```
 
-初期状態を表す実体stateは設けません。状態図上ではinitial pseudo-stateから`DOING`へ遷移します。
+初期状態を表す実体stateは設けません。状態図上ではinitial pseudo-stateから`EXECUTING`へ遷移します。
 
 ```text
-[*] -> DOING
+[*] -> EXECUTING
 ```
 
 Goalの終端Result送信処理が完了し、Runtimeの保持責務が終了した時点でGoalインスタンスを破棄します。
@@ -70,12 +70,12 @@ FINISHING -> [*]
 Runtimeはaccept済みGoalについて、少なくとも次の3状態を管理します。
 
 ```text
-DOING
+EXECUTING
 CANCELING
 FINISHING
 ```
 
-### 4.1 DOING
+### 4.1 EXECUTING
 
 ApplicationがGoalを実行している状態です。
 
@@ -86,21 +86,21 @@ ApplicationがCancel Requestをacceptし、非同期の停止処理を行って�
 Cancel Requestを受信しただけでは`CANCELING`へ遷移しません。ApplicationがCancelをacceptした時点で遷移します。
 
 ```text
-DOING
+EXECUTING
   -> Cancel Request received
   -> Application notified
   -> Application accepts cancel
   -> CANCELING
 ```
 
-ApplicationがCancelをrejectした場合は`DOING`を維持します。
+ApplicationがCancelをrejectした場合は`EXECUTING`を維持します。
 
 ### 4.3 FINISHING
 
 Applicationが終端statusおよびResult bodyを確定し、RuntimeがResult送信とGoalインスタンス破棄を処理している状態です。
 
 ```text
-DOING      -> FINISHING
+EXECUTING  -> FINISHING
 CANCELING  -> FINISHING
 ```
 
@@ -110,13 +110,13 @@ CANCELING  -> FINISHING
 
 ```text
 normal:
-  [*] -> DOING -> FINISHING -> [*]
+  [*] -> EXECUTING -> FINISHING -> [*]
 
 cancel:
-  [*] -> DOING -> CANCELING -> FINISHING -> [*]
+  [*] -> EXECUTING -> CANCELING -> FINISHING -> [*]
 
 cancel rejected:
-  DOING -> DOING
+  EXECUTING -> EXECUTING
 ```
 
 ## 6. イベント発生元
@@ -180,7 +180,7 @@ Action:
   RuntimeまたはApplicationが実行する処理
 
 Next:
-  DOING / CANCELING / FINISHING / RELEASE / SAME
+  EXECUTING / CANCELING / FINISHING / RELEASE / SAME
 ```
 
 - `ALLOW`: 現在状態で正規に受理する。
@@ -195,10 +195,10 @@ Next:
 
 ## 9. Server Applicationイベント × 状態マトリクス
 
-| Event | DOING | CANCELING | FINISHING |
+| Event | EXECUTING | CANCELING | FINISHING |
 | --- | --- | --- | --- |
-| `PUBLISH_FEEDBACK` | `ALLOW`: Feedbackを採番・送信。`SAME` | **レビュー対象**: 原則`APPLICATION_API_ERROR`。停止進捗を許す場合は`ALLOW`。`SAME` | `APPLICATION_API_ERROR`: Result確定後のFeedback。`SAME` |
-| `COMPLETE_SUCCEEDED` | `ALLOW`: terminal statusとResultを確定。`FINISHING` | **レビュー対象**: `APPLICATION_API_ERROR`または競合規約適用。`SAME` | `APPLICATION_API_ERROR`または冪等判定。`SAME` |
+| `PUBLISH_FEEDBACK` | `ALLOW`: Feedbackを採番・送信。`SAME` | `ALLOW`: 停止処理中のFeedbackを採番・送信。`SAME` | `APPLICATION_API_ERROR`: Result確定後のFeedback。`SAME` |
+| `COMPLETE_SUCCEEDED` | `ALLOW`: terminal statusとResultを確定。`FINISHING` | `APPLICATION_API_ERROR`: Cancel受理後の成功完了は不正。`SAME` | `APPLICATION_API_ERROR`または冪等判定。`SAME` |
 | `COMPLETE_CANCELED` | 原則`APPLICATION_API_ERROR`: Cancel未受理。`SAME` | `ALLOW`: Canceled Resultを確定。`FINISHING` | `APPLICATION_API_ERROR`または冪等判定。`SAME` |
 | `COMPLETE_ABORTED` | `ALLOW`: Aborted Resultを確定。`FINISHING` | `ALLOW`: Cancel処理中のabortを許容。`FINISHING` | `APPLICATION_API_ERROR`または冪等判定。`SAME` |
 | `ACCEPT_CANCEL` | `cancel_decision_pending=true`なら`ALLOW`し`CANCELING`へ。falseなら`APPLICATION_API_ERROR`で`SAME` | `IDEMPOTENT`または`APPLICATION_API_ERROR`: 重複accept。`SAME` | `APPLICATION_API_ERROR`: すでにResult確定済み。`SAME` |
@@ -208,7 +208,7 @@ Next:
 
 ## 10. Client / Protocolイベント × 状態マトリクス
 
-| Event | DOING | CANCELING | FINISHING |
+| Event | EXECUTING | CANCELING | FINISHING |
 | --- | --- | --- | --- |
 | `CANCEL_REQUEST_RECEIVED` | `DEFER`: Applicationへ通知。判断までは`SAME` | **レビュー対象**: 冪等に既存Cancel Responseを返す、または重複として拒否。`SAME` | **レビュー対象**: completion committedとして拒否、または別の規約を適用。`SAME` |
 | `DUPLICATE_CANCEL_REQUEST_RECEIVED` | Cancel判断中なら重複Policyを適用。`SAME` | 既存のCancel受理結果を再応答する候補。`SAME` | 完了処理中として拒否する候補。`SAME` |
@@ -216,7 +216,7 @@ Next:
 
 ## 11. Cancel判断待ちContext
 
-`CANCEL_REQUEST_RECEIVED`からApplicationの`ACCEPT_CANCEL`または`REJECT_CANCEL`まで、Goalの主状態は`DOING`を維持します。
+`CANCEL_REQUEST_RECEIVED`からApplicationの`ACCEPT_CANCEL`または`REJECT_CANCEL`まで、Goalの主状態は`EXECUTING`を維持します。
 
 ```text
 cancel_decision_pending = true / false
@@ -226,7 +226,7 @@ cancel_decision_pending = true / false
 
 ## 12. Runtime / Transportイベント × 状態マトリクス
 
-| Event | DOING | CANCELING | FINISHING |
+| Event | EXECUTING | CANCELING | FINISHING |
 | --- | --- | --- | --- |
 | `FEEDBACK_SEND_COMPLETED` | `ALLOW`: 送信済み情報を更新。`SAME` | 送信開始済みFeedbackについて完了処理。`SAME` | 送信開始済みFeedbackについて完了処理。`SAME` |
 | `FEEDBACK_SEND_FAILED` | Runtime Policyに従いdrop、retry、Application通知。`SAME` | 同左。`SAME` | 同左。ただしResult送信を妨げない。`SAME` |
@@ -270,34 +270,84 @@ Protocolは次のみを規定します。
 - Runtimeが`sequence_no`を採番することを推奨する。
 - `FINISHING`へ遷移した後、新規Feedbackを受理しない。
 
-`CANCELING`中のFeedbackを許可するかはレビュー対象です。
+`CANCELING`中のFeedbackも`ALLOW`とします。停止処理の進捗を通知するかどうか、またその内容と周期はServer Applicationが決定します。これはROS 2の一般的なServer APIより広い箱庭独自の許容仕様です。
 
-## 15. 現時点の設計判断
+## 15. ROS 2 Actionとの親和性
 
-- GoalインスタンスはApplicationのaccept後、`DOING`で生成する。
-- accept済みGoalは`DOING`、`CANCELING`、`FINISHING`の3状態をMUSTで持つ。
+本状態モデルはROS 2 ActionのGoal lifecycleと意味論上整合することを重視します。ただし、箱庭Runtime固有の配送・保持責務を扱うため、一部に箱庭独自の補強があります。
+
+対応関係は次のとおりです。
+
+| Hakoniwa Server Runtime | ROS 2 Action | 考え方 |
+| --- | --- | --- |
+| Goalインスタンス未生成 | Goal未受理またはreject | rejectされたGoalを実行状態として保持しない |
+| `EXECUTING` | `EXECUTING` | accept済みGoalをApplicationが実行中 |
+| `CANCELING` | `CANCELING` | Cancel RequestをApplicationがacceptし、非同期停止処理中 |
+| `FINISHING` | 直接対応する公開状態なし | terminal statusとResult確定後の配送・保持を管理する箱庭内部状態 |
+| `SUCCEEDED` | `SUCCEEDED` | Goalの目的を正常に達成 |
+| `CANCELED` | `CANCELED` | Cancel受理後の停止処理を完了 |
+| `ABORTED` | `ABORTED` | ApplicationがGoalを達成できないと判断して正常なAction API経路で終了 |
+
+箱庭ではROS 2の`ACCEPTED`と`EXECUTING`を分離せず、ApplicationがGoalをacceptした時点でGoalインスタンスを`EXECUTING`として生成します。遅延実行やRuntime共通queue状態が必要にならない限り、`ACCEPTED`相当の状態は追加しません。
+
+終端Application APIの有効状態もROS 2と同じ方向に制約します。
+
+```text
+EXECUTING + COMPLETE_SUCCEEDED -> FINISHING
+EXECUTING + COMPLETE_ABORTED   -> FINISHING
+CANCELING + COMPLETE_CANCELED  -> FINISHING
+CANCELING + COMPLETE_SUCCEEDED -> APPLICATION_API_ERROR
+```
+
+`FINISHING`はGoalの意味論的な実行状態ではありません。terminal statusとResultが確定した後に、遅延Feedback、遅延Cancel、重複完了、Result配送完了・失敗を制御するためのServer Runtime内部状態です。この状態により、ROS 2のGoal意味論を変えずに箱庭PDU Runtimeの非同期処理を補強します。
+
+`CANCELING`中のFeedbackは箱庭Protocolでは許可します。停止処理の進捗を通知できるようにするためであり、ROS 2の一般的なServer APIより広い箱庭独自仕様です。ROS Bridgeでは、必要に応じてdrop、別経路への変換、または対応Runtimeの能力に合わせた写像を行います。
+
+### 15.1 `ABORTED`とRuntime内部エラーの分離
+
+`ABORTED`はServer ApplicationがActionの意味論に基づき、Goalを達成できないと判断して`COMPLETE_ABORTED`を発行した正常な終端結果です。
+
+一方、Runtimeの資源枯渇、内部不変条件違反、Transport障害、Result配送不能などはRuntime Errorです。Runtime Errorを自動的に`ABORTED`へ変換しません。
+
+```text
+Application semantic failure
+  -> COMPLETE_ABORTED
+  -> terminal status = ABORTED
+
+Runtime / Transport failure
+  -> Runtime Error
+  -> terminal Resultを送信できるとは限らない
+```
+
+Runtime障害時にterminal通知を試行する条件、Resultを生成できない場合の記録、Goal Contextの解放条件は、後続のErrorおよびProtocol規約で定義します。
+
+## 16. 現時点の設計判断
+
+- GoalインスタンスはApplicationのaccept後、`EXECUTING`で生成する。
+- `CANCELING`中のFeedbackを許可する。
+- `CANCELING`中の`COMPLETE_SUCCEEDED`は`APPLICATION_API_ERROR`とし、状態を変更しない。
+- accept済みGoalは`EXECUTING`、`CANCELING`、`FINISHING`の3状態をMUSTで持つ。
 - `UNKNOWN_GOAL_ID_REQUEST_RECEIVED`はper-goal状態マトリクスではなくRuntime dispatcherで扱う。
 - Cancel Request受信だけでは`CANCELING`へ遷移しない。
 - `ACCEPT_CANCEL`および`REJECT_CANCEL`はCancel判断待ちContextが存在する場合だけ有効とする。
 - Application APIの誤用、Protocol拒否、Runtime不変条件違反を区別する。
 - terminal statusとResult確定時に`FINISHING`へ遷移する。
+- `ABORTED`とRuntime Errorを区別し、Runtime Errorを自動的に`ABORTED`へ変換しない。
 - `SERVER_SHUTDOWN_REQUESTED`と`RUNTIME_FORCED_TERMINATION`をRuntime起因イベントとして検討対象に含める。
 - Result送信後のRuntime保持責務が完了した時点でGoalインスタンスを破棄する。
 
-## 16. レビューで確認する事項
+## 17. レビューで確認する事項
 
-1. `CANCELING`中のFeedbackを許可するか。
-2. `CANCELING`中の`COMPLETE_SUCCEEDED`を常にApplication API Errorとするか。
-3. `DOING`中の`COMPLETE_CANCELED`を常にApplication API Errorとするか。
-4. Cancel判断待ち中に通常完了した場合、未回答Cancelへ何を返すか。
-5. `CANCELING`中の重複Cancel Requestを冪等応答にするか。
-6. `FINISHING`中のCancel Requestへ何を返すか。
-7. 重複`COMPLETE_*`を冪等またはエラーのどちらにするか。
-8. Result送信失敗時の保持、再送、解放条件をどこで定義するか。
-9. shutdown policyをProtocol、Runtime設定、Application Policyのどこへ置くか。
-10. Runtime強制終了時にterminal通知を試行する条件をどう定義するか。
+1. `EXECUTING`中の`COMPLETE_CANCELED`を常にApplication API Errorとするか。
+2. Cancel判断待ち中に通常完了した場合、未回答Cancelへ何を返すか。
+3. `CANCELING`中の重複Cancel Requestを冪等応答にするか。
+4. `FINISHING`中のCancel Requestへ何を返すか。
+5. 重複`COMPLETE_*`を冪等またはエラーのどちらにするか。
+6. Result送信失敗時の保持、再送、解放条件をどこで定義するか。
+7. shutdown policyをProtocol、Runtime設定、Application Policyのどこへ置くか。
+8. Runtime強制終了時にterminal通知を試行する条件をどう定義するか。
 
-## 17. 対象外
+## 18. 対象外
 
 - PDUのバイトレイアウト
 - 公開APIの具体的な関数シグネチャ

--- a/docs/design/action/04-state-model.md
+++ b/docs/design/action/04-state-model.md
@@ -28,6 +28,7 @@
 - Goal Requestのaccept/reject判定前の一時Context
 - Client Runtimeのローカルな送受信待ち状態
 - Transport接続そのものの状態
+- Goalインスタンスを特定する前のRuntime dispatcher処理
 
 同一Action Typeに複数Goalが存在する場合、それぞれが独立した状態を持ちます。
 
@@ -78,14 +79,6 @@ FINISHING
 
 ApplicationがGoalを実行している状態です。
 
-この状態では、次の操作が発生し得ます。
-
-- Feedback発行
-- 通常完了
-- 異常終了
-- Cancel Request受信
-- Cancelのaccept/reject判断
-
 ### 4.2 CANCELING
 
 ApplicationがCancel Requestをacceptし、非同期の停止処理を行っている状態です。
@@ -115,37 +108,18 @@ CANCELING  -> FINISHING
 
 ## 5. 基本状態遷移
 
-### 5.1 通常完了
-
 ```text
-[*]
-  -> DOING
-  -> FINISHING
-  -> [*]
-```
+normal:
+  [*] -> DOING -> FINISHING -> [*]
 
-### 5.2 Cancel完了
+cancel:
+  [*] -> DOING -> CANCELING -> FINISHING -> [*]
 
-```text
-[*]
-  -> DOING
-  -> CANCELING
-  -> FINISHING
-  -> [*]
-```
-
-### 5.3 Cancel拒否
-
-```text
-DOING
-  -> Cancel Request
-  -> Application rejects cancel
-  -> DOING
+cancel rejected:
+  DOING -> DOING
 ```
 
 ## 6. イベント発生元
-
-イベントは、発生元ごとに整理します。
 
 ### 6.1 Server Application起因
 
@@ -161,7 +135,6 @@ DOING
 - `CANCEL_REQUEST_RECEIVED(goal_id)`
 - `DUPLICATE_CANCEL_REQUEST_RECEIVED(goal_id)`
 - `DUPLICATE_GOAL_REQUEST_RECEIVED(goal_id)`
-- `UNKNOWN_GOAL_ID_REQUEST_RECEIVED(goal_id)`
 
 ### 6.3 Server Runtime / Transport起因
 
@@ -171,16 +144,37 @@ DOING
 - `RESULT_SEND_FAILED(goal_id)`
 - `TRANSPORT_DISCONNECTED`
 - `APPLICATION_RESPONSE_TIMEOUT(goal_id)`
+- `SERVER_SHUTDOWN_REQUESTED`
+- `RUNTIME_FORCED_TERMINATION(goal_id, reason)`
 
 イベント名は説明用の抽象名です。公開APIの関数名やPDU種別をこの文書では確定しません。
 
-## 7. セルの記述形式
+## 7. Runtime dispatcherで扱うイベント
+
+`UNKNOWN_GOAL_ID_REQUEST_RECEIVED(goal_id)`は、対応するGoalインスタンスが存在しない場合に発生するため、per-goal状態マトリクスには含めません。
+
+```text
+Runtime dispatcher
+  -> goal_id lookup
+       -> found: per-goal state matrixへ配送
+       -> not found: unknown-goal handling
+```
+
+unknown-goalへの応答内容は、後続のProtocolおよびError規約で定義します。
+
+## 8. セルの記述形式
 
 各マトリクスセルでは、次の三要素を定義します。
 
 ```text
 Decision:
-  ALLOW / REJECT / IGNORE / IDEMPOTENT / DEFER
+  ALLOW
+  PROTOCOL_REJECT
+  APPLICATION_API_ERROR
+  INVARIANT_VIOLATION
+  IGNORE
+  IDEMPOTENT
+  DEFER
 
 Action:
   RuntimeまたはApplicationが実行する処理
@@ -189,53 +183,40 @@ Next:
   DOING / CANCELING / FINISHING / RELEASE / SAME
 ```
 
-意味は以下です。
-
 - `ALLOW`: 現在状態で正規に受理する。
-- `REJECT`: 不正または受理不能としてエラーを返す。
+- `PROTOCOL_REJECT`: Client／Protocol起因の要求を受理せず、Protocol応答を返す。
+- `APPLICATION_API_ERROR`: Server ApplicationからRuntimeへの不正操作としてApplicationへエラーを返す。
+- `INVARIANT_VIOLATION`: Runtime内部で本来発生しないイベントを検出したことを表す。
 - `IGNORE`: 副作用を起こさず破棄する。
 - `IDEMPOTENT`: 以前と同じ応答または結果を返し、状態を変えない。
 - `DEFER`: 判断または処理を別主体へ委譲し、現在状態を維持する。
 - `SAME`: 状態を維持する。
 - `RELEASE`: Goalインスタンスを破棄する。
 
-## 8. Server Applicationイベント × 状態マトリクス
+## 9. Server Applicationイベント × 状態マトリクス
 
 | Event | DOING | CANCELING | FINISHING |
 | --- | --- | --- | --- |
-| `PUBLISH_FEEDBACK` | `ALLOW`: Feedbackを採番・送信。`SAME` | **レビュー対象**: 原則`REJECT`。停止進捗を許す場合は`ALLOW`。`SAME` | `REJECT`: Result確定後のFeedback。`SAME` |
-| `COMPLETE_SUCCEEDED` | `ALLOW`: terminal statusとResultを確定。`FINISHING` | `REJECT`または競合規約適用。`SAME` | `REJECT`または冪等判定。`SAME` |
-| `COMPLETE_CANCELED` | 原則`REJECT`: Cancel未受理。`SAME` | `ALLOW`: Canceled Resultを確定。`FINISHING` | `REJECT`または冪等判定。`SAME` |
-| `COMPLETE_ABORTED` | `ALLOW`: Aborted Resultを確定。`FINISHING` | `ALLOW`: Cancel処理中のabortを許容。`FINISHING` | `REJECT`または冪等判定。`SAME` |
-| `ACCEPT_CANCEL` | Cancel判断待ちContextが存在する場合に`ALLOW`。Cancel Responseを確定し、`CANCELING` | `IDEMPOTENT`または`REJECT`: 重複accept。`SAME` | `REJECT`: すでにResult確定済み。`SAME` |
-| `REJECT_CANCEL` | Cancel判断待ちContextが存在する場合に`ALLOW`。Cancel Responseを返し、`SAME` | `REJECT`: すでにcancel accept済み。`SAME` | `REJECT`: すでにResult確定済み。`SAME` |
+| `PUBLISH_FEEDBACK` | `ALLOW`: Feedbackを採番・送信。`SAME` | **レビュー対象**: 原則`APPLICATION_API_ERROR`。停止進捗を許す場合は`ALLOW`。`SAME` | `APPLICATION_API_ERROR`: Result確定後のFeedback。`SAME` |
+| `COMPLETE_SUCCEEDED` | `ALLOW`: terminal statusとResultを確定。`FINISHING` | **レビュー対象**: `APPLICATION_API_ERROR`または競合規約適用。`SAME` | `APPLICATION_API_ERROR`または冪等判定。`SAME` |
+| `COMPLETE_CANCELED` | 原則`APPLICATION_API_ERROR`: Cancel未受理。`SAME` | `ALLOW`: Canceled Resultを確定。`FINISHING` | `APPLICATION_API_ERROR`または冪等判定。`SAME` |
+| `COMPLETE_ABORTED` | `ALLOW`: Aborted Resultを確定。`FINISHING` | `ALLOW`: Cancel処理中のabortを許容。`FINISHING` | `APPLICATION_API_ERROR`または冪等判定。`SAME` |
+| `ACCEPT_CANCEL` | `cancel_decision_pending=true`なら`ALLOW`し`CANCELING`へ。falseなら`APPLICATION_API_ERROR`で`SAME` | `IDEMPOTENT`または`APPLICATION_API_ERROR`: 重複accept。`SAME` | `APPLICATION_API_ERROR`: すでにResult確定済み。`SAME` |
+| `REJECT_CANCEL` | `cancel_decision_pending=true`なら`ALLOW`しCancel Responseを返して`SAME`。falseなら`APPLICATION_API_ERROR` | `APPLICATION_API_ERROR`: すでにcancel accept済み。`SAME` | `APPLICATION_API_ERROR`: すでにResult確定済み。`SAME` |
 
-### 8.1 完了イベントの共通Action
+`ACCEPT_CANCEL`および`REJECT_CANCEL`は、Cancel判断待ちContextが存在する場合だけ有効です。Contextが存在しない呼び出しは、Protocol上の拒否ではなくApplication APIの誤用として扱います。
 
-`COMPLETE_*`を受理する場合、Runtimeは少なくとも以下を一つの論理操作として行います。
-
-1. terminal statusを確定する。
-2. Result bodyを確定する。
-3. 状態を`FINISHING`へ変更する。
-4. 以降のFeedbackおよび新規Cancelを抑止する。
-5. `RESPONSE_KIND_RESULT`を送信する。
-
-状態を`FINISHING`へ変更してからResultを送信することで、完了処理中に到着するイベントとの競合を閉じます。
-
-## 9. Client / Protocolイベント × 状態マトリクス
+## 10. Client / Protocolイベント × 状態マトリクス
 
 | Event | DOING | CANCELING | FINISHING |
 | --- | --- | --- | --- |
-| `CANCEL_REQUEST_RECEIVED` | `DEFER`: Applicationへ通知。判断までは`SAME` | **レビュー対象**: 冪等に既存Cancel Responseを返す、または重複として拒否。`SAME` | `REJECT`またはterminal結果を案内。`SAME` |
+| `CANCEL_REQUEST_RECEIVED` | `DEFER`: Applicationへ通知。判断までは`SAME` | **レビュー対象**: 冪等に既存Cancel Responseを返す、または重複として拒否。`SAME` | **レビュー対象**: completion committedとして拒否、または別の規約を適用。`SAME` |
 | `DUPLICATE_CANCEL_REQUEST_RECEIVED` | Cancel判断中なら重複Policyを適用。`SAME` | 既存のCancel受理結果を再応答する候補。`SAME` | 完了処理中として拒否する候補。`SAME` |
-| `DUPLICATE_GOAL_REQUEST_RECEIVED` | Runtime rejection。既存Goalは`SAME` | Runtime rejection。既存Goalは`SAME` | Runtime rejectionまたは再照会Policy。既存Goalは`SAME` |
-| `UNKNOWN_GOAL_ID_REQUEST_RECEIVED` | 対象インスタンス外のため、現在Goalへ影響なし | 対象インスタンス外のため、現在Goalへ影響なし | 対象インスタンス外のため、現在Goalへ影響なし |
+| `DUPLICATE_GOAL_REQUEST_RECEIVED` | `PROTOCOL_REJECT`。既存Goalは`SAME` | `PROTOCOL_REJECT`。既存Goalは`SAME` | `PROTOCOL_REJECT`または再照会Policy。既存Goalは`SAME` |
 
-### 9.1 Cancel判断待ち
+## 11. Cancel判断待ちContext
 
 `CANCEL_REQUEST_RECEIVED`からApplicationの`ACCEPT_CANCEL`または`REJECT_CANCEL`まで、Goalの主状態は`DOING`を維持します。
-
-ただしRuntimeは、同じCancel RequestをApplicationへ重複通知しないため、次のような補助情報を保持する可能性があります。
 
 ```text
 cancel_decision_pending = true / false
@@ -243,89 +224,40 @@ cancel_decision_pending = true / false
 
 これはGoalの実行状態ではなく、未完了のProtocol要求を相関するためのRuntime管理情報です。
 
-## 10. Runtime / Transportイベント × 状態マトリクス
+## 12. Runtime / Transportイベント × 状態マトリクス
 
 | Event | DOING | CANCELING | FINISHING |
 | --- | --- | --- | --- |
 | `FEEDBACK_SEND_COMPLETED` | `ALLOW`: 送信済み情報を更新。`SAME` | 送信開始済みFeedbackについて完了処理。`SAME` | 送信開始済みFeedbackについて完了処理。`SAME` |
 | `FEEDBACK_SEND_FAILED` | Runtime Policyに従いdrop、retry、Application通知。`SAME` | 同左。`SAME` | 同左。ただしResult送信を妨げない。`SAME` |
-| `RESULT_SEND_COMPLETED` | `REJECT`: Result未確定 | `REJECT`: Result未確定 | `ALLOW`: 保持責務完了後に`RELEASE` |
-| `RESULT_SEND_FAILED` | `REJECT`: Result未確定 | `REJECT`: Result未確定 | retry、保持、Runtime error通知のPolicyを適用。`SAME`または`RELEASE`は後続規約で決定 |
+| `RESULT_SEND_COMPLETED` | `INVARIANT_VIOLATION`: Result未確定 | `INVARIANT_VIOLATION`: Result未確定 | `ALLOW`: 保持責務完了後に`RELEASE` |
+| `RESULT_SEND_FAILED` | `INVARIANT_VIOLATION`: Result未確定 | `INVARIANT_VIOLATION`: Result未確定 | retry、保持、Runtime error通知のPolicyを適用。`SAME`または`RELEASE`は後続規約で決定 |
 | `TRANSPORT_DISCONNECTED` | Goal実行を継続、abort、保持のいずれかを設定・Protocolで決定 | 停止処理を継続するかを設定・Protocolで決定 | Result保持・再送・破棄Policyを決定 |
-| `APPLICATION_RESPONSE_TIMEOUT` | Goal accept後のCancel判断timeoutとして扱う場合、Cancel ResponseをRuntimeが拒否する候補。`SAME` | 通常は対象外 | 通常は対象外 |
+| `APPLICATION_RESPONSE_TIMEOUT` | Cancel判断timeoutとして扱う場合、RuntimeがCancel Responseを拒否する候補。`SAME` | 通常は対象外 | 通常は対象外 |
+| `SERVER_SHUTDOWN_REQUESTED` | shutdown policyへ`DEFER`。`SAME`または`FINISHING`は後続規約で決定 | shutdown policyへ`DEFER`。`SAME`または`FINISHING`は後続規約で決定 | Result配送・保持を含むshutdown policyへ`DEFER` |
+| `RUNTIME_FORCED_TERMINATION` | 可能ならterminal通知を試み、Runtime errorを記録。解放条件は後続規約で決定 | 同左 | Result配送不能を含むRuntime errorを記録し、解放条件は後続規約で決定 |
 
-## 11. イレギュラーケースの洗い出し
+### 12.1 ShutdownとRuntime強制終了
 
-以下は、イベントマトリクスから後続のエラー・競合規約へ送る主要論点です。
+`SERVER_SHUTDOWN_REQUESTED`は、graceful shutdown、猶予時間、強制終了などのPolicyへ委譲します。本状態モデルでは具体的なtimeoutや停止方式を固定しません。
 
-### 11.1 Result確定とFeedback発行の競合
+`RUNTIME_FORCED_TERMINATION`は、Runtime自身の資源枯渇や内部障害によってGoal処理を継続できないケースを表します。この場合、terminal Resultを送信できるとは限りません。
 
-```text
-Application thread A: COMPLETE_SUCCEEDED
-Application thread B: PUBLISH_FEEDBACK
-```
+## 13. イレギュラーケースの洗い出し
 
-Runtimeが先に受理したイベントによって結果を決めます。
+後続のエラー・競合規約で、少なくとも以下を確定します。
 
-- Feedbackが先に受理された場合、そのFeedback送信後に`FINISHING`へ遷移できる。
-- Completeが先に受理された場合、`FINISHING`へ遷移し、後続Feedbackを拒否する。
+- Result確定とFeedback発行の競合
+- 通常完了とCancel Requestの競合
+- Cancel受理と通常成功の競合
+- 重複完了
+- `FINISHING`中のCancel
+- Result送信失敗
+- Transport切断
+- Server shutdown中の既存Goal
+- Runtime強制終了時の通知・解放
 
-具体的な排他・atomicity要件は後続文書で定義します。
-
-### 11.2 通常完了とCancel Requestの競合
-
-```text
-Server Application: COMPLETE_SUCCEEDED
-Client: Cancel Request
-```
-
-- Completeが先に`FINISHING`へ遷移させた場合、Cancel Requestは受理しない。
-- Cancel Requestが先にApplicationへ通知されても、Applicationがacceptする前に通常完了が確定する可能性がある。
-
-Cancel判断待ちと通常完了の優先規則は、後続の競合規約で確定します。
-
-### 11.3 Cancel受理と通常成功の競合
-
-`CANCELING`へ遷移した後の`COMPLETE_SUCCEEDED`は、原則として不正とします。
-
-ただし、停止要求を受けた時点ですでに目的を達成していた場合などを`SUCCEEDED`として許容するかはApplication semanticsに関係するため、レビュー対象です。
-
-### 11.4 重複完了
-
-同じGoalへ複数の`COMPLETE_*`が発行された場合、最初に受理された終端結果だけを有効とします。
-
-後続の完了要求は、次のいずれかとします。
-
-- 同一terminal statusおよび同一Resultなら冪等に成功扱い
-- statusやResultに関係なく重複完了エラー
-
-この選択は後続のAPIおよび競合規約で決定します。
-
-### 11.5 FINISHING中のCancel
-
-Resultがすでに確定しているため、新しいCancelはGoalの終端結果を変更しません。
-
-Cancel Responseとして何を返すかは、次の候補があります。
-
-- `REJECTED`: completion already committed
-- terminal Resultを再通知する
-- unknown/finished Goalとして扱う
-
-### 11.6 Result送信失敗
-
-Result送信に失敗しても、Applicationの処理結果はすでに確定しています。
-
-したがって、`FINISHING`から`DOING`または`CANCELING`へ戻してはなりません。
-
-```text
-FINISHING
-  -> Result send failed
-  -> FINISHINGを維持、またはRuntime Contextをエラー終了
-```
-
-再送および保持期間は、Transport非依存のProtocol規約とRuntime設定の境界を後続文書で整理します。
-
-## 12. Feedback規則
+## 14. Feedback規則
 
 Feedbackの発行契機および周期はServer Applicationが決定します。
 
@@ -340,54 +272,32 @@ Protocolは次のみを規定します。
 
 `CANCELING`中のFeedbackを許可するかはレビュー対象です。
 
-## 13. 状態をProtocol公開するか
+## 15. 現時点の設計判断
 
-`DOING`、`CANCELING`、`FINISHING`は、まずServer Runtimeがイベント受理可否を判断するための正規状態です。
-
-これらをClientへ明示的に通知するPDUを追加するかは、本状態モデルでは決定しません。
-
-現在のPDU契約では、Clientは次のメッセージからlifecycleを観測します。
-
-```text
-Goal Response(ACCEPTED)
-Feedback 0..N
-Cancel Response(ACCEPTED / REJECTED)
-Result(SUCCEEDED / CANCELED / ABORTED)
-```
-
-Client側が観測する状態とServer Runtimeの内部状態は同一である必要はありません。
-
-## 14. 現時点の設計判断
-
-- Action Type全体の状態はProtocolに持たない。
-- worker状態はApplication実装の責務であり、本状態モデルから除外する。
-- Goal Requestがrejectされた場合、Goalインスタンスを生成しない。
 - GoalインスタンスはApplicationのaccept後、`DOING`で生成する。
-- 初期状態は実体stateにせず、initial pseudo-stateで表現する。
 - accept済みGoalは`DOING`、`CANCELING`、`FINISHING`の3状態をMUSTで持つ。
+- `UNKNOWN_GOAL_ID_REQUEST_RECEIVED`はper-goal状態マトリクスではなくRuntime dispatcherで扱う。
 - Cancel Request受信だけでは`CANCELING`へ遷移しない。
-- ApplicationがCancelをacceptした時点で`CANCELING`へ遷移する。
+- `ACCEPT_CANCEL`および`REJECT_CANCEL`はCancel判断待ちContextが存在する場合だけ有効とする。
+- Application APIの誤用、Protocol拒否、Runtime不変条件違反を区別する。
 - terminal statusとResult確定時に`FINISHING`へ遷移する。
-- `FINISHING`中は新規Feedback、Cancel、別の完了要求によって終端結果を変更しない。
+- `SERVER_SHUTDOWN_REQUESTED`と`RUNTIME_FORCED_TERMINATION`をRuntime起因イベントとして検討対象に含める。
 - Result送信後のRuntime保持責務が完了した時点でGoalインスタンスを破棄する。
-- イベント処理規則は、イベント×状態マトリクスで定義する。
 
-## 15. レビューで確認する事項
+## 16. レビューで確認する事項
 
-1. イベントの洗い出しに不足がないか。
-2. 各イベントの発生元と受信側が正しいか。
-3. `CANCELING`中のFeedbackを許可するか。
-4. `CANCELING`中の`COMPLETE_SUCCEEDED`を常に拒否するか。
-5. `DOING`中の`COMPLETE_CANCELED`を常に拒否するか。
-6. Cancel判断待ち中に通常完了した場合、未回答Cancelへ何を返すか。
-7. `CANCELING`中の重複Cancel Requestを冪等応答にするか。
-8. `FINISHING`中のCancel Requestへ何を返すか。
-9. 重複`COMPLETE_*`を冪等またはエラーのどちらにするか。
-10. Result送信失敗時の保持、再送、解放条件をどこで定義するか。
-11. Transport切断時にApplication実行を継続するかをProtocolが規定するか。
-12. 状態をClientへ明示公開する必要があるか。
+1. `CANCELING`中のFeedbackを許可するか。
+2. `CANCELING`中の`COMPLETE_SUCCEEDED`を常にApplication API Errorとするか。
+3. `DOING`中の`COMPLETE_CANCELED`を常にApplication API Errorとするか。
+4. Cancel判断待ち中に通常完了した場合、未回答Cancelへ何を返すか。
+5. `CANCELING`中の重複Cancel Requestを冪等応答にするか。
+6. `FINISHING`中のCancel Requestへ何を返すか。
+7. 重複`COMPLETE_*`を冪等またはエラーのどちらにするか。
+8. Result送信失敗時の保持、再送、解放条件をどこで定義するか。
+9. shutdown policyをProtocol、Runtime設定、Application Policyのどこへ置くか。
+10. Runtime強制終了時にterminal通知を試行する条件をどう定義するか。
 
-## 16. 対象外
+## 17. 対象外
 
 - PDUのバイトレイアウト
 - 公開APIの具体的な関数シグネチャ
@@ -395,5 +305,3 @@ Client側が観測する状態とServer Runtimeの内部状態は同一である
 - Application内部のworkerおよびqueue状態
 - 状態・イベント処理の排他実装
 - Resultおよび終了済み`goal_id`の具体的な保持時間
-
-これらは、Protocol、エラー・競合規約、API設計、設定モデルで順に具体化します。


### PR DESCRIPTION
Related: #44, #50, #51

## 概要

Claudeレビューと再検討を踏まえ、Hakoniwa Action Serverの状態モデルと責務境界を整理します。

## 反映内容

- `UNKNOWN_GOAL_ID_REQUEST_RECEIVED`をper-goal状態マトリクスから外し、Runtime dispatcherのlookup失敗として分離
- Decision分類を明確化
  - `PROTOCOL_REJECT`
  - `APPLICATION_API_ERROR`
  - `INVARIANT_VIOLATION`
- `ACCEPT_CANCEL` / `REJECT_CANCEL`について、pending contextなしと二重呼び出しをApplication API Errorとして定義
- Cancel Requestの重複相関方式は後続Protocol文書で定義することを明記
- `RESULT_SEND_COMPLETED` / `RESULT_SEND_FAILED`が実行中状態で発生した場合をRuntime不変条件違反として整理
- 状態名を`DOING`からROS 2と同じ`EXECUTING`へ変更
- `CANCELING`中のFeedbackを`ALLOW`として確定
- `CANCELING`中の`COMPLETE_SUCCEEDED`を`APPLICATION_API_ERROR`として確定
- ROS 2 Actionとの親和性を説明する節を追加
- `ABORTED`をApplicationによる意味論上の失敗として定義し、通信・基盤異常から分離
- `RUNTIME_CANCEL_REQUESTED(goal_id, cause)`を追加
- `TRANSPORT_DISCONNECTED`からRuntime起因Cancelを発生させ、Applicationの正規Cancel経路へ流す設計を追加
- Applicationハング、complete忘れ、Runtimeの致命的障害の救済は初版の対象外と明記
- `02-responsibility-boundaries.md`の`ACCEPTED / QUEUED / EXECUTING`未確定事項を解消

## 状態モデル

```text
normal:
  [*] -> EXECUTING -> FINISHING -> [*]

cancel:
  [*] -> EXECUTING -> CANCELING -> FINISHING -> [*]
```

`FINISHING`はROS 2の公開Goal stateを置き換えるものではなく、terminal statusとResult確定後の配送・保持・遅延イベントを制御する箱庭Runtime内部状態です。

## Runtime起因Cancel

```text
TRANSPORT_DISCONNECTED
  -> disconnect policy
  -> RUNTIME_CANCEL_REQUESTED(
       goal_id,
       cause = TRANSPORT_DISCONNECTED)
  -> ApplicationへCancel通知
  -> ACCEPT_CANCEL
  -> CANCELING
  -> COMPLETE_CANCELED
  -> FINISHING
```

RuntimeはClient Cancelを偽装せず、Applicationの正規停止経路を再利用します。切断済みClientへのCancel Responseは送信しません。

## 最終レビューで確認したい点

- ROS 2との対応関係の記述に誤りがないか
- `FINISHING`がGoal意味論ではなくRuntime内部状態として明確か
- `ABORTED`と通信・基盤異常の責務分離が明確か
- `RUNTIME_CANCEL_REQUESTED`がClient Cancelと適切に分離されているか
- 02と04の責務境界・状態定義が整合しているか
- 残っているレビュー対象セルに重大な矛盾やイベント漏れがないか

このPRはServer側状態遷移仕様の最終レビュー用Draftです。