### PR TITLE
Add initial Action API headers

### DIFF
--- a/docs/design/action/05-client-state-model.md
+++ b/docs/design/action/05-client-state-model.md
@@ -108,6 +108,8 @@ RESPONSE_TIMEOUT(GOAL_RESPONSE)
   -> RELEASE
 ```
 
+初版Client APIの`send_goal(..., timeout_usec)`は、このGoal Response待ちにだけ適用します。`timeout_usec=0`はGoal Response timeoutなしを表します。Goalがacceptされた後のResult待ち、およびCancel Response待ちには同じ値を流用しません。それらのtimeout／保持Policyは初版の公開契約へ含めません。
+
 Goal Response timeout時、Goal RequestがServerへ到達し、Server側でaccept済みとなっている可能性があります。しかし、Client Runtimeはこの可能性を理由に追加主状態、状態照会、自動再送、特別な救済処理を導入しません。Client側では通信失敗としてContextを解放し、Server側で残存Goalが発生し得ることは異常ケースとして扱います。
 
 `GOAL_REQUESTING`や`ACCEPTED`などの追加主状態は設けません。これはROS 2 Action ClientがGoal Response待ちをFutureで表現する考え方と整合します。

--- a/docs/design/action/08-c-api.md
+++ b/docs/design/action/08-c-api.md
@@ -185,9 +185,19 @@ Action Client poll RESULT
 ```c
 typedef struct hako_pdu_action_client_handle
     hako_pdu_action_client_handle_t;
+
+typedef struct {
+    uint8_t bytes[HAKO_PDU_ACTION_GOAL_ID_SIZE];
+} hako_pdu_action_goal_id_t;
+
+typedef struct {
+    hako_pdu_action_goal_id_t goal_id;
+} hako_pdu_action_client_goal_handle_t;
 ```
 
 一つのClient handleは、設定に含まれる複数Action Typeと、各Action Typeの複数Goal Contextを管理できます。
+
+通常のClient利用者は`hako_pdu_action_client_goal_handle_t`を保持し、UUIDを直接管理しません。ROS Adapterなど、外部ProtocolのUUIDを維持する必要がある利用者だけが`hako_pdu_action_goal_id_t`を明示指定します。
 
 ### 5.3 Client event
 
@@ -197,24 +207,30 @@ typedef enum {
     HAKO_PDU_ACTION_CLIENT_EVENT_GOAL_RESPONSE,
     HAKO_PDU_ACTION_CLIENT_EVENT_FEEDBACK,
     HAKO_PDU_ACTION_CLIENT_EVENT_CANCEL_RESPONSE,
-    HAKO_PDU_ACTION_CLIENT_EVENT_RESULT
+    HAKO_PDU_ACTION_CLIENT_EVENT_RESULT,
+    HAKO_PDU_ACTION_CLIENT_EVENT_TIMEOUT,
+    HAKO_PDU_ACTION_CLIENT_EVENT_ERROR
 } hako_pdu_action_client_event_t;
 ```
 
-Transport errorやProtocol errorをeventへ含めるか、`out_error`だけで返すかは後続レビューで確定します。
+`TIMEOUT`は、Goal確立前のGoal Response timeoutをApplicationへ通知するローカルRuntimeイベントです。通信異常をGoalのterminal statusへ変換しません。
+
+`ERROR`は、正常なAction Protocolイベントとして表現できないProtocol／Runtimeエラーを通知するローカルRuntimeイベントです。具体的な原因は`poll()`の`out_error`へ設定します。`ERROR`はwire上のAction packetでも、Goalのterminal statusでもありません。
 
 ### 5.4 Client event info
 
 ```c
 typedef struct {
     char action_name[HAKO_PDU_ACTION_NAME_MAX];
-    hako_pdu_action_goal_id_t goal_id;
-    uint8_t status;
+    hako_pdu_action_client_goal_handle_t goal;
+    hako_pdu_action_decision_t decision;
+    hako_pdu_action_terminal_status_t terminal_status;
+    uint32_t feedback_sequence;
     size_t pdu_size;
 } hako_pdu_action_client_event_info_t;
 ```
 
-`status`は、イベント種別に応じてGoal Response、Cancel Response、Resultのstatusを保持します。Feedbackでは`UNSPECIFIED`とします。
+`decision`はGoal ResponseまたはCancel Responseで使用します。`terminal_status`はResultで使用し、`feedback_sequence`はFeedbackで使用します。イベント種別に不要なフィールドは`UNSPECIFIED`または`0`とします。
 
 ### 5.5 Client操作の概念形
 
@@ -235,13 +251,14 @@ hako_pdu_action_client_send_goal(
     const uint8_t* goal_pdu,
     size_t goal_pdu_size,
     const hako_pdu_action_goal_id_t* requested_goal_id,
-    hako_pdu_action_goal_id_t* out_goal_id);
+    hako_pdu_action_client_goal_handle_t* out_goal,
+    uint64_t timeout_usec);
 
 hako_pdu_action_error_t
 hako_pdu_action_client_cancel_goal(
     hako_pdu_action_client_handle_t* handle,
     const char* action_name,
-    const hako_pdu_action_goal_id_t* goal_id);
+    const hako_pdu_action_client_goal_handle_t* goal);
 
 hako_pdu_action_client_event_t
 hako_pdu_action_client_poll(...);
@@ -253,7 +270,9 @@ void
 hako_pdu_action_client_destroy(...);
 ```
 
-`requested_goal_id == NULL`の場合はRuntimeがUUIDを生成し、`out_goal_id`へ返します。外部AdapterがUUIDを保持している場合は、`requested_goal_id`を指定できます。
+`requested_goal_id == NULL`の場合はRuntimeがUUIDを生成し、実際のGoal identityを`out_goal`へ返します。外部AdapterがUUIDを保持している場合は、`requested_goal_id`を指定できます。
+
+`timeout_usec`はGoal Request送信後、Goal Responseを受信するまでにだけ適用します。`0`はGoal Response timeoutなしを表します。Goalがacceptされた後のResult待ち、およびCancel Response待ちには適用しません。
 
 ### 5.6 Client pollの意味
 
@@ -265,9 +284,11 @@ GOAL_RESPONSE
 FEEDBACK
 CANCEL_RESPONSE
 RESULT
+TIMEOUT
+ERROR
 ```
 
-イベントには必ず`action_name`と`goal_id`を含めます。これによりAdapterは、複数同時Goalを各ROS GoalHandleへ配送できます。
+Goalに相関できるイベントには`action_name`とClient Goal Handleを含めます。これによりAdapterは、複数同時Goalを各ROS GoalHandleへ配送できます。
 
 `poll()`はcallbackを実行せず、Runtime内部queueからイベントを取り出します。
 
@@ -313,9 +334,19 @@ typedef enum {
     HAKO_PDU_ACTION_SERVER_EVENT_NONE = 0,
     HAKO_PDU_ACTION_SERVER_EVENT_GOAL_REQUEST,
     HAKO_PDU_ACTION_SERVER_EVENT_CANCEL_REQUEST,
-    HAKO_PDU_ACTION_SERVER_EVENT_RUNTIME_CANCEL_REQUEST
+    HAKO_PDU_ACTION_SERVER_EVENT_RUNTIME_CANCEL_REQUEST,
+    HAKO_PDU_ACTION_SERVER_EVENT_ERROR
 } hako_pdu_action_server_event_t;
