### PR TITLE
Add Action protocol overview and logical packet fields

### DIFF
--- a/docs/design/action/06-protocol.md
+++ b/docs/design/action/06-protocol.md
@@ -1,0 +1,287 @@
+# Hakoniwa Action Protocol概要
+
+> **Status: Draft**  
+> 本文書は、Hakoniwa Action Protocolの通信端点、代表的な通信順序、論理パケット項目を直感的に理解するための概要です。
+
+## 1. 目的
+
+本書は、Action通信について次の3点を示します。
+
+```text
+誰から誰へ送るか
+何を送るか
+どの順番で送るか
+```
+
+状態とイベントの網羅的な許容規則は、以下を正とします。
+
+- Server Runtime: `04-state-model.md`
+- Client Runtime: `05-client-state-model.md`
+
+本書では、それらの状態遷移を重複して再定義しません。
+
+## 2. 通信端点
+
+```text
+Client Application
+  -> Client Runtime
+  -> Transport
+  -> Server Runtime
+  -> Server Application
+```
+
+Client RuntimeとServer Runtimeの間では、次の共通Protocolイベントを使用します。
+
+```text
+GOAL_REQUEST
+GOAL_RESPONSE
+FEEDBACK
+CANCEL_REQUEST
+CANCEL_RESPONSE
+RESULT
+```
+
+## 3. 代表シーケンス
+
+### 3.1 Goal受理と正常完了
+
+```text
+Client Runtime                    Server Runtime
+      |                                 |
+      |--- GOAL_REQUEST --------------->|
+      |                                 |--- Server ApplicationへGoal通知
+      |                                 |<-- accept
+      |<-- GOAL_RESPONSE(ACCEPTED) ------|
+      |                                 |
+      |<-- FEEDBACK [0..n] --------------|
+      |                                 |
+      |<-- RESULT(SUCCEEDED) -------------|
+      |                                 |
+```
+
+- Goal Responseが`ACCEPTED`の場合、ClientとServerはGoalを`EXECUTING`として扱います。
+- Feedbackは0回以上送信できます。
+- Result受信後、Client Runtimeは`FINISHING`へ進み、Application通知後にContextを解放します。
+
+### 3.2 Goal拒否
+
+```text
+Client Runtime                    Server Runtime
+      |                                 |
+      |--- GOAL_REQUEST --------------->|
+      |                                 |--- Server ApplicationへGoal通知
+      |                                 |<-- reject
+      |<-- GOAL_RESPONSE(REJECTED) ------|
+      |                                 |
+```
+
+拒否されたGoalはaccept済みGoalの主状態を持ちません。
+
+### 3.3 Client起因Cancel
+
+```text
+Client Runtime                    Server Runtime
+      |                                 |
+      |--- CANCEL_REQUEST ------------->|
+      |                                 |--- Server ApplicationへCancel通知
+      |                                 |<-- accept cancel
+      |<-- CANCEL_RESPONSE(ACCEPTED) ----|
+      |                                 |
+      |<-- FEEDBACK [0..n] --------------|
+      |                                 |
+      |<-- RESULT(CANCELED) --------------|
+      |                                 |
+```
+
+- Cancel Request送信だけではClient状態を変更しません。
+- Cancel Responseが`ACCEPTED`の場合、ClientとServerはGoalを`CANCELING`として扱います。
+- Cancel Responseが`REJECTED`の場合、Goalは`EXECUTING`を維持します。
+
+### 3.4 Runtime起因Cancel
+
+```text
+Server Runtime                    Server Application
+      |                                 |
+      |--- RUNTIME_CANCEL_REQUESTED ---->|
+      |                                 |
+      |<-- ACCEPT_CANCEL ----------------|
+      |                                 |
+      |<-- COMPLETE_CANCELED ------------|
+      |                                 |
+      |--- RESULT(CANCELED) ------------> Client Runtime
+```
+
+Runtime起因CancelはClient Cancelを偽装しません。Client endpointが切断済みの場合、Cancel Responseは生成せず、Resultの配送・保持はRuntime Policyへ委譲します。
+
+## 4. 論理パケット一覧
+
+本書では、バイト配置ではなく論理フィールドを定義します。
+
+### 4.1 共通フィールド
+
+| Field | 型・表現 | 説明 |
+| --- | --- | --- |
+| `protocol_version` | unsigned integer | Protocol互換性を識別する。v1初期値は`1` |
+| `message_type` | enum | パケット種別 |
+| `action_type_id` | identifier | Action Typeを識別する |
+| `goal_id` | 128-bit UUID | Goal lifecycleを識別する |
+| `request_id` | unsigned integer | RequestとResponseを相関する。Request/Response系のみ有効 |
+| `body_length` | unsigned integer | bodyのbyte長 |
+
+`goal_id`と`request_id`の責務を分離します。
+
+```text
+goal_id:
+  Goalインスタンスの識別
+
+request_id:
+  個々のRequest / Responseの相関
+```
+
+### 4.2 GOAL_REQUEST
+
+| Field | 説明 |
+| --- | --- |
+| 共通フィールド | `message_type=GOAL_REQUEST` |
+| `goal_body` | Action固有Goalデータ |
+
+通常ClientではClient Runtimeが`goal_id`を生成します。ROS BridgeなどのAdapterは、外部UUIDを`goal_id`として指定できます。
+
+### 4.3 GOAL_RESPONSE
+
+| Field | 説明 |
+| --- | --- |
+| 共通フィールド | `message_type=GOAL_RESPONSE`。Requestと同じ`goal_id`および`request_id` |
+| `decision` | `ACCEPTED` / `REJECTED` |
+| `reason_code` | reject理由。accept時は`NONE` |
+
+### 4.4 FEEDBACK
+
+| Field | 説明 |
+| --- | --- |
+| 共通フィールド | `message_type=FEEDBACK`。`request_id`は使用しない |
+| `sequence_no` | Goalごとの単調増加番号 |
+| `feedback_body` | Action固有Feedbackデータ |
+
+`sequence_no`の初期値は`0`とします。
+
+### 4.5 CANCEL_REQUEST
+
+| Field | 説明 |
+| --- | --- |
+| 共通フィールド | `message_type=CANCEL_REQUEST` |
+
+v1では、Cancel Requestは単一`goal_id`を対象とします。
+
+ROS 2の全Goal Cancelおよび時刻指定Cancelは、`hakoniwa-pdu-ros`が対象Goalを列挙し、単一Goal Cancelへ分解します。
+
+### 4.6 CANCEL_RESPONSE
+
+| Field | 説明 |
+| --- | --- |
+| 共通フィールド | `message_type=CANCEL_RESPONSE`。Requestと同じ`goal_id`および`request_id` |
+| `decision` | `ACCEPTED` / `REJECTED` |
+| `reason_code` | reject理由。accept時は`NONE` |
+
+### 4.7 RESULT
+
+| Field | 説明 |
+| --- | --- |
+| 共通フィールド | `message_type=RESULT`。`request_id`は使用しない |
+| `terminal_status` | `SUCCEEDED` / `CANCELED` / `ABORTED` |
+| `result_body` | Action固有Resultデータ |
+
+ResultをServer pushとClient pullのどちらで配送するかは、実装Protocolで確定します。どちらの場合も論理Resultの内容は同じです。
+
+## 5. enum設定値
+
+### 5.1 message_type
+
+```text
+1 = GOAL_REQUEST
+2 = GOAL_RESPONSE
+3 = FEEDBACK
+4 = CANCEL_REQUEST
+5 = CANCEL_RESPONSE
+6 = RESULT
+```
+
+`0`は未設定・無効値として予約します。
+
+### 5.2 decision
+
+```text
+0 = UNSPECIFIED
+1 = ACCEPTED
+2 = REJECTED
+```
+
+### 5.3 terminal_status
+
+```text
+0 = UNSPECIFIED
+1 = SUCCEEDED
+2 = CANCELED
+3 = ABORTED
+```
+
+### 5.4 reason_code
+
+初版では次の最小集合を定義します。
+
+```text
+0 = NONE
+1 = INVALID_REQUEST
+2 = UNKNOWN_GOAL_ID
+3 = DUPLICATE_GOAL_ID
+4 = APPLICATION_REJECTED
+5 = COMPLETION_COMMITTED
+6 = INTERNAL_ERROR
+```
+
+Action固有の詳細理由はbodyまたは将来拡張へ委ねます。
+
+## 6. 型とエンコードの既定方針
+
+- 整数値は符号なし固定幅整数を使用する。
+- multi-byte整数のbyte orderはlittle-endianとする。
+- `goal_id`は16 byte UUIDとして扱う。
+- `request_id`はRequest送信元が採番し、同一endpoint内で未完了Requestと重複しない値とする。
+- `sequence_no`はGoal単位で`0`から始まり、Feedbackごとに1増加する。
+- bodyはAction TypeごとのSchemaに従う。
+- アライメント、padding、固定ヘッダサイズ、body配置はPDUデータモデル／Registry定義で確定する。
+
+## 7. 設計意図
+
+本Protocol概要は、通信の姿を直感的に理解できることを目的とします。
+
+```text
+04 / 05:
+  状態とイベント処理規則
+
+06:
+  通信端点、代表シーケンス、論理パケット項目
+
+PDUデータモデル:
+  バイトレイアウト、型幅、アライメント、Schema
+```
+
+異常系、重複、遅延、timeout、切断、競合を本書で網羅しません。これらの許容可否と状態遷移は`04-state-model.md`および`05-client-state-model.md`を参照します。
+
+## 8. レビューで確認する事項
+
+1. `request_id`をGoal Request／Cancel Requestの双方で必須とするか。
+2. `message_type`、`decision`、`terminal_status`の数値割り当てが妥当か。
+3. `reason_code`の初期集合が過不足ないか。
+4. `sequence_no`を`0`開始とするか。
+5. little-endianをProtocol既定とするか、Transport／CDRへ委譲するか。
+6. Result push/pullをどの後続文書で確定するか。
+
+## 9. 対象外
+
+- 状態遷移規則の再定義
+- 全異常シーケンスの列挙
+- Transport固有のretry、再接続、fragmentation
+- C/C++構造体レイアウト
+- PDU Registryの具体的Schema
+- bodyのAction Type固有定義

