### PR TITLE
Clarify Action client ROS compatibility and timeout policy

### DIFF
--- a/docs/design/action/05-client-state-model.md
+++ b/docs/design/action/05-client-state-model.md
@@ -1,7 +1,7 @@
 # Hakoniwa Action Clientの状態モデル
 
 > **Status: Draft**  
-> 本文書はレビューと議論のための初稿です。現時点では確定仕様ではありません。
+本文書はレビューと議論のための初稿です。現時点では確定仕様ではありません。
 
 ## 1. 目的
 
@@ -71,13 +71,15 @@ FINISHING -> RELEASE
 
 ## 4. Goal確立前のContext
 
-`SEND_GOAL`を呼び出した時点で、Client Runtimeは`goal_id`を生成し、Goal Requestを送信するためのContextを作成します。
+`SEND_GOAL`を呼び出した時点で、Client RuntimeはGoal Requestを送信するためのContextを作成します。
+
+通常のHakoniwa ClientではRuntimeがUUID形式の`goal_id`を生成します。ROS BridgeなどのAdapterは、外部で生成された互換UUIDを`goal_id`として指定できます。生成元が異なっても、以降の状態遷移は同じです。
 
 Goal Responseを受信するまでは、accept済みGoalの主状態を持ちません。
 
 ```text
 SEND_GOAL
-  -> goal_id生成
+  -> goal_idを生成、または外部UUIDを受け入れる
   -> Goal Context生成
   -> Goal Request送信
   -> goal_response_pending = true
@@ -94,7 +96,19 @@ Goal Response REJECTED
   -> goal_response_pending = false
   -> Client Applicationへreject通知
   -> RELEASE
+
+REQUEST_SEND_FAILED(GOAL)
+  -> goal_response_pending = false
+  -> Client Applicationへ送信失敗を通知
+  -> RELEASE
+
+RESPONSE_TIMEOUT(GOAL_RESPONSE)
+  -> goal_response_pending = false
+  -> Client Applicationへtimeoutを通知
+  -> RELEASE
 ```
+
+Goal Response timeout時、Goal RequestがServerへ到達し、Server側でaccept済みとなっている可能性があります。しかし、Client Runtimeはこの可能性を理由に追加主状態、状態照会、自動再送、特別な救済処理を導入しません。Client側では通信失敗としてContextを解放し、Server側で残存Goalが発生し得ることは異常ケースとして扱います。
 
 `GOAL_REQUESTING`や`ACCEPTED`などの追加主状態は設けません。これはROS 2 Action ClientがGoal Response待ちをFutureで表現する考え方と整合します。
 
@@ -114,7 +128,7 @@ REQUEST_CANCEL(goal_id)
 Runtimeは少なくとも次を行います。
 
 - Goal bodyのローカル検査
-- UUID形式の`goal_id`生成
+- UUID形式の`goal_id`生成、またはAdapterが指定した互換UUIDの受け入れ
 - Goal Context生成
 - Goal Request送信
 - Goal Response待ちContext生成
@@ -135,6 +149,8 @@ EXECUTING + REQUEST_CANCEL
 Cancel Requestを送信しただけではGoal状態を変更しません。
 
 `CANCELING`または`FINISHING`での二重呼び出しは、Client Application APIの誤用として扱います。
+
+Hakoniwa Action Protocol v1の`REQUEST_CANCEL`は単一`goal_id`だけを対象とします。ROS 2の全Goal Cancelや時刻指定Cancelは、`hakoniwa-pdu-ros`が自身の管理するGoalHandleを列挙し、対象Goalごとの単一`REQUEST_CANCEL`へ分解します。一括Cancelを共通Protocolの主状態やイベントへ持ち込みません。
 
 ## 6. ClientとServerで共通のProtocolイベント
 