+
+typedef enum {
+    HAKO_PDU_ACTION_RUNTIME_CANCEL_UNSPECIFIED = 0,
+    HAKO_PDU_ACTION_RUNTIME_CANCEL_TRANSPORT_DISCONNECTED,
+    HAKO_PDU_ACTION_RUNTIME_CANCEL_SERVER_SHUTDOWN,
+    HAKO_PDU_ACTION_RUNTIME_CANCEL_INTERNAL_POLICY
+} hako_pdu_action_runtime_cancel_cause_t;
 ```
+
+`ERROR`はClient側と同様にローカルRuntimeイベントであり、wire上のAction eventではありません。具体的な原因は`poll()`の`out_error`へ設定します。
 
 ### 6.4 Server event info
 
@@ -324,10 +355,16 @@ typedef struct {
     hako_pdu_action_event_token_t event_token;
     hako_pdu_action_goal_token_t goal_token;
     char action_name[HAKO_PDU_ACTION_NAME_MAX];
+    char client_name[HAKO_PDU_ACTION_NAME_MAX];
     hako_pdu_action_goal_id_t goal_id;
+    hako_pdu_action_runtime_cancel_cause_t runtime_cancel_cause;
     size_t pdu_size;
 } hako_pdu_action_server_event_info_t;
 ```
+
+`client_name`は受信元を診断・配送するためのRuntime metadataです。GoalのProtocol identityには使用しません。Protocol上の相関キーは引き続き`goal_id`です。
+
+`runtime_cancel_cause`は`RUNTIME_CANCEL_REQUEST`で使用し、それ以外のイベントでは`UNSPECIFIED`とします。
 
 `goal_token`の値:
 