--- a/docs/design/action/06-protocol.md
+++ b/docs/design/action/06-protocol.md
@@ -199,15 +199,30 @@ FEEDBACK
 | 論理イベント | Registry packet | Header識別 | body |
 | --- | --- | --- | --- |
 | `GOAL_REQUEST` | `<Action>ActionRequest` | `request_kind=GOAL` | `<Action>Goal` |
-| `GOAL_RESPONSE` | `<Action>ActionResponse` | `response_kind=GOAL` | 原則未使用または既定値 |
+| `GOAL_RESPONSE` | `<Action>ActionResponse` | `response_kind=GOAL` | 既定値・未使用 |
 | `FEEDBACK` | `<Action>ActionFeedback` | Feedback専用Header | `<Action>Feedback` |
-| `CANCEL_REQUEST` | `<Action>ActionRequest` | `request_kind=CANCEL` | 原則未使用または既定値 |
-| `CANCEL_RESPONSE` | `<Action>ActionResponse` | `response_kind=CANCEL` | 原則未使用または既定値 |
+| `CANCEL_REQUEST` | `<Action>ActionRequest` | `request_kind=CANCEL` | 既定値・未使用 |
+| `CANCEL_RESPONSE` | `<Action>ActionResponse` | `response_kind=CANCEL` | 既定値・未使用 |
 | `RESULT` | `<Action>ActionResponse` | `response_kind=RESULT` | `<Action>Result` |
 
 現行Generatorでは、Request packetのbody型は常に`<Action>Goal`、Response packetのbody型は常に`<Action>Result`です。
 
 そのため、Cancel RequestおよびGoal／Cancel ResponseではbodyをProtocol意味論上使用しません。body領域には生成型の既定値を格納します。