@@ -201,9 +217,11 @@ unknown `goal_id`へのAPI呼び出しも`APPLICATION_API_ERROR`とします。
 | Event | EXECUTING | CANCELING | FINISHING |
 | --- | --- | --- | --- |
 | `FEEDBACK_RECEIVED` | `ALLOW`: sequenceを検査しApplicationへ通知。`SAME` | `ALLOW`: Serverが送信した停止進捗をApplicationへ通知。`SAME` | 遅延Feedbackとして`IGNORE`または診断記録。`SAME` |
-| `CANCEL_RESPONSE_RECEIVED(ACCEPTED)` | pending Contextがあれば`ALLOW`: pendingを解除し`CANCELING`へ | 重複応答として`IDEMPOTENT`または診断記録。`SAME` | 遅延応答として`IGNORE`または診断記録。`SAME` |
-| `CANCEL_RESPONSE_RECEIVED(REJECTED)` | pending Contextがあれば`ALLOW`: pendingを解除し`EXECUTING`維持 | Server状態との不整合として`PROTOCOL_REJECT`または診断記録。`SAME` | 遅延応答として`IGNORE`または診断記録。`SAME` |
+| `CANCEL_RESPONSE_RECEIVED(ACCEPTED)` | `cancel_response_pending=true`なら`ALLOW`: pendingを解除し`CANCELING`へ。falseなら`IGNORE`: 診断を記録し`SAME` | 重複応答として`IDEMPOTENT`または診断記録。`SAME` | 遅延応答として`IGNORE`または診断記録。`SAME` |
+| `CANCEL_RESPONSE_RECEIVED(REJECTED)` | `cancel_response_pending=true`なら`ALLOW`: pendingを解除し`EXECUTING`維持。falseなら`IGNORE`: 診断を記録し`SAME` | Server状態との不整合として診断記録し`IGNORE`。`SAME` | 遅延応答として`IGNORE`または診断記録。`SAME` |
 | `RESULT_RECEIVED` | `ALLOW`: terminal statusとResultを確定し`FINISHING`へ | `ALLOW`: terminal statusとResultを確定し`FINISHING`へ | 重複Resultとして冪等処理または診断記録。`SAME` |
+
+pending Contextが存在しないCancel Responseは、Client Application APIの誤用ではありません。相関不能、遅延、重複したProtocol応答としてApplicationへ通知せず、診断を記録して`IGNORE`します。
 
 `RESULT_RECEIVED`に含まれるterminal statusは、少なくとも`SUCCEEDED`、`CANCELED`、`ABORTED`を扱います。
 
@@ -232,7 +250,9 @@ Runtime自体のクラッシュ、メモリ破壊、プロセス強制終了な�
 | `TRANSPORT_DISCONNECTED` | Applicationへ通信切断を通知し、再接続Policyへ`DEFER`。`SAME` | 同左。Server側の停止処理を推測しない。`SAME` | Result通知・Context解放の状況に応じて保持Policyへ`DEFER` |
 | `CLIENT_SHUTDOWN_REQUESTED` | shutdown policyへ`DEFER`。Goalを自動的に`CANCELED`または`ABORTED`へ変更しない | 同左 | Application通知とContext解放Policyへ`DEFER` |
 
-Goal Request送信前後の`REQUEST_SEND_FAILED(GOAL)`および`RESPONSE_TIMEOUT(GOAL_RESPONSE)`は、Goal確立前のContextで扱います。accept済みGoalの主状態は生成しません。
+Goal確立前の`REQUEST_SEND_FAILED(GOAL)`および`RESPONSE_TIMEOUT(GOAL_RESPONSE)`は4節で定義します。どちらもaccept済みGoalの主状態を生成せず、Client Applicationへ通信失敗を通知してGoal確立前Contextを解放します。
+
+Goal Response timeout後にServer側へGoalが残る可能性はありますが、初版Client Runtimeは状態照会、自動再送、受理状態UNKNOWNなどの特別な救済を提供しません。このケースはServer側の異常ケースとして記録し、Client状態モデルは単純な通信失敗として閉じます。
 
 ## 12. 通信異常とGoal terminal statusの分離
 