@@ -513,6 +550,7 @@ typedef enum {
     HAKO_PDU_ACTION_ERROR_INITIALIZE,
     HAKO_PDU_ACTION_ERROR_START,
     HAKO_PDU_ACTION_ERROR_NOT_RUNNING,
+    HAKO_PDU_ACTION_ERROR_SEND,
     HAKO_PDU_ACTION_ERROR_BUFFER_TOO_SMALL,
     HAKO_PDU_ACTION_ERROR_NOT_FOUND,
     HAKO_PDU_ACTION_ERROR_INVALID_STATE,
@@ -522,6 +560,8 @@ typedef enum {
 ```
 
 Protocol上のGoal rejectやCancel rejectはC API呼び出し失敗ではありません。Applicationの正常な判断として相手側へResponseを送ります。
+
+Clientが明示指定した`requested_goal_id`が、そのClient Runtimeで管理中または保持中のGoalと重複する場合、`send_goal()`は`HAKO_PDU_ACTION_ERROR_DUPLICATE_GOAL`を返します。Serverが受信時に検出したduplicate Goal RequestはProtocol上のGoal rejectとして処理し、Server Applicationへ新規Goalイベントを公開しません。
 
 ## 10. Mux Serverとの対称性
 
@@ -551,11 +591,11 @@ create
 start
 create_goal_buffer
 Goal body設定
-send_goal -> goal_id
+send_goal -> Client Goal Handle
 
 poll GOAL_RESPONSE
 poll FEEDBACK 0..n
-必要ならcancel_goal(goal_id)
+必要ならcancel_goal(Client Goal Handle)
 poll CANCEL_RESPONSE
 poll RESULT
 
@@ -590,6 +630,9 @@ destroy
 - Server APIはAction Server Application利用を主対象とする。
 - 一つのClient handleで複数Goalを管理する。
 - Protocol相関には`goal_id`を使用する。
+- 通常ClientはClient Goal Handleを保持し、外部Adapterだけが必要に応じてUUIDを明示指定する。
+- `send_goal()`のtimeoutはGoal Response待ちにだけ適用し、accept後のResultおよびCancel Responseには適用しない。
+- `TIMEOUT`と`ERROR`はローカルRuntimeイベントであり、Goalのterminal statusではない。
 - Server Application向けには`event_token`と`goal_token`を分離する。
 - `event_token`は受信イベントへの一回限りの判断に使用する。
 - `goal_token`はaccept済みGoalの継続操作に使用する。

--- a/include/hakoniwa/pdu/action/action_client_endpoint.hpp
+++ b/include/hakoniwa/pdu/action/action_client_endpoint.hpp
@@ -3,6 +3,7 @@
 #include "action_types.hpp"
 
 #include <nlohmann/json_fwd.hpp>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -15,14 +16,19 @@ public:
     virtual bool initialize(const nlohmann::json& action_config,
                             int pdu_meta_data_size) = 0;
 
-    // One endpoint may own multiple active goals. goal_id is the correlation
-    // key; a single in-flight request restriction must not be introduced.
-    virtual bool send_goal(const GoalId& goal_id, const PduData& goal_pdu,
-                           std::uint64_t timeout_usec) = 0;
-    virtual bool send_cancel(const GoalId& goal_id) = 0;
+    // Normal clients omit requested_goal_id and let the Runtime generate the
+    // UUID. Protocol adapters may provide an external GoalId that must be
+    // preserved. The returned handle is used for cancel and correlation.
+    virtual bool send_goal(const PduData& goal_pdu,
+                           ClientGoalHandle& goal_handle_out,
+                           std::optional<GoalId> requested_goal_id = std::nullopt,
+                           std::uint64_t timeout_usec = 0) = 0;
+    virtual bool send_cancel(const ClientGoalHandle& goal) = 0;
     virtual ClientEventType poll(ClientEvent& event_out) = 0;
-    virtual bool create_goal_buffer(const GoalId& goal_id,
-                                    PduData& pdu_out) = 0;
+
+    // Creates the generated Action Goal packet body. The Runtime writes the
+    // selected GoalId into the Action header when send_goal() is called.
+    virtual bool create_goal_buffer(PduData& pdu_out) = 0;
     virtual void clear_pending_events() = 0;
 
     const std::string& get_action_name() const { return action_name_; }

--- a/include/hakoniwa/pdu/action/action_client_endpoint.hpp
+++ b/include/hakoniwa/pdu/action/action_client_endpoint.hpp
@@ -19,6 +19,8 @@ public:
     // Normal clients omit requested_goal_id and let the Runtime generate the
     // UUID. Protocol adapters may provide an external GoalId that must be
     // preserved. The returned handle is used for cancel and correlation.
+    // timeout_usec applies only while waiting for GOAL_RESPONSE; zero disables
+    // that timeout. It does not time out Result or Cancel Response delivery.
     virtual bool send_goal(const PduData& goal_pdu,
                            ClientGoalHandle& goal_handle_out,
                            std::optional<GoalId> requested_goal_id = std::nullopt,
@@ -46,7 +48,7 @@ protected:
     std::uint64_t delta_time_usec_;
 };
 
-// TODO(codex): specify timeout semantics per goal and terminal-event retention
-// after the first native implementation proves the required bookkeeping.
+// Result and Cancel Response timeout/retention policies are intentionally not
+// part of the initial public contract.
 
 } // namespace hakoniwa::pdu::action

--- a/include/hakoniwa/pdu/action/action_client_endpoint.hpp
+++ b/include/hakoniwa/pdu/action/action_client_endpoint.hpp
@@ -4,6 +4,7 @@
 
 #include <nlohmann/json_fwd.hpp>
 #include <string>
+#include <utility>
 
 namespace hakoniwa::pdu::action {
 

--- a/include/hakoniwa/pdu/action/action_client_endpoint.hpp
+++ b/include/hakoniwa/pdu/action/action_client_endpoint.hpp
@@ -16,9 +16,10 @@ public:
     virtual bool initialize(const nlohmann::json& action_config,
                             int pdu_meta_data_size) = 0;
 
-    // Normal clients omit requested_goal_id and let the Runtime generate the
-    // UUID. Protocol adapters may provide an external GoalId that must be
-    // preserved. The returned handle is used for cancel and correlation.
+    // Normal clients omit requested_goal_id and let the Runtime generate a
+    // non-zero UUID. Protocol adapters may provide an external GoalId that must
+    // be preserved; an explicitly requested all-zero GoalId is invalid and
+    // must be rejected. The returned handle is used for cancel and correlation.
     // timeout_usec applies only while waiting for GOAL_RESPONSE; zero disables
     // that timeout. It does not time out Result or Cancel Response delivery.
     virtual bool send_goal(const PduData& goal_pdu,

--- a/include/hakoniwa/pdu/action/action_client_endpoint.hpp
+++ b/include/hakoniwa/pdu/action/action_client_endpoint.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "action_types.hpp"
+
+#include <nlohmann/json_fwd.hpp>
+#include <string>
+
+namespace hakoniwa::pdu::action {
+
+class IActionClientEndpoint {
+public:
+    virtual ~IActionClientEndpoint() = default;
+
+    virtual bool initialize(const nlohmann::json& action_config,
+                            int pdu_meta_data_size) = 0;
+
+    // One endpoint may own multiple active goals. goal_id is the correlation
+    // key; a single in-flight request restriction must not be introduced.
+    virtual bool send_goal(const GoalId& goal_id, const PduData& goal_pdu,
+                           std::uint64_t timeout_usec) = 0;
+    virtual bool send_cancel(const GoalId& goal_id) = 0;
+    virtual ClientEventType poll(ClientEvent& event_out) = 0;
+    virtual bool create_goal_buffer(const GoalId& goal_id,
+                                    PduData& pdu_out) = 0;
+    virtual void clear_pending_events() = 0;
+
+    const std::string& get_action_name() const { return action_name_; }
+    const std::string& get_client_name() const { return client_name_; }
+
+protected:
+    IActionClientEndpoint(std::string action_name, std::string client_name,
+                          std::uint64_t delta_time_usec)
+        : action_name_(std::move(action_name)),
+          client_name_(std::move(client_name)),
+          delta_time_usec_(delta_time_usec) {}
+
+    std::string action_name_;
+    std::string client_name_;
+    std::uint64_t delta_time_usec_;
+};
+
+// TODO(codex): specify timeout semantics per goal and terminal-event retention
+// after the first native implementation proves the required bookkeeping.
+
+} // namespace hakoniwa::pdu::action

--- a/include/hakoniwa/pdu/action/action_server_endpoint.hpp
+++ b/include/hakoniwa/pdu/action/action_server_endpoint.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "action_types.hpp"
+
+#include <nlohmann/json_fwd.hpp>
+#include <optional>
+#include <string>
+
+namespace hakoniwa::pdu::action {
+
+class IActionServerEndpoint {
+public:
+    virtual ~IActionServerEndpoint() = default;
+
+    virtual bool initialize(const nlohmann::json& action_config,
+                            int pdu_meta_data_size,
+                            std::optional<std::string> client_node_id = std::nullopt) = 0;
+
+    virtual ServerEventType poll(ServerEvent& event_out) = 0;
+
+    // event_token is one-shot and is consumed by exactly one accept/reject call.
+    // Accepting a goal creates a long-lived goal_token used for feedback and
+    // terminal completion.
+    virtual bool accept_goal(EventToken event_token, GoalToken& goal_token_out) = 0;
+    virtual bool reject_goal(EventToken event_token) = 0;
+    virtual bool accept_cancel(EventToken event_token) = 0;
+    virtual bool reject_cancel(EventToken event_token) = 0;
+
+    virtual bool send_feedback(GoalToken goal_token,
+                               const PduData& feedback_pdu) = 0;
+    virtual bool complete(GoalToken goal_token,
+                          TerminalStatus status,
+                          const PduData& result_pdu) = 0;
+
+    virtual void clear_pending_events() = 0;
+    const std::string& get_action_name() const { return action_name_; }
+
+protected:
+    IActionServerEndpoint(std::string action_name,
+                          std::uint64_t delta_time_usec)
+        : action_name_(std::move(action_name)),
+          delta_time_usec_(delta_time_usec) {}
+
+    std::string action_name_;
+    std::uint64_t delta_time_usec_;
+};
+
+// Invariant for the implementation:
+// COMPLETE_SUCCEEDED and ACCEPT_CANCEL must commit atomically per goal. If the
+// Result wins, the pending cancel token is invalidated and no Cancel Response
+// is emitted. See docs/design/action/10-cancel-result-race.md.
+
+} // namespace hakoniwa::pdu::action

--- a/include/hakoniwa/pdu/action/action_server_endpoint.hpp
+++ b/include/hakoniwa/pdu/action/action_server_endpoint.hpp
@@ -5,6 +5,7 @@
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 #include <string>
+#include <utility>
 
 namespace hakoniwa::pdu::action {
 

--- a/include/hakoniwa/pdu/action/action_services_client.hpp
+++ b/include/hakoniwa/pdu/action/action_services_client.hpp
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace hakoniwa::pdu::action {
@@ -27,15 +28,17 @@ public:
     void stop_all_services();
     void clear_all_instances();
 
+    // Ordinary callers receive an opaque-style GoalHandle and do not need to
+    // construct or retain GoalId directly. Adapters may request a specific ID.
     bool send_goal(const std::string& action_name,
-                   const GoalId& goal_id,
                    const PduData& goal_pdu,
+                   ClientGoalHandle& goal_handle_out,
+                   std::optional<GoalId> requested_goal_id = std::nullopt,
                    std::uint64_t timeout_usec = 0);
-    bool send_cancel(const std::string& action_name, const GoalId& goal_id);
+    bool send_cancel(const std::string& action_name,
+                     const ClientGoalHandle& goal);
     ClientEventType poll(std::string& action_name, ClientEvent& event_out);
-    bool create_goal_buffer(const std::string& action_name,
-                            const GoalId& goal_id,
-                            PduData& pdu_out);
+    bool create_goal_buffer(const std::string& action_name, PduData& pdu_out);
 
 private:
     std::string node_id_;

--- a/include/hakoniwa/pdu/action/action_services_client.hpp
+++ b/include/hakoniwa/pdu/action/action_services_client.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "action_client_endpoint.hpp"
+#include "action_types.hpp"
+#include "hakoniwa/pdu/endpoint_container.hpp"
+#include "hakoniwa/time_source/time_source.hpp"
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace hakoniwa::pdu::action {
+
+class ActionServicesClient {
+public:
+    ActionServicesClient(const std::string& node_id,
+                         const std::string& client_name,
+                         const std::string& config_path,
+                         const std::string& impl_type = "ActionClientEndpointImpl",
+                         std::uint64_t delta_time_usec = 1000,
+                         std::string time_source_type = "real");
+    ~ActionServicesClient();
+
+    bool initialize_services(
+        std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container);
+    bool start_all_services();
+    void stop_all_services();
+    void clear_all_instances();
+
+    bool send_goal(const std::string& action_name,
+                   const GoalId& goal_id,
+                   const PduData& goal_pdu,
+                   std::uint64_t timeout_usec = 0);
+    bool send_cancel(const std::string& action_name, const GoalId& goal_id);
+    ClientEventType poll(std::string& action_name, ClientEvent& event_out);
+    bool create_goal_buffer(const std::string& action_name,
+                            const GoalId& goal_id,
+                            PduData& pdu_out);
+
+private:
+    std::string node_id_;
+    std::string client_name_;
+    std::string config_path_;
+    std::string impl_type_;
+    std::uint64_t delta_time_usec_;
+
+    std::map<std::string, std::shared_ptr<IActionClientEndpoint>> action_endpoints_;
+    std::shared_ptr<hakoniwa::time_source::ITimeSource> time_source_;
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container_;
+
+    // TODO(codex): decide whether round-robin polling is sufficient or whether
+    // a ready queue is needed. This is an implementation detail, not API.
+};
+
+} // namespace hakoniwa::pdu::action

--- a/include/hakoniwa/pdu/action/action_services_server.hpp
+++ b/include/hakoniwa/pdu/action/action_services_server.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "action_server_endpoint.hpp"
+#include "action_types.hpp"
+#include "hakoniwa/pdu/endpoint_container.hpp"
+#include "hakoniwa/time_source/time_source.hpp"
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace hakoniwa::pdu::action {
+
+class ActionServicesServer {
+public:
+    ActionServicesServer(const std::string& node_id,
+                         const std::string& config_path,
+                         const std::string& impl_type = "ActionServerEndpointImpl",
+                         std::uint64_t delta_time_usec = 1000,
+                         std::string time_source_type = "real");
+    ~ActionServicesServer();
+
+    bool initialize_services(
+        std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container);
+    bool start_all_services();
+    void stop_all_services();
+    void clear_all_instances();
+
+    ServerEventType poll(std::string& action_name, ServerEvent& event_out);
+
+    bool accept_goal(const std::string& action_name,
+                     EventToken event_token,
+                     GoalToken& goal_token_out);
+    bool reject_goal(const std::string& action_name, EventToken event_token);
+    bool accept_cancel(const std::string& action_name, EventToken event_token);
+    bool reject_cancel(const std::string& action_name, EventToken event_token);
+    bool send_feedback(const std::string& action_name,
+                       GoalToken goal_token,
+                       const PduData& feedback_pdu);
+    bool complete(const std::string& action_name,
+                  GoalToken goal_token,
+                  TerminalStatus status,
+                  const PduData& result_pdu);
+
+private:
+    std::string node_id_;
+    std::string config_path_;
+    std::string impl_type_;
+    std::uint64_t delta_time_usec_;
+
+    std::map<std::string, std::shared_ptr<IActionServerEndpoint>> action_endpoints_;
+    std::shared_ptr<hakoniwa::time_source::ITimeSource> time_source_;
+    std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container_;
+
+    // TODO(codex): the Goal Context map, locking strategy, and token allocator
+    // belong in the implementation. Do not expose them through this API.
+};
+
+} // namespace hakoniwa::pdu::action

--- a/include/hakoniwa/pdu/action/action_types.hpp
+++ b/include/hakoniwa/pdu/action/action_types.hpp
@@ -12,9 +12,39 @@ using GoalId = std::array<std::uint8_t, 16>;
 using EventToken = std::uint64_t;
 using GoalToken = std::uint64_t;
 
+inline constexpr EventToken INVALID_EVENT_TOKEN = 0;
+inline constexpr GoalToken INVALID_GOAL_TOKEN = 0;
+
+// High-level client code should retain this handle rather than manipulate a
+// GoalId directly. GoalId remains available for adapters that must preserve an
+// external protocol identity, such as a ROS 2 Action bridge.
+struct ClientGoalHandle {
+    GoalId goal_id{};
+
+    bool valid() const noexcept {
+        for (auto byte : goal_id) {
+            if (byte != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+// Server-side long-lived handle. event_token is intentionally not included:
+// it is a one-shot decision token, while goal_token survives until terminal
+// completion commits.
+struct ServerGoalHandle {
+    GoalId goal_id{};
+    GoalToken goal_token{INVALID_GOAL_TOKEN};
+
+    bool valid() const noexcept { return goal_token != INVALID_GOAL_TOKEN; }
+};
+
 // These values describe logical runtime events. Wire-level values are defined
 // by the generated Action headers from hakoniwa-pdu-registry.
-enum class ClientEventType {
+enum class ClientEventType : std::uint8_t {
+    UNSPECIFIED = 0,
     NONE,
     GOAL_RESPONSE,
     FEEDBACK,
@@ -24,54 +54,74 @@ enum class ClientEventType {
     ERROR
 };
 
-enum class ServerEventType {
+enum class ServerEventType : std::uint8_t {
+    UNSPECIFIED = 0,
     NONE,
     GOAL_REQUEST,
     CANCEL_REQUEST,
+    RUNTIME_CANCEL_REQUEST,
     ERROR
 };
 
-enum class GoalDecision {
+enum class GoalDecision : std::uint8_t {
+    UNSPECIFIED = 0,
     ACCEPTED,
     REJECTED
 };
 
-enum class CancelDecision {
+enum class CancelDecision : std::uint8_t {
+    UNSPECIFIED = 0,
     ACCEPTED,
     REJECTED
 };
 
-enum class TerminalStatus {
+enum class TerminalStatus : std::uint8_t {
+    UNSPECIFIED = 0,
     SUCCEEDED,
     CANCELED,
     ABORTED
 };
 
-enum class GoalState {
+enum class GoalState : std::uint8_t {
+    UNSPECIFIED = 0,
     EXECUTING,
     CANCELING,
     FINISHING
 };
 
+enum class RuntimeCancelCause : std::uint8_t {
+    UNSPECIFIED = 0,
+    TRANSPORT_DISCONNECTED,
+    SERVER_SHUTDOWN,
+    INTERNAL_POLICY
+};
+
 struct ClientEvent {
     ClientEventType type{ClientEventType::NONE};
     std::string action_name;
-    GoalId goal_id{};
-    GoalDecision goal_decision{GoalDecision::REJECTED};
-    CancelDecision cancel_decision{CancelDecision::REJECTED};
-    TerminalStatus terminal_status{TerminalStatus::ABORTED};
+    ClientGoalHandle goal;
+    GoalDecision goal_decision{GoalDecision::UNSPECIFIED};
+    CancelDecision cancel_decision{CancelDecision::UNSPECIFIED};
+    TerminalStatus terminal_status{TerminalStatus::UNSPECIFIED};
     std::uint32_t feedback_sequence{0};
     PduData pdu;
 };
 
 struct ServerEvent {
     ServerEventType type{ServerEventType::NONE};
-    EventToken event_token{0};
+    EventToken event_token{INVALID_EVENT_TOKEN};
+    ServerGoalHandle goal;
+    RuntimeCancelCause runtime_cancel_cause{RuntimeCancelCause::UNSPECIFIED};
     std::string action_name;
     std::string client_name;
-    GoalId goal_id{};
     PduData pdu;
 };
+
+// Event field contract:
+//   GOAL_REQUEST:           goal.goal_token == INVALID_GOAL_TOKEN
+//   CANCEL_REQUEST:         goal identifies the accepted target Goal
+//   RUNTIME_CANCEL_REQUEST: goal identifies the target Goal and cause is set
+// event_token is consumed by exactly one accept/reject operation.
 
 // TODO(codex): define the precise runtime error model without exposing
 // implementation-specific exceptions through the public API.

--- a/include/hakoniwa/pdu/action/action_types.hpp
+++ b/include/hakoniwa/pdu/action/action_types.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace hakoniwa::pdu::action {
+
+using PduData = std::vector<std::uint8_t>;
+using GoalId = std::array<std::uint8_t, 16>;
+using EventToken = std::uint64_t;
+using GoalToken = std::uint64_t;
+
+// These values describe logical runtime events. Wire-level values are defined
+// by the generated Action headers from hakoniwa-pdu-registry.
+enum class ClientEventType {
+    NONE,
+    GOAL_RESPONSE,
+    FEEDBACK,
+    CANCEL_RESPONSE,
+    RESULT,
+    TIMEOUT,
+    ERROR
+};
+
+enum class ServerEventType {
+    NONE,
+    GOAL_REQUEST,
+    CANCEL_REQUEST,
+    ERROR
+};
+
+enum class GoalDecision {
+    ACCEPTED,
+    REJECTED
+};
+
+enum class CancelDecision {
+    ACCEPTED,
+    REJECTED
+};
+
+enum class TerminalStatus {
+    SUCCEEDED,
+    CANCELED,
+    ABORTED
+};
+
+enum class GoalState {
+    EXECUTING,
+    CANCELING,
+    FINISHING
+};
+
+struct ClientEvent {
+    ClientEventType type{ClientEventType::NONE};
+    std::string action_name;
+    GoalId goal_id{};
+    GoalDecision goal_decision{GoalDecision::REJECTED};
+    CancelDecision cancel_decision{CancelDecision::REJECTED};
+    TerminalStatus terminal_status{TerminalStatus::ABORTED};
+    std::uint32_t feedback_sequence{0};
+    PduData pdu;
+};
+
+struct ServerEvent {
+    ServerEventType type{ServerEventType::NONE};
+    EventToken event_token{0};
+    std::string action_name;
+    std::string client_name;
+    GoalId goal_id{};
+    PduData pdu;
+};
+
+// TODO(codex): define the precise runtime error model without exposing
+// implementation-specific exceptions through the public API.
+
+} // namespace hakoniwa::pdu::action

--- a/include/hakoniwa/pdu/action/action_types.hpp
+++ b/include/hakoniwa/pdu/action/action_types.hpp
@@ -15,30 +15,40 @@ using GoalToken = std::uint64_t;
 inline constexpr EventToken INVALID_EVENT_TOKEN = 0;
 inline constexpr GoalToken INVALID_GOAL_TOKEN = 0;
 
+inline bool is_valid_goal_id(const GoalId& goal_id) noexcept {
+    for (auto byte : goal_id) {
+        if (byte != 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // High-level client code should retain this handle rather than manipulate a
 // GoalId directly. GoalId remains available for adapters that must preserve an
 // external protocol identity, such as a ROS 2 Action bridge.
+//
+// The all-zero GoalId is reserved as invalid. Runtime-generated IDs must be
+// non-zero, and an explicitly requested all-zero ID must be rejected.
 struct ClientGoalHandle {
     GoalId goal_id{};
 
-    bool valid() const noexcept {
-        for (auto byte : goal_id) {
-            if (byte != 0) {
-                return true;
-            }
-        }
-        return false;
-    }
+    bool valid() const noexcept { return is_valid_goal_id(goal_id); }
 };
 
-// Server-side long-lived handle. event_token is intentionally not included:
-// it is a one-shot decision token, while goal_token survives until terminal
-// completion commits.
+// Server event metadata for an accepted Goal. This groups the wire identity
+// and the Runtime-local capability so an Application can identify the target
+// of CANCEL_REQUEST and RUNTIME_CANCEL_REQUEST events.
+//
+// Server operations continue to use goal_token directly. This type is not a
+// replacement for event_token, which remains a one-shot decision token.
 struct ServerGoalHandle {
     GoalId goal_id{};
     GoalToken goal_token{INVALID_GOAL_TOKEN};
 
-    bool valid() const noexcept { return goal_token != INVALID_GOAL_TOKEN; }
+    bool valid() const noexcept {
+        return is_valid_goal_id(goal_id) && goal_token != INVALID_GOAL_TOKEN;
+    }
 };
 
 // These values describe logical runtime events. Wire-level values are defined
@@ -63,13 +73,9 @@ enum class ServerEventType : std::uint8_t {
     ERROR = 4
 };
 
-enum class GoalDecision : std::uint8_t {
-    UNSPECIFIED = 0,
-    ACCEPTED = 1,
-    REJECTED = 2
-};
-
-enum class CancelDecision : std::uint8_t {
+// GOAL_RESPONSE and CANCEL_RESPONSE share the same accepted/rejected value
+// domain. The event type determines which decision this field represents.
+enum class Decision : std::uint8_t {
     UNSPECIFIED = 0,
     ACCEPTED = 1,
     REJECTED = 2
@@ -100,8 +106,7 @@ struct ClientEvent {
     ClientEventType type{ClientEventType::NONE};
     std::string action_name;
     ClientGoalHandle goal;
-    GoalDecision goal_decision{GoalDecision::UNSPECIFIED};
-    CancelDecision cancel_decision{CancelDecision::UNSPECIFIED};
+    Decision decision{Decision::UNSPECIFIED};
     TerminalStatus terminal_status{TerminalStatus::UNSPECIFIED};
     std::uint32_t feedback_sequence{0};
     PduData pdu;
@@ -119,6 +124,7 @@ struct ServerEvent {
 
 // Event field contract:
 //   GOAL_REQUEST:           goal.goal_token == INVALID_GOAL_TOKEN
+//                           and goal.goal_id is non-zero
 //   CANCEL_REQUEST:         goal identifies the accepted target Goal
 //   RUNTIME_CANCEL_REQUEST: goal identifies the target Goal and cause is set
 // event_token is consumed by exactly one accept/reject operation.

--- a/include/hakoniwa/pdu/action/action_types.hpp
+++ b/include/hakoniwa/pdu/action/action_types.hpp
@@ -45,55 +45,55 @@ struct ServerGoalHandle {
 // by the generated Action headers from hakoniwa-pdu-registry.
 enum class ClientEventType : std::uint8_t {
     UNSPECIFIED = 0,
-    NONE,
-    GOAL_RESPONSE,
-    FEEDBACK,
-    CANCEL_RESPONSE,
-    RESULT,
-    TIMEOUT,
-    ERROR
+    NONE = 0,
+    GOAL_RESPONSE = 1,
+    FEEDBACK = 2,
+    CANCEL_RESPONSE = 3,
+    RESULT = 4,
+    TIMEOUT = 5,
+    ERROR = 6
 };
 
 enum class ServerEventType : std::uint8_t {
     UNSPECIFIED = 0,
-    NONE,
-    GOAL_REQUEST,
-    CANCEL_REQUEST,
-    RUNTIME_CANCEL_REQUEST,
-    ERROR
+    NONE = 0,
+    GOAL_REQUEST = 1,
+    CANCEL_REQUEST = 2,
+    RUNTIME_CANCEL_REQUEST = 3,
+    ERROR = 4
 };
 
 enum class GoalDecision : std::uint8_t {
     UNSPECIFIED = 0,
-    ACCEPTED,
-    REJECTED
+    ACCEPTED = 1,
+    REJECTED = 2
 };
 
 enum class CancelDecision : std::uint8_t {
     UNSPECIFIED = 0,
-    ACCEPTED,
-    REJECTED
+    ACCEPTED = 1,
+    REJECTED = 2
 };
 
 enum class TerminalStatus : std::uint8_t {
     UNSPECIFIED = 0,
-    SUCCEEDED,
-    CANCELED,
-    ABORTED
+    SUCCEEDED = 1,
+    CANCELED = 2,
+    ABORTED = 3
 };
 
 enum class GoalState : std::uint8_t {
     UNSPECIFIED = 0,
-    EXECUTING,
-    CANCELING,
-    FINISHING
+    EXECUTING = 1,
+    CANCELING = 2,
+    FINISHING = 3
 };
 
 enum class RuntimeCancelCause : std::uint8_t {
     UNSPECIFIED = 0,
-    TRANSPORT_DISCONNECTED,
-    SERVER_SHUTDOWN,
-    INTERNAL_POLICY
+    TRANSPORT_DISCONNECTED = 1,
+    SERVER_SHUTDOWN = 2,
+    INTERNAL_POLICY = 3
 };
 
 struct ClientEvent {

--- a/include/hakoniwa/pdu/action/c_action.h
+++ b/include/hakoniwa/pdu/action/c_action.h
@@ -1,0 +1,192 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef HAKO_PDU_ACTION_NAME_MAX
+#define HAKO_PDU_ACTION_NAME_MAX 128
+#endif
+
+#define HAKO_PDU_ACTION_GOAL_ID_SIZE 16
+
+typedef struct hako_pdu_action_client_handle hako_pdu_action_client_handle_t;
+typedef struct hako_pdu_action_server_handle hako_pdu_action_server_handle_t;
+
+typedef uint64_t hako_pdu_action_event_token_t;
+typedef uint64_t hako_pdu_action_goal_token_t;
+
+typedef enum {
+    HAKO_PDU_ACTION_OK = 0,
+    HAKO_PDU_ACTION_ERROR_INVALID_ARGUMENT = 1,
+    HAKO_PDU_ACTION_ERROR_INITIALIZE = 2,
+    HAKO_PDU_ACTION_ERROR_START = 3,
+    HAKO_PDU_ACTION_ERROR_NOT_RUNNING = 4,
+    HAKO_PDU_ACTION_ERROR_SEND = 5,
+    HAKO_PDU_ACTION_ERROR_BUFFER_TOO_SMALL = 6,
+    HAKO_PDU_ACTION_ERROR_NOT_FOUND = 7,
+    HAKO_PDU_ACTION_ERROR_INVALID_STATE = 8,
+    HAKO_PDU_ACTION_ERROR_INTERNAL = 9
+} hako_pdu_action_error_t;
+
+typedef enum {
+    HAKO_PDU_ACTION_CLIENT_EVENT_NONE = 0,
+    HAKO_PDU_ACTION_CLIENT_EVENT_GOAL_RESPONSE = 1,
+    HAKO_PDU_ACTION_CLIENT_EVENT_FEEDBACK = 2,
+    HAKO_PDU_ACTION_CLIENT_EVENT_CANCEL_RESPONSE = 3,
+    HAKO_PDU_ACTION_CLIENT_EVENT_RESULT = 4,
+    HAKO_PDU_ACTION_CLIENT_EVENT_TIMEOUT = 5,
+    HAKO_PDU_ACTION_CLIENT_EVENT_ERROR = 6
+} hako_pdu_action_client_event_t;
+
+typedef enum {
+    HAKO_PDU_ACTION_SERVER_EVENT_NONE = 0,
+    HAKO_PDU_ACTION_SERVER_EVENT_GOAL_REQUEST = 1,
+    HAKO_PDU_ACTION_SERVER_EVENT_CANCEL_REQUEST = 2,
+    HAKO_PDU_ACTION_SERVER_EVENT_ERROR = 3
+} hako_pdu_action_server_event_t;
+
+typedef enum {
+    HAKO_PDU_ACTION_DECISION_UNSPECIFIED = 0,
+    HAKO_PDU_ACTION_DECISION_ACCEPTED = 1,
+    HAKO_PDU_ACTION_DECISION_REJECTED = 2
+} hako_pdu_action_decision_t;
+
+typedef enum {
+    HAKO_PDU_ACTION_TERMINAL_UNSPECIFIED = 0,
+    HAKO_PDU_ACTION_TERMINAL_SUCCEEDED = 1,
+    HAKO_PDU_ACTION_TERMINAL_CANCELED = 2,
+    HAKO_PDU_ACTION_TERMINAL_ABORTED = 3
+} hako_pdu_action_terminal_status_t;
+
+typedef struct {
+    char action_name[HAKO_PDU_ACTION_NAME_MAX];
+    uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE];
+    hako_pdu_action_decision_t decision;
+    hako_pdu_action_terminal_status_t terminal_status;
+    uint32_t feedback_sequence;
+    size_t pdu_size;
+} hako_pdu_action_client_event_info_t;
+
+typedef struct {
+    hako_pdu_action_event_token_t event_token;
+    char action_name[HAKO_PDU_ACTION_NAME_MAX];
+    char client_name[HAKO_PDU_ACTION_NAME_MAX];
+    uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE];
+    size_t pdu_size;
+} hako_pdu_action_server_event_info_t;
+
+/* Caller owns buffers returned by *_alloc and releases them with this function. */
+void hako_pdu_action_buffer_free(uint8_t* buffer);
+
+hako_pdu_action_client_handle_t* hako_pdu_action_client_create(
+    const char* node_id,
+    const char* client_name,
+    const char* action_config_path,
+    const char* endpoint_config_path,
+    uint64_t delta_time_usec,
+    const char* time_source_type);
+void hako_pdu_action_client_destroy(hako_pdu_action_client_handle_t* handle);
+hako_pdu_action_error_t hako_pdu_action_client_start(hako_pdu_action_client_handle_t* handle);
+hako_pdu_action_error_t hako_pdu_action_client_stop(hako_pdu_action_client_handle_t* handle);
+hako_pdu_action_error_t hako_pdu_action_client_create_goal_buffer(
+    hako_pdu_action_client_handle_t* handle,
+    const char* action_name,
+    const uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE],
+    uint8_t* buffer,
+    size_t capacity,
+    size_t* out_size);
+hako_pdu_action_error_t hako_pdu_action_client_create_goal_buffer_alloc(
+    hako_pdu_action_client_handle_t* handle,
+    const char* action_name,
+    const uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE],
+    uint8_t** out_buffer,
+    size_t* out_size);
+hako_pdu_action_error_t hako_pdu_action_client_send_goal(
+    hako_pdu_action_client_handle_t* handle,
+    const char* action_name,
+    const uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE],
+    const uint8_t* pdu,
+    size_t pdu_size,
+    uint64_t timeout_usec);
+hako_pdu_action_error_t hako_pdu_action_client_cancel(
+    hako_pdu_action_client_handle_t* handle,
+    const char* action_name,
+    const uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE]);
+hako_pdu_action_client_event_t hako_pdu_action_client_poll(
+    hako_pdu_action_client_handle_t* handle,
+    hako_pdu_action_client_event_info_t* out_info,
+    uint8_t* buffer,
+    size_t capacity,
+    size_t* out_size,
+    hako_pdu_action_error_t* out_error);
+hako_pdu_action_client_event_t hako_pdu_action_client_poll_alloc(
+    hako_pdu_action_client_handle_t* handle,
+    hako_pdu_action_client_event_info_t* out_info,
+    uint8_t** out_buffer,
+    size_t* out_size,
+    hako_pdu_action_error_t* out_error);
+
+hako_pdu_action_server_handle_t* hako_pdu_action_server_create(
+    const char* node_id,
+    const char* action_config_path,
+    const char* endpoint_config_path,
+    uint64_t delta_time_usec,
+    const char* time_source_type);
+void hako_pdu_action_server_destroy(hako_pdu_action_server_handle_t* handle);
+hako_pdu_action_error_t hako_pdu_action_server_start(hako_pdu_action_server_handle_t* handle);
+hako_pdu_action_error_t hako_pdu_action_server_stop(hako_pdu_action_server_handle_t* handle);
+hako_pdu_action_server_event_t hako_pdu_action_server_poll(
+    hako_pdu_action_server_handle_t* handle,
+    hako_pdu_action_server_event_info_t* out_info,
+    uint8_t* buffer,
+    size_t capacity,
+    size_t* out_size,
+    hako_pdu_action_error_t* out_error);
+hako_pdu_action_server_event_t hako_pdu_action_server_poll_alloc(
+    hako_pdu_action_server_handle_t* handle,
+    hako_pdu_action_server_event_info_t* out_info,
+    uint8_t** out_buffer,
+    size_t* out_size,
+    hako_pdu_action_error_t* out_error);
+
+hako_pdu_action_error_t hako_pdu_action_server_accept_goal(
+    hako_pdu_action_server_handle_t* handle,
+    hako_pdu_action_event_token_t event_token,
+    hako_pdu_action_goal_token_t* out_goal_token);
+hako_pdu_action_error_t hako_pdu_action_server_reject_goal(
+    hako_pdu_action_server_handle_t* handle,
+    hako_pdu_action_event_token_t event_token);
+hako_pdu_action_error_t hako_pdu_action_server_accept_cancel(
+    hako_pdu_action_server_handle_t* handle,
+    hako_pdu_action_event_token_t event_token);
+hako_pdu_action_error_t hako_pdu_action_server_reject_cancel(
+    hako_pdu_action_server_handle_t* handle,
+    hako_pdu_action_event_token_t event_token);
+hako_pdu_action_error_t hako_pdu_action_server_send_feedback(
+    hako_pdu_action_server_handle_t* handle,
+    hako_pdu_action_goal_token_t goal_token,
+    const uint8_t* pdu,
+    size_t pdu_size);
+hako_pdu_action_error_t hako_pdu_action_server_complete(
+    hako_pdu_action_server_handle_t* handle,
+    hako_pdu_action_goal_token_t goal_token,
+    hako_pdu_action_terminal_status_t status,
+    const uint8_t* pdu,
+    size_t pdu_size);
+
+/*
+ * TODO(codex): add mux declarations only after Goal ownership across transport
+ * sessions is implemented. The static API intentionally lands first.
+ *
+ * Contract: event_token is one-shot. goal_token is valid from goal acceptance
+ * until one terminal completion commits. Result wins over a pending Cancel by
+ * invalidating its event_token and emitting no Cancel Response.
+ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/hakoniwa/pdu/action/c_action.h
+++ b/include/hakoniwa/pdu/action/c_action.h
@@ -38,7 +38,8 @@ typedef enum {
     HAKO_PDU_ACTION_ERROR_BUFFER_TOO_SMALL = 6,
     HAKO_PDU_ACTION_ERROR_NOT_FOUND = 7,
     HAKO_PDU_ACTION_ERROR_INVALID_STATE = 8,
-    HAKO_PDU_ACTION_ERROR_INTERNAL = 9
+    HAKO_PDU_ACTION_ERROR_DUPLICATE_GOAL = 9,
+    HAKO_PDU_ACTION_ERROR_INTERNAL = 10
 } hako_pdu_action_error_t;
 
 typedef enum {
@@ -126,6 +127,9 @@ hako_pdu_action_error_t hako_pdu_action_client_create_goal_buffer_alloc(
 /*
  * requested_goal_id may be NULL. In that case the Runtime generates a UUID.
  * out_goal receives the actual Goal identity and is used for cancel requests.
+ * timeout_usec applies only while waiting for GOAL_RESPONSE. Zero means no
+ * Goal Response timeout. It does not impose a Result or Cancel Response
+ * deadline on an accepted Goal.
  */
 hako_pdu_action_error_t hako_pdu_action_client_send_goal(
     hako_pdu_action_client_handle_t* handle,
@@ -135,7 +139,7 @@ hako_pdu_action_error_t hako_pdu_action_client_send_goal(
     const hako_pdu_action_goal_id_t* requested_goal_id,
     hako_pdu_action_client_goal_handle_t* out_goal,
     uint64_t timeout_usec);
-hako_pdu_action_error_t hako_pdu_action_client_cancel(
+hako_pdu_action_error_t hako_pdu_action_client_cancel_goal(
     hako_pdu_action_client_handle_t* handle,
     const char* action_name,
     const hako_pdu_action_client_goal_handle_t* goal);

--- a/include/hakoniwa/pdu/action/c_action.h
+++ b/include/hakoniwa/pdu/action/c_action.h
@@ -19,6 +19,15 @@ typedef struct hako_pdu_action_server_handle hako_pdu_action_server_handle_t;
 typedef uint64_t hako_pdu_action_event_token_t;
 typedef uint64_t hako_pdu_action_goal_token_t;
 
+typedef struct {
+    uint8_t bytes[HAKO_PDU_ACTION_GOAL_ID_SIZE];
+} hako_pdu_action_goal_id_t;
+
+/* High-level bindings should wrap this value as an ActionGoalHandle object. */
+typedef struct {
+    hako_pdu_action_goal_id_t goal_id;
+} hako_pdu_action_client_goal_handle_t;
+
 typedef enum {
     HAKO_PDU_ACTION_OK = 0,
     HAKO_PDU_ACTION_ERROR_INVALID_ARGUMENT = 1,
@@ -46,7 +55,8 @@ typedef enum {
     HAKO_PDU_ACTION_SERVER_EVENT_NONE = 0,
     HAKO_PDU_ACTION_SERVER_EVENT_GOAL_REQUEST = 1,
     HAKO_PDU_ACTION_SERVER_EVENT_CANCEL_REQUEST = 2,
-    HAKO_PDU_ACTION_SERVER_EVENT_ERROR = 3
+    HAKO_PDU_ACTION_SERVER_EVENT_RUNTIME_CANCEL_REQUEST = 3,
+    HAKO_PDU_ACTION_SERVER_EVENT_ERROR = 4
 } hako_pdu_action_server_event_t;
 
 typedef enum {
@@ -62,9 +72,16 @@ typedef enum {
     HAKO_PDU_ACTION_TERMINAL_ABORTED = 3
 } hako_pdu_action_terminal_status_t;
 
+typedef enum {
+    HAKO_PDU_ACTION_RUNTIME_CANCEL_UNSPECIFIED = 0,
+    HAKO_PDU_ACTION_RUNTIME_CANCEL_TRANSPORT_DISCONNECTED = 1,
+    HAKO_PDU_ACTION_RUNTIME_CANCEL_SERVER_SHUTDOWN = 2,
+    HAKO_PDU_ACTION_RUNTIME_CANCEL_INTERNAL_POLICY = 3
+} hako_pdu_action_runtime_cancel_cause_t;
+
 typedef struct {
     char action_name[HAKO_PDU_ACTION_NAME_MAX];
-    uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE];
+    hako_pdu_action_client_goal_handle_t goal;
     hako_pdu_action_decision_t decision;
     hako_pdu_action_terminal_status_t terminal_status;
     uint32_t feedback_sequence;
@@ -73,9 +90,11 @@ typedef struct {
 
 typedef struct {
     hako_pdu_action_event_token_t event_token;
+    hako_pdu_action_goal_token_t goal_token;
     char action_name[HAKO_PDU_ACTION_NAME_MAX];
     char client_name[HAKO_PDU_ACTION_NAME_MAX];
-    uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE];
+    hako_pdu_action_goal_id_t goal_id;
+    hako_pdu_action_runtime_cancel_cause_t runtime_cancel_cause;
     size_t pdu_size;
 } hako_pdu_action_server_event_info_t;
 
@@ -95,27 +114,31 @@ hako_pdu_action_error_t hako_pdu_action_client_stop(hako_pdu_action_client_handl
 hako_pdu_action_error_t hako_pdu_action_client_create_goal_buffer(
     hako_pdu_action_client_handle_t* handle,
     const char* action_name,
-    const uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE],
     uint8_t* buffer,
     size_t capacity,
     size_t* out_size);
 hako_pdu_action_error_t hako_pdu_action_client_create_goal_buffer_alloc(
     hako_pdu_action_client_handle_t* handle,
     const char* action_name,
-    const uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE],
     uint8_t** out_buffer,
     size_t* out_size);
+
+/*
+ * requested_goal_id may be NULL. In that case the Runtime generates a UUID.
+ * out_goal receives the actual Goal identity and is used for cancel requests.
+ */
 hako_pdu_action_error_t hako_pdu_action_client_send_goal(
     hako_pdu_action_client_handle_t* handle,
     const char* action_name,
-    const uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE],
     const uint8_t* pdu,
     size_t pdu_size,
+    const hako_pdu_action_goal_id_t* requested_goal_id,
+    hako_pdu_action_client_goal_handle_t* out_goal,
     uint64_t timeout_usec);
 hako_pdu_action_error_t hako_pdu_action_client_cancel(
     hako_pdu_action_client_handle_t* handle,
     const char* action_name,
-    const uint8_t goal_id[HAKO_PDU_ACTION_GOAL_ID_SIZE]);
+    const hako_pdu_action_client_goal_handle_t* goal);
 hako_pdu_action_client_event_t hako_pdu_action_client_poll(
     hako_pdu_action_client_handle_t* handle,
     hako_pdu_action_client_event_info_t* out_info,
@@ -182,9 +205,10 @@ hako_pdu_action_error_t hako_pdu_action_server_complete(
  * TODO(codex): add mux declarations only after Goal ownership across transport
  * sessions is implemented. The static API intentionally lands first.
  *
- * Contract: event_token is one-shot. goal_token is valid from goal acceptance
- * until one terminal completion commits. Result wins over a pending Cancel by
- * invalidating its event_token and emitting no Cancel Response.
+ * Contract: event_token is one-shot. goal_token is a server-side capability
+ * valid from goal acceptance until terminal completion commits. Client users
+ * retain a goal handle; they do not manipulate goal_token. Result wins over a
+ * pending Cancel by invalidating its event_token and emitting no response.
  */
 
 #ifdef __cplusplus


### PR DESCRIPTION
Related: #21, #44, #50, #56, #57, #58, #59, #60

## 概要

Action Runtime実装の第一弾として、既存RPC Serviceの構造に対応する公開Header契約を追加します。

このPRでは実装を追加せず、Codexが後続PRでNative実装へ着手できる境界、所有権、token寿命、Cancel／Result競合の不変条件を先に固定します。

## 追加Header

- `action_types.hpp`
- `action_client_endpoint.hpp`
- `action_server_endpoint.hpp`
- `action_services_client.hpp`
- `action_services_server.hpp`
- `c_action.h`

## 固定する契約

- namespaceは`hakoniwa::pdu::action`
- 1 Client Endpointで複数Goalを扱う
- `goal_id`は16 byte
- `event_token`はGoal／Cancel判断専用のone-shot token
- `goal_token`はGoal acceptからterminal commitまで有効
- Client pollはGoal Response／Feedback／Cancel Response／Resultを共通イベントとして返す
- Server pollはGoal Request／Cancel Requestを返す
- Result commitとCancel acceptはGoal単位で排他的
- Result勝利時はpending Cancelを無効化し、Cancel Responseを送らない
- C APIはcaller-owned bufferと`*_alloc`を用意する
- Mux APIはGoal ownership設計が確定するまでTODOとして保留

## 意図的なTODO

- timeoutの厳密なper-goal意味論
- native error modelの詳細
- Endpoint pollのready queue方式
- Goal Context map／locking／token allocator
- Muxにおけるtransport sessionとGoal lifetimeの所有関係

これらは公開APIへ漏らさず、後続の実装PRでCodexに担当させます。

## レビュー観点

1. 既存RPC Serviceと適切に対称か
2. 公開APIが実装詳細を露出していないか
3. event tokenとgoal tokenの責務が明確か
4. Result／Cancel race契約がHeaderコメントにも反映されているか
5. C APIの粒度がPython/CFFIから利用しやすいか
6. Muxを第一弾から外す判断が妥当か

## このPRで行わないこと

- `.cpp`実装
- CMake source登録
- Python/CFFI実装
- Runtime Contract Test
- Mux API実装