+
+既定値は、生成されたAction body型を通常どおり初期化した値とします。未使用bodyを特別なbyte列として扱いません。
+
+```text
+数値型      = 0
+bool        = false
+string      = empty
+可変長配列  = length 0
+固定長配列  = 各要素を既定値
+ネスト型    = 各フィールドを再帰的に既定値
+time        = sec 0 / nanosec 0
+duration    = sec 0 / nanosec 0
+```
+
+受信側は、`request_kind`または`response_kind`によりbodyが未使用と判断した場合、その内容を検証せず参照しません。
 
 この方式はpacket型を増やさず、既存Generatorの3 packet構成を維持します。
 
@@ -312,7 +327,24 @@ uint32 sequence_no
 Feedback送信ごとに1増加
 ```
 
-### 8.7 reserved
+### 8.7 未使用bodyの既定値
+
+Cancel Request、Goal Response、Cancel Responseで使用しないbodyは、PDU Registryが生成した型の通常の既定値で初期化します。
+
+```text
+CANCEL_REQUEST:
+  <Action>Goal body = default initialized
+
+GOAL_RESPONSE:
+  <Action>Result body = default initialized
+
+CANCEL_RESPONSE:
+  <Action>Result body = default initialized
+```
+
+未使用bodyへProtocol上の情報を埋め込むことは禁止します。受信側は未使用bodyを検証・解釈しません。
+
+### 8.8 reserved
 
 reserved領域は送信時に`0`で初期化し、受信時は値に依存しません。
 
@@ -343,7 +375,8 @@ byte order、padding、可変長body、固定サイズはPDU Registryの生成�
 - Action TypeはSchema／endpointで識別し、Headerへ`action_type_id`を追加しない。
 - v1では`request_id`を追加せず、`goal_id`とpending Contextで相関する。
 - body長はPDU Registryへ委ね、Headerへ`body_length`を追加しない。
-- Cancel RequestおよびGoal／Cancel Responseでは生成済みbody型を既定値で保持し、意味論上は使用しない。
+- Cancel RequestおよびGoal／Cancel Responseでは生成済みbody型を通常の型既定値で初期化し、意味論上は使用しない。
+- 受信側は未使用bodyを検証・解釈しない。
 - `sequence_no`は`uint32`で0開始とする。
 - reservedは0送信、受信時無視とする。
 
@@ -352,7 +385,7 @@ byte order、padding、可変長body、固定サイズはPDU Registryの生成�
 1. `request_kind`の数値割り当てを`GOAL=1`、`CANCEL=2`とするか。
 2. `response_kind`の数値割り当てを`GOAL=1`、`CANCEL=2`、`RESULT=3`とするか。
 3. `status`をresponse kind依存の共用フィールドとするか。
-4. Cancel RequestおよびGoal／Cancel Responseのbodyを既定値・未使用とするか。
+4. 未使用bodyを生成型の通常の既定値で初期化し、受信側が解釈しない方針でよいか。
 5. `sequence_no`を0開始とするか。
 
 ## 12. 対象外

--- a/docs/design/action/06-protocol.md
+++ b/docs/design/action/06-protocol.md
@@ -1,16 +1,17 @@
 # Hakoniwa Action Protocol概要
 
 > **Status: Draft**  
-> 本文書は、Hakoniwa Action Protocolの通信端点、代表的な通信順序、論理パケット項目を直感的に理解するための概要です。
+> 本文書は、Hakoniwa Action Protocolの通信端点、代表的な通信順序、および`hakoniwa-pdu-registry`と整合する論理パケット構成を直感的に理解するための概要です。
 
 ## 1. 目的
 
-本書は、Action通信について次の3点を示します。
+本書は、Action通信について次を示します。
 
 ```text
 誰から誰へ送るか
 何を送るか
 どの順番で送るか