@@ -248,9 +268,11 @@ RESPONSE_TIMEOUT
   != ABORTED
 ```
 
-通信異常時点では、Server上のGoalが`EXECUTING`、`CANCELING`、terminal済みのいずれであるかをClientが確定できないためです。
+accept済みGoalの通信異常時点では、Server上のGoalが`EXECUTING`、`CANCELING`、terminal済みのいずれであるかをClientが確定できないためです。
 
-Client Runtimeは通信異常をClient Applicationへ通知し、Goal Contextを保持したうえで、再接続、状態照会、Result再取得、保持期限による解放などのPolicyへ委譲します。
+accept済みGoalについては、Client Runtimeが通信異常をClient Applicationへ通知し、Goal Contextを保持したうえで、再接続、状態照会、Result再取得、保持期限による解放などのPolicyへ委譲します。
+
+Goal確立前のGoal Request送信失敗またはGoal Response timeoutは、Client Applicationへ通信失敗を通知してContextを解放します。Goal Response timeout時にServer側でGoalが残り得ることを理由に、Client側へ新しい主状態や救済Protocolを追加しません。
 
 ## 13. ROS 2 Action Clientとの親和性
 
@@ -266,8 +288,12 @@ Client状態モデルは、ROS 2 Action ClientのGoalHandleとFutureの構造へ
 | `CANCELING` | `CANCELING` | ServerがCancelを受理した状態 |
 | `RESULT_RECEIVED` | Result Future completion | terminal Result受信 |
 | `FINISHING` | Future解決、callback実行、GoalHandle後処理 | Hakoniwa Runtime内部状態 |
+| 単一`goal_id` Cancel | ROS 2の単一・複数Goal Cancel | Bridgeが複数対象をgoal_id単位へ分解 |
+| Goal Context管理 | ROS 2 status topic生成元 | Bridgeが管理中GoalからROS側statusを生成 |
 
 箱庭独自の`FINISHING`はROS 2の公開Goal Statusへ変換しません。`hakoniwa-pdu-ros`内部でResult Future解決やcallback実行を行う後処理として閉じ込めます。
+
+Hakoniwa共通ProtocolはROS 2のstatus topic相当のブロードキャストを持ちません。`hakoniwa-pdu-ros`が自身の管理するGoalHandleとHakoniwa Goal状態からROS 2のstatus topicを生成します。status topicはClient側主状態へ新しいイベントを追加する理由にはしません。
 
 Client RuntimeはServer状態を推測して先行遷移しません。
 
@@ -290,23 +316,29 @@ RESULT_RECEIVED
 - Goal Response待ち、Cancel Response待ち、Result待ちはpending Contextとして管理する。
 - `GOAL_REQUESTING`、`CANCEL_REQUESTING`、`RESULT_WAITING`などの主状態を追加しない。
 - Client Application APIは初版では`SEND_GOAL`と`REQUEST_CANCEL`を必須とする。
+- 通常ClientはRuntimeが`goal_id`を生成し、Adapterは外部UUIDを指定できる。
+- Hakoniwa Protocol v1のCancelは単一`goal_id`を対象とし、ROS 2の一括CancelはBridgeが単一Goal Cancelへ分解する。
 - Cancel Request送信だけでは`CANCELING`へ遷移しない。
 - Cancel Response ACCEPTED受信時に`CANCELING`へ遷移する。
+- pending ContextのないCancel Responseは診断を記録して`IGNORE`する。
 - Result受信時に`FINISHING`へ遷移し、Application通知後にContextを解放する。
 - ClientとServer間のProtocolイベントは共通のデータ契約を使用する。
 - Client Application APIの二重呼び出しは`APPLICATION_API_ERROR`として扱う。
+- Goal Request送信失敗とGoal Response timeoutは、Client側では通信失敗としてGoal確立前Contextを解放する。
+- Goal Response timeout後にServer側Goalが残る可能性に対し、Client側へ特別な状態、照会、自動再送を追加しない。
+- Hakoniwa共通ProtocolはROS 2 status topic相当を持たず、ROS Bridgeが管理中GoalからROS statusを生成する。
 - 通信異常をGoalの`CANCELED`または`ABORTED`へ自動変換しない。
 - Runtimeの致命的内部障害からの正規状態遷移は初版の対象外とする。
 
 ## 15. レビューで確認する事項
 
 1. `CANCELING`中に受信したFeedbackを常にClient Applicationへ通知するか。
-2. 重複Cancel Responseを冪等処理、IGNORE、Protocol Errorのどれにするか。
+2. 重複Cancel Responseを冪等処理またはIGNOREのどちらにするか。
 3. `FINISHING`中の遅延FeedbackおよびCancel ResponseをIGNOREとするか、診断対象とするか。
 4. 重複Resultを冪等処理するために保持すべき情報は何か。
 5. ResultをServer pushとClient pullのどちらで配送するか。
-6. Goal Response、Cancel Response、Resultのtimeout Policyをどこで定義するか。
-7. 通信切断後の再接続、状態照会、Result再取得、Context解放条件をどう定義するか。
+6. Cancel ResponseおよびResultのtimeout Policyをどこで定義するか。
+7. accept済みGoalの通信切断後に、再接続、状態照会、Result再取得、Context解放条件をどう定義するか。
 8. Client shutdown時に未終端GoalへCancelを試行するか。
 
 ## 16. 対象外
@@ -315,5 +347,6 @@ RESULT_RECEIVED
 - 公開APIの具体的な関数シグネチャ
 - ROS 2 executorおよびFuture実装の詳細
 - Transport固有のretryおよび再接続実装
+- Goal Response timeout後の自動照会、自動再送、受理状態UNKNOWNの導入
 - Runtimeが正規のイベント処理を継続できない致命的障害
 - Resultおよび終了済み`goal_id`の具体的な保持時間


### PR DESCRIPTION
Related: #44, #50, #51, #52, #53, #54

## 概要

Client状態モデルのレビューで合意した修正と、Goal Response timeoutを単純な通信失敗として扱う設計意図を追記します。

## 変更内容

- Hakoniwa Protocol v1のCancelは単一`goal_id`を対象とする
- ROS 2の全Goal Cancel／時刻指定Cancelは`hakoniwa-pdu-ros`が対象Goalを列挙し、単一Goal Cancelへ分解する
- Hakoniwa共通ProtocolはROS 2 status topic相当のブロードキャストを持たず、Bridgeが管理中GoalからROS statusを生成する
- `cancel_response_pending=false`で受信したCancel Responseは診断を記録して`IGNORE`する
- 通常ClientはRuntimeがUUIDを生成し、ROS BridgeなどのAdapterは外部UUIDを指定できる
- Goal Request送信失敗とGoal Response timeoutの処理をGoal確立前Contextへ明記する

## Goal Response timeoutの設計意図

Goal Response timeout時、RequestがServerへ到達してaccept済みとなっている可能性はあります。

ただしv1 Client Runtimeでは、これを理由に次の仕組みを追加しません。

- 受理状態`UNKNOWN`の追加
- 自動状態照会
- Goal Requestの自動再送
- 特別な救済Protocol

Client側では通信失敗としてApplicationへ通知し、Goal確立前Contextを解放します。Server側にGoalが残る可能性は異常ケースとして扱い、Client状態モデルを複雑化しません。

## レビュー観点

- ROS 2一括CancelをBridge側で分解する責務境界が妥当か
- pendingなしCancel Responseを`IGNORE + diagnostic`とする方針が妥当か
- Goal Response timeoutに特別な救済を持ち込まない方針が明確か
- ROS status topicをBridge責務とする記述が適切か