+PDU Registry上でどのデータ構造を使うか
 ```
 
 状態とイベントの網羅的な許容規則は、以下を正とします。
@@ -18,7 +19,7 @@
 - Server Runtime: `04-state-model.md`
 - Client Runtime: `05-client-state-model.md`
 
-本書では、それらの状態遷移を重複して再定義しません。
+本書では、異常系や競合を再網羅しません。
 
 ## 2. 通信端点
 
@@ -30,7 +31,7 @@ Client Application
   -> Server Application
 ```
 
-Client RuntimeとServer Runtimeの間では、次の共通Protocolイベントを使用します。
+Client RuntimeとServer Runtimeの間では、次の論理イベントを扱います。
 
 ```text
 GOAL_REQUEST
@@ -40,6 +41,8 @@ CANCEL_REQUEST
 CANCEL_RESPONSE
 RESULT
 ```
+
+これらは、PDU RegistryのAction packetへ写像します。
 
 ## 3. 代表シーケンス
 
@@ -56,12 +59,11 @@ Client Runtime                    Server Runtime
       |<-- FEEDBACK [0..n] --------------|
       |                                 |
       |<-- RESULT(SUCCEEDED) -------------|
-      |                                 |
 ```
 
-- Goal Responseが`ACCEPTED`の場合、ClientとServerはGoalを`EXECUTING`として扱います。
+- Goal Responseが`ACCEPTED`の場合、双方はGoalを`EXECUTING`として扱います。
 - Feedbackは0回以上送信できます。
-- Result受信後、Client Runtimeは`FINISHING`へ進み、Application通知後にContextを解放します。
+- Result受信後、Client Runtimeは`FINISHING`へ進みます。
 
 ### 3.2 Goal拒否
 
@@ -72,7 +74,6 @@ Client Runtime                    Server Runtime
       |                                 |--- Server ApplicationへGoal通知
       |                                 |<-- reject
       |<-- GOAL_RESPONSE(REJECTED) ------|
-      |                                 |
 ```
 
 拒否されたGoalはaccept済みGoalの主状態を持ちません。
@@ -84,18 +85,15 @@ Client Runtime                    Server Runtime
       |                                 |
       |--- CANCEL_REQUEST ------------->|
       |                                 |--- Server ApplicationへCancel通知
-      |                                 |<-- accept cancel
-      |<-- CANCEL_RESPONSE(ACCEPTED) ----|
+      |                                 |<-- accept / reject
+      |<-- CANCEL_RESPONSE --------------|
       |                                 |
-      |<-- FEEDBACK [0..n] --------------|
-      |                                 |
-      |<-- RESULT(CANCELED) --------------|
-      |                                 |
+      |<-- RESULT(CANCELED) --------------|  accept時
 ```
 
 - Cancel Request送信だけではClient状態を変更しません。
-- Cancel Responseが`ACCEPTED`の場合、ClientとServerはGoalを`CANCELING`として扱います。
-- Cancel Responseが`REJECTED`の場合、Goalは`EXECUTING`を維持します。
+- Cancel Responseが`ACCEPTED`の場合、双方はGoalを`CANCELING`として扱います。
+- `REJECTED`の場合、Goalは`EXECUTING`を維持します。
 
 ### 3.4 Runtime起因Cancel
 
@@ -103,185 +101,264 @@ Client Runtime                    Server Runtime
 Server Runtime                    Server Application
       |                                 |
       |--- RUNTIME_CANCEL_REQUESTED ---->|
-      |                                 |
       |<-- ACCEPT_CANCEL ----------------|
-      |                                 |
       |<-- COMPLETE_CANCELED ------------|
-      |                                 |
       |--- RESULT(CANCELED) ------------> Client Runtime
 ```
 
-Runtime起因CancelはClient Cancelを偽装しません。Client endpointが切断済みの場合、Cancel Responseは生成せず、Resultの配送・保持はRuntime Policyへ委譲します。
+Runtime起因CancelはClient Cancelを偽装しません。
 
-## 4. 論理パケット一覧
+## 4. PDU RegistryのActionデータ構成
 
-本書では、バイト配置ではなく論理フィールドを定義します。
-
-### 4.1 共通フィールド
-
-| Field | 型・表現 | 説明 |
-| --- | --- | --- |
-| `protocol_version` | unsigned integer | Protocol互換性を識別する。v1初期値は`1` |
-| `message_type` | enum | パケット種別 |
-| `action_type_id` | identifier | Action Typeを識別する |
-| `goal_id` | 128-bit UUID | Goal lifecycleを識別する |
-| `request_id` | unsigned integer | RequestとResponseを相関する。Request/Response系のみ有効 |
-| `body_length` | unsigned integer | bodyのbyte長 |
-
-`goal_id`と`request_id`の責務を分離します。
+`hakoniwa-pdu-registry`のAction generatorは、ROS 2 `.action`から次の6メッセージを生成します。
 
 ```text
-goal_id:
-  Goalインスタンスの識別
-
-request_id:
-  個々のRequest / Responseの相関
+<Action>Goal.msg
+<Action>Result.msg
+<Action>Feedback.msg
+<Action>ActionRequest.msg
+<Action>ActionResponse.msg
+<Action>ActionFeedback.msg
 ```
 
-### 4.2 GOAL_REQUEST
-
-| Field | 説明 |
-| --- | --- |
-| 共通フィールド | `message_type=GOAL_REQUEST` |
-| `goal_body` | Action固有Goalデータ |
-
-通常ClientではClient Runtimeが`goal_id`を生成します。ROS BridgeなどのAdapterは、外部UUIDを`goal_id`として指定できます。
-
-### 4.3 GOAL_RESPONSE
-
-| Field | 説明 |
-| --- | --- |
-| 共通フィールド | `message_type=GOAL_RESPONSE`。Requestと同じ`goal_id`および`request_id` |
-| `decision` | `ACCEPTED` / `REJECTED` |
-| `reason_code` | reject理由。accept時は`NONE` |
-
-### 4.4 FEEDBACK
-
-| Field | 説明 |
-| --- | --- |
-| 共通フィールド | `message_type=FEEDBACK`。`request_id`は使用しない |
-| `sequence_no` | Goalごとの単調増加番号 |
-| `feedback_body` | Action固有Feedbackデータ |
-
-`sequence_no`の初期値は`0`とします。
-
-### 4.5 CANCEL_REQUEST
-
-| Field | 説明 |
-| --- | --- |
-| 共通フィールド | `message_type=CANCEL_REQUEST` |
-
-v1では、Cancel Requestは単一`goal_id`を対象とします。
-
-ROS 2の全Goal Cancelおよび時刻指定Cancelは、`hakoniwa-pdu-ros`が対象Goalを列挙し、単一Goal Cancelへ分解します。
-
-### 4.6 CANCEL_RESPONSE
-
-| Field | 説明 |
-| --- | --- |
-| 共通フィールド | `message_type=CANCEL_RESPONSE`。Requestと同じ`goal_id`および`request_id` |
-| `decision` | `ACCEPTED` / `REJECTED` |
-| `reason_code` | reject理由。accept時は`NONE` |
-
-### 4.7 RESULT
-
-| Field | 説明 |
-| --- | --- |
-| 共通フィールド | `message_type=RESULT`。`request_id`は使用しない |
-| `terminal_status` | `SUCCEEDED` / `CANCELED` / `ABORTED` |
-| `result_body` | Action固有Resultデータ |
-
-ResultをServer pushとClient pullのどちらで配送するかは、実装Protocolで確定します。どちらの場合も論理Resultの内容は同じです。
-
-## 5. enum設定値
-
-### 5.1 message_type
+packetは、共通HeaderとAction固有bodyの組み合わせです。
 
 ```text
-1 = GOAL_REQUEST
-2 = GOAL_RESPONSE
-3 = FEEDBACK
-4 = CANCEL_REQUEST
-5 = CANCEL_RESPONSE
-6 = RESULT
+<Action>ActionRequest
+  hako_action_msgs/ActionRequestHeader header
+  <Action>Goal body
+
+<Action>ActionResponse
+  hako_action_msgs/ActionResponseHeader header
+  <Action>Result body
+
+<Action>ActionFeedback
+  hako_action_msgs/ActionFeedbackHeader header
+  <Action>Feedback body
 ```
 
-`0`は未設定・無効値として予約します。
+この構成をAction Protocol v1のデータ契約の基準とします。
 
-### 5.2 decision
+## 5. Registryで定義済みのHeader
+
+### 5.1 ActionRequestHeader
+
+```text
+uint8     version
+uint8     request_kind
+uint8[2]  reserved
+uint8[16] goal_id
+```
+
+用途:
+
+```text
+GOAL_REQUEST
+CANCEL_REQUEST
+```
+
+`request_kind`により要求種別を区別します。
+
+### 5.2 ActionResponseHeader
+
+```text
+uint8     version
+uint8     response_kind
+uint8     status
+uint8     reserved
+uint8[16] goal_id
+```
+
+用途:
+
+```text
+GOAL_RESPONSE
+CANCEL_RESPONSE
+RESULT
+```
+
+`response_kind`により応答種別を区別し、`status`はその種別に応じた判断またはterminal statusを表します。
+
+### 5.3 ActionFeedbackHeader
+
+```text
+uint8     version
+uint8[3]  reserved
+uint8[16] goal_id
+uint32    sequence_no
+```
+
+用途:
+
+```text
+FEEDBACK
+```
+
+## 6. 論理イベントとRegistry packetの対応
+
+| 論理イベント | Registry packet | Header識別 | body |
+| --- | --- | --- | --- |
+| `GOAL_REQUEST` | `<Action>ActionRequest` | `request_kind=GOAL` | `<Action>Goal` |
+| `GOAL_RESPONSE` | `<Action>ActionResponse` | `response_kind=GOAL` | 原則未使用または既定値 |
+| `FEEDBACK` | `<Action>ActionFeedback` | Feedback専用Header | `<Action>Feedback` |
+| `CANCEL_REQUEST` | `<Action>ActionRequest` | `request_kind=CANCEL` | 原則未使用または既定値 |
+| `CANCEL_RESPONSE` | `<Action>ActionResponse` | `response_kind=CANCEL` | 原則未使用または既定値 |
+| `RESULT` | `<Action>ActionResponse` | `response_kind=RESULT` | `<Action>Result` |
+
+現行Generatorでは、Request packetのbody型は常に`<Action>Goal`、Response packetのbody型は常に`<Action>Result`です。
+
+そのため、Cancel RequestおよびGoal／Cancel ResponseではbodyをProtocol意味論上使用しません。body領域には生成型の既定値を格納します。
+
+この方式はpacket型を増やさず、既存Generatorの3 packet構成を維持します。
+
+## 7. v1で追加しない共通フィールド
+
+初稿で候補としていた次のフィールドは、現行PDU RegistryのAction Headerには存在しないため、v1 Headerへ追加しません。
+
+```text
+action_type_id
+request_id
+body_length
+message_type
+```
+
+理由は次のとおりです。
+
+### 7.1 action_type_id
+
+Action Typeは、使用するPDU Schema／packet型およびendpoint設定によって識別します。packet Headerへ重複して保持しません。
+
+### 7.2 request_id
+
+v1は`goal_id`とpending ContextでGoal／Cancel応答を相関します。独立した`request_id`は追加しません。
+
+Cancel再送の厳密な要求単位相関が必要になった場合は、将来のHeader versionで検討します。
+
+### 7.3 body_length
+
+可変長bodyの配置と長さは、PDU Registryの`MetaData / BaseData / HeapData`形式および生成Schemaが管理します。Action Headerへ独自のbody長を追加しません。
+
+### 7.4 message_type
+
+単一の`message_type`は追加せず、Registryで定義済みの次を使用します。
+
+```text
+request_kind
+response_kind
+Feedback専用packet型
+```
+
+## 8. 設定値
+
+### 8.1 version
+
+```text
+version = 1
+```
+
+Headerの`uint8 version`を使用します。
+
+### 8.2 goal_id
+
+```text
+uint8[16]
+```
+
+128-bit UUIDを16 byteで保持します。
+
+### 8.3 request_kind
+
+初期割り当て案:
 
 ```text
 0 = UNSPECIFIED
-1 = ACCEPTED
-2 = REJECTED
+1 = GOAL
+2 = CANCEL
 ```
 
-### 5.3 terminal_status
+### 8.4 response_kind
+
+初期割り当て案:
 
 ```text
 0 = UNSPECIFIED
-1 = SUCCEEDED
-2 = CANCELED
-3 = ABORTED
+1 = GOAL
+2 = CANCEL
+3 = RESULT
 ```
 
-### 5.4 reason_code
+### 8.5 status
 
-初版では次の最小集合を定義します。
+`status`は`response_kind`によって意味を切り替えます。
 
 ```text
-0 = NONE
-1 = INVALID_REQUEST
-2 = UNKNOWN_GOAL_ID
-3 = DUPLICATE_GOAL_ID
-4 = APPLICATION_REJECTED
-5 = COMPLETION_COMMITTED
-6 = INTERNAL_ERROR
+response_kind = GOAL / CANCEL:
+  0 = UNSPECIFIED
+  1 = ACCEPTED
+  2 = REJECTED
+
+response_kind = RESULT:
+  0 = UNSPECIFIED
+  1 = SUCCEEDED
+  2 = CANCELED
+  3 = ABORTED
 ```
 
-Action固有の詳細理由はbodyまたは将来拡張へ委ねます。
+### 8.6 sequence_no
 
-## 6. 型とエンコードの既定方針
+```text
+uint32 sequence_no
+初期値 = 0
+Feedback送信ごとに1増加
+```
 
-- 整数値は符号なし固定幅整数を使用する。
-- multi-byte整数のbyte orderはlittle-endianとする。
-- `goal_id`は16 byte UUIDとして扱う。
-- `request_id`はRequest送信元が採番し、同一endpoint内で未完了Requestと重複しない値とする。
-- `sequence_no`はGoal単位で`0`から始まり、Feedbackごとに1増加する。
-- bodyはAction TypeごとのSchemaに従う。
-- アライメント、padding、固定ヘッダサイズ、body配置はPDUデータモデル／Registry定義で確定する。
+### 8.7 reserved
 
-## 7. 設計意図
+reserved領域は送信時に`0`で初期化し、受信時は値に依存しません。
 
-本Protocol概要は、通信の姿を直感的に理解できることを目的とします。
+## 9. Registryとの責務境界
 
 ```text
 04 / 05:
   状態とイベント処理規則
 
 06:
-  通信端点、代表シーケンス、論理パケット項目
+  通信端点、代表シーケンス、Header値の意味
 
-PDUデータモデル:
-  バイトレイアウト、型幅、アライメント、Schema
+hakoniwa-pdu-registry:
+  .msg定義
+  固定Header型
+  Action固有body型
+  バイトレイアウト
+  アライメント
+  MetaData / BaseData / HeapData
 ```
 
-異常系、重複、遅延、timeout、切断、競合を本書で網羅しません。これらの許容可否と状態遷移は`04-state-model.md`および`05-client-state-model.md`を参照します。
+byte order、padding、可変長body、固定サイズはPDU Registryの生成規則へ委ねます。本Protocol文書では独自に再定義しません。
 
-## 8. レビューで確認する事項
+## 10. 現時点の設計判断
 
-1. `request_id`をGoal Request／Cancel Requestの双方で必須とするか。
-2. `message_type`、`decision`、`terminal_status`の数値割り当てが妥当か。
-3. `reason_code`の初期集合が過不足ないか。
-4. `sequence_no`を`0`開始とするか。
-5. little-endianをProtocol既定とするか、Transport／CDRへ委譲するか。
-6. Result push/pullをどの後続文書で確定するか。
+- PDU Registryの既存Action Headerをv1データ契約の基準とする。
+- packetはRequest、Response、Feedbackの3種類とし、kindで論理イベントを識別する。
+- Action TypeはSchema／endpointで識別し、Headerへ`action_type_id`を追加しない。
+- v1では`request_id`を追加せず、`goal_id`とpending Contextで相関する。
+- body長はPDU Registryへ委ね、Headerへ`body_length`を追加しない。
+- Cancel RequestおよびGoal／Cancel Responseでは生成済みbody型を既定値で保持し、意味論上は使用しない。
+- `sequence_no`は`uint32`で0開始とする。
+- reservedは0送信、受信時無視とする。
 
-## 9. 対象外
+## 11. 最小レビュー事項
+
+1. `request_kind`の数値割り当てを`GOAL=1`、`CANCEL=2`とするか。
+2. `response_kind`の数値割り当てを`GOAL=1`、`CANCEL=2`、`RESULT=3`とするか。
+3. `status`をresponse kind依存の共用フィールドとするか。
+4. Cancel RequestおよびGoal／Cancel Responseのbodyを既定値・未使用とするか。
+5. `sequence_no`を0開始とするか。
+
+## 12. 対象外
 
 - 状態遷移規則の再定義
 - 全異常シーケンスの列挙
 - Transport固有のretry、再接続、fragmentation
-- C/C++構造体レイアウト
-- PDU Registryの具体的Schema
-- bodyのAction Type固有定義
+- PDU Registry生成物のバイトレイアウト再定義
+- Action固有Goal／Result／Feedback bodyの内容


### PR DESCRIPTION
Related: #44, #50, #51, #52, #53, #54, #55

## 概要

Action Protocolの通信端点、代表的な通信順序、および`hakoniwa-pdu-registry`の既存Actionデータ構成と整合するHeader設定値を`06-protocol.md`として追加します。

## 設計方針

- 状態遷移の網羅は`04-state-model.md`と`05-client-state-model.md`を正とする
- 本文書は「誰から誰へ、何を、どの順番で送るか」の直感的理解に限定する
- 異常系、重複、遅延、timeout、切断、競合を再網羅しない
- データ内訳は`hakoniwa-pdu-registry`のAction generatorと既存Headerを基準にする

## PDU Registryとの整合

RegistryのAction generatorは、次の3 packetを生成します。

```text
<Action>ActionRequest
  ActionRequestHeader + <Action>Goal

<Action>ActionResponse
  ActionResponseHeader + <Action>Result

<Action>ActionFeedback
  ActionFeedbackHeader + <Action>Feedback
```

既存Headerは以下です。

```text
ActionRequestHeader:
  uint8 version
  uint8 request_kind
  uint8[2] reserved
  uint8[16] goal_id

ActionResponseHeader:
  uint8 version
  uint8 response_kind
  uint8 status
  uint8 reserved
  uint8[16] goal_id

ActionFeedbackHeader:
  uint8 version
  uint8[3] reserved
  uint8[16] goal_id
  uint32 sequence_no
```

## 初稿からの修正

現行Registryに存在しないため、v1 Headerへ次を追加しない方針へ修正しました。

```text
action_type_id
request_id
body_length
message_type
```

- Action TypeはPDU Schema／endpointで識別
- 応答相関は`goal_id`とpending Contextで行う
- body長・byte order・alignmentはPDU Registryへ委譲
- 論理イベントは`request_kind`、`response_kind`、Feedback専用packetで識別

## 論理イベントの写像

```text
GOAL_REQUEST     -> ActionRequest  / request_kind=GOAL
CANCEL_REQUEST   -> ActionRequest  / request_kind=CANCEL
GOAL_RESPONSE    -> ActionResponse / response_kind=GOAL
CANCEL_RESPONSE  -> ActionResponse / response_kind=CANCEL
RESULT           -> ActionResponse / response_kind=RESULT
FEEDBACK         -> ActionFeedback
```

現行GeneratorではRequest bodyが常にGoal、Response bodyが常にResultなので、Cancel RequestおよびGoal／Cancel Responseではbodyを既定値・未使用とします。

## 最小レビュー観点

1. `request_kind`: `GOAL=1`, `CANCEL=2`
2. `response_kind`: `GOAL=1`, `CANCEL=2`, `RESULT=3`
3. `status`をresponse kind依存で共用すること
4. Cancel RequestおよびGoal／Cancel Responseのbodyを既定値・未使用とすること
5. `sequence_no`を`uint32`の0開始とすること
