### PR TITLE
Add Action server endpoint implementation outline

### DIFF
--- a/config/sample/action.json
+++ b/config/sample/action.json
@@ -1,0 +1,15 @@
+{
+  "actions": [
+    {
+      "name": "fibonacci",
+      "type": "sample_action_msgs/Fibonacci",
+      "slotCount": 4,
+      "clientEndpoint": {
+        "nodeId": "fibonacci-client"
+      },
+      "serverEndpoint": {
+        "nodeId": "fibonacci-server"
+      }
+    }
+  ]
+}

--- a/docs/design/action/08-configuration.md
+++ b/docs/design/action/08-configuration.md
@@ -1,0 +1,392 @@
+# Hakoniwa Action設定モデル
+
+> **Status: Draft**  
+> 本文書はレビューと議論のための初稿です。現時点では確定仕様ではありません。
+
+## 1. 目的
+
+Hakoniwa Action Runtimeは、生成済みのAction Packet型だけでは通信経路を初期化できません。
+
+Runtimeは少なくとも、次の構成情報を必要とします。
+
+- どのActionを公開または利用するか
+- Actionの型は何か
+- Client側とServer側をどのEndpointへ対応付けるか
+- 同時利用に備えて何個の通信スロットを予約するか
+- 各スロットの論理チャネル名と論理チャネルIDをどう決めるか
+
+本書では、Service定義ファイルに対応するAction定義ファイルの責務と、Action Runtimeが使用する論理チャネルおよびスロットの規則を定義します。
+
+## 2. 設計原則
+
+### 2.1 ProtocolとTransport設定を分離する
+
+Action設定は、共有メモリ、TCP、muxなどの特定Transportへ依存しない論理構成を表します。
+
+```text
+Action設定
+  Action名
+  Action型
+  Endpoint対応
+  予約スロット数
+  論理チャネル規則
+
+Transport設定
+  共有メモリ領域
+  TCP host / port
+  mux接続
+  Transport固有のbufferおよびrouting情報
+```
+
+Action Protocol上の相関キーは`goal_id`です。Endpoint、接続、共有メモリチャネル、socketなどはProtocol identityではありません。
+
+### 2.2 PDUサイズは共通必須設定にしない
+
+固定PDUサイズは、主に共有メモリTransportが領域およびPDU定義を事前確保するために必要とします。
+
+TCPやlength-prefixed transportでは、受信フレーム長からPacketサイズを動的に扱えるため、Action設定の共通必須項目としてPDUサイズを要求しません。
+
+共有メモリTransportは、Registryが生成したAction Packetのsize情報とPDU metadata sizeから、必要な固定サイズを解決します。
+
+```text
+shared memory packet size
+  = generated packet size
+  + transport metadata size
+```
+
+必要な場合に限りTransport設定側で明示的な上書きを許可できますが、Action論理定義へ重複して記述することを標準にはしません。
+
+## 3. Action定義の基本単位
+
+Action定義は、Action Typeごとに一つの論理チャネル名前空間を持ちます。
+
+例:
+
+```text
+Action name: fibonacci
+Action type: sample_action_msgs/Fibonacci
+```
+
+別のAction Typeは独立した名前空間を持つため、それぞれの論理チャネルIDは0から開始できます。
+
+```text
+fibonacci
+  channel_id 0..
+
+move_robot
+  channel_id 0..
+```
+
+実際のPDU識別は、Action名とチャネル名、またはAction名と論理チャネルIDの組み合わせで行います。
+
+```text
+PduKey
+  robot/action name = fibonacci
+  pdu/channel name  = Slot0Request
+
+PduResolvedKey
+  robot/action name = fibonacci
+  channel_id        = 0
+```
+
+## 4. 通信スロット
+
+### 4.1 スロットの目的
+
+共有メモリでは、通信に使用するチャネルを実行前に予約する必要があります。
+
+同一Action Typeで複数Goalを並行処理するため、Action定義は複数の通信スロットを予約します。
+
+各スロットは、次の3論理チャネルを持ちます。
+
+```text
+Request
+  Goal Request
+  Cancel Request
+
+Response
+  Goal Response
+  Cancel Response
+  Result
+
+Feedback
+  Feedback
+```
+
+1スロットにつき3チャネルです。
+
+### 4.2 論理チャネルID
+
+論理チャネルIDはAction Typeごとに0から連番で自動採番します。
+
+スロット`n`に対する割り当ては次のとおりです。
+
+```text
+request_channel_id(n)  = n * 3 + 0
+response_channel_id(n) = n * 3 + 1
+feedback_channel_id(n) = n * 3 + 2
+```
+
+例として、4スロットを予約する場合は次の12チャネルを生成します。
+
+```text
+slot 0
+  0: request
+  1: response
+  2: feedback
+
+slot 1
+  3: request
+  4: response
+  5: feedback
+
+slot 2
+  6: request
+  7: response
+  8: feedback
+
+slot 3
+  9: request
+ 10: response
+ 11: feedback
+```
+
+論理チャネルIDはAction Typeの名前空間内でのみ一意です。システム全体でグローバルに一意である必要はありません。
+
+### 4.3 チャネル名
+
+数値の論理チャネルIDだけでは、外部の設定、ログ、PDU定義、デバッグツールから意味を判別できません。
+
+そのため、各論理チャネルは決定的に生成されるチャネル名を持ちます。
+
+初期候補は次のとおりです。
+
+```text
+Slot0Request
+Slot0Response
+Slot0Feedback
+Slot1Request
+Slot1Response
+Slot1Feedback
+...
+```
+
+命名規則は一度確定した後、設定、Runtime、生成ツール、テスト間で共通化しなければなりません。
+
+チャネル名から論理チャネルIDを解決でき、論理チャネルIDからチャネル名を復元できることを要求します。
+
+## 5. Goalとスロットの動的対応
+
+通信スロットは、特定のGoalへ静的に固定しません。
+
+Client RuntimeはGoal開始時に空きスロットを取得し、`goal_id`とスロットを動的に対応付けます。
+
+```text
+Goal Request開始
+  -> free slotを取得
+  -> goal_id -> slot_indexを登録
+  -> slotのRequest channelで送信
+```
+
+Server RuntimeはGoal Requestを受信したスロットを記録し、同じGoalのGoal Response、Cancel Response、Feedback、Resultを対応するResponseまたはFeedbackチャネルへ配送します。
+
+```text
+goal_id
+  -> slot_index
+      -> request channel
+      -> response channel
+      -> feedback channel
+```
+
+Goalがrejectされた場合、または受理後にterminal Resultまで完了した場合、Runtimeは対応するスロットを解放します。
+
+```text
+pending Goal rejected
+  -> slot release
+
+accepted Goal terminal completion
+  -> Result delivery responsibility completed
+  -> slot release
+```
+
+スロット割り当てはTransport routing上の資源管理です。Protocol上のGoal identityは引き続き`goal_id`です。
+
+## 6. 予約スロット数
+
+Action定義は、事前に予約する通信スロット数を指定します。
+
+既存Service設定との対称性から、初期実装では`maxClients`という名前を利用できます。
+
+```json
+{
+  "name": "fibonacci",
+  "type": "sample_action_msgs/Fibonacci",
+  "maxClients": 4
+}
+```
+
+ただしActionでは、1 Clientが複数Goalを並行実行する可能性があります。そのため、この値の実質的な意味は「同時に使用可能な通信スロット数」です。
+
+将来的に設定名を整理する場合は、次の候補があります。
+
+```text
+slotCount
+maxConcurrentGoals
+maxChannels
+```
+
+初期実装で`maxClients`を採用する場合でも、Runtime内部ではClient数ではなくスロット数として扱うことを明記します。
+
+スロットが枯渇した場合のClient API挙動は、後続のエラー契約で定義します。少なくとも、既存Goalのチャネルを再利用して混線させてはなりません。
+
+## 7. Endpoint対応
+
+Action定義は、Action Client RuntimeおよびAction Server RuntimeをEndpoint定義へ対応付けます。
+
+概念例:
+
+```json
+{
+  "name": "fibonacci",
+  "type": "sample_action_msgs/Fibonacci",
+  "maxClients": 4,
+  "clientEndpoint": {
+    "nodeId": "fibonacci-client"
+  },
+  "serverEndpoint": {
+    "nodeId": "fibonacci-server"
+  }
+}
+```
+
+この対応は論理構成です。各Endpointが共有メモリ、TCP、muxなどのどのTransportを利用するかはEndpointまたはTransport設定側で定義します。
+
+複数Client Endpoint、動的Endpoint、mux上のroutingなどの詳細は初期実装範囲外とし、後続で拡張します。
+
+## 8. 最小Action定義例
+
+初期のstatic Endpoint構成では、Action定義を次のように表現できます。
+
+```json
+{
+  "actions": [
+    {
+      "name": "fibonacci",
+      "type": "sample_action_msgs/Fibonacci",
+      "maxClients": 4,
+      "clientEndpoint": {
+        "nodeId": "fibonacci-client"
+      },
+      "serverEndpoint": {
+        "nodeId": "fibonacci-server"
+      }
+    }
+  ]
+}
+```
+
+この定義から、Runtimeまたは設定生成ツールは次を自動展開します。
+
+```text
+Action namespace
+  fibonacci
+
+reserved slots
+  4
+
+logical channels
+  4 slots * 3 channels = 12 channels
+
+channel ids
+  0..11
+
+channel names
+  Slot0Request
+  Slot0Response
+  Slot0Feedback
+  ...
+  Slot3Feedback
+
+shared memory only
+  generated packet sizesをRegistryから解決
+  metadata sizeを加算
+  PDU definitionsを事前登録
+```
+
+## 9. Transport別の解釈
+
+### 9.1 共有メモリ
+
+共有メモリTransportは、予約スロットに対応する全論理チャネルを起動時にPDU定義へ登録します。
+
+- チャネルIDはAction Typeごとに0から連番
+- チャネル名は決定的な命名規則から生成
+- PDUサイズはRegistry生成情報から解決
+- Goal開始時に空きスロットを割り当て
+- terminal完了後にスロットを解放
+
+### 9.2 動的サイズを扱えるTransport
+
+TCPやlength-prefixed transportは、Packetサイズを受信フレームから判断できます。
+
+これらのTransportは、共有メモリと同じAction設定インターフェースを受け取りますが、固定PDUサイズや事前の共有メモリチャネル確保を必要としない場合があります。
+
+実装は、論理チャネル名、slot index、packet kind、transport sessionなどを内部routingへマッピングできます。
+
+Action設定インターフェースを共通化する目的は、すべてのTransportへ共有メモリの実装制約を強制することではありません。
+
+## 10. Runtimeが保持する情報
+
+初期実装のRuntimeは、少なくとも次の情報を保持します。
+
+```text
+ActionDefinition
+  name
+  type
+  slot_count
+  client_endpoint
+  server_endpoint
+
+ChannelDefinition
+  slot_index
+  channel_kind
+  channel_id
+  channel_name
+  packet_type
+  packet_size optional / transport-specific
+
+ActiveSlot
+  slot_index
+  goal_id
+  lifecycle state
+  response routing
+  feedback routing
+```
+
+`goal_id`からActiveSlotを検索でき、slot indexから対応する3チャネルを決定できる必要があります。
+
+## 11. 設計判断
+
+1. Action定義ファイルをService定義ファイルに対応する論理構成として追加する。
+2. PDUサイズはAction設定の共通必須項目にしない。
+3. 固定PDUサイズは共有メモリTransportがRegistry生成情報から解決する。
+4. 同一Action Typeの並行Goalに備え、複数の通信スロットを事前予約する。
+5. 1スロットはRequest、Response、Feedbackの3論理チャネルを持つ。
+6. 論理チャネルIDはAction Typeごとに0から自動採番する。
+7. 各論理チャネルは外部から意味を識別できる決定的なチャネル名を持つ。
+8. Goal開始時に`goal_id`と空きスロットを動的に対応付ける。
+9. Goal終了後にスロットを解放する。
+10. スロットとチャネルはTransport routing資源であり、Protocol identityは`goal_id`のままとする。
+11. 初期実装はstatic Endpoint対応を対象とし、dynamic Endpointおよびmux routingは後続で設計する。
+
+## 12. 未確定事項
+
+- 設定項目名を`maxClients`のままにするか、`slotCount`へ変更するか
+- チャネル名の最終的な大文字小文字および接尾辞規則
+- Action定義ファイルの正式ファイル名と配置
+- 複数Client Endpointを一つのAction定義へ記載する方式
+- slot枯渇時の同期エラー、待機、timeoutの契約
+- reject時およびResult送信失敗時の正確なslot解放条件
+- dynamic transportで論理チャネルをwire上へ表現する必要があるか
+- mux transport sessionとslot lifetimeの対応
+- Registry size情報の具体的な参照API

--- a/docs/design/action/08-configuration.md
+++ b/docs/design/action/08-configuration.md
@@ -50,8 +50,9 @@ TCPやlength-prefixed transportでは、受信フレーム長からPacketサイ�
 
 ```text
 shared memory packet size
-  = generated packet size
-  + transport metadata size
+  = transport metadata size
+  + generated base size
+  + configured heap capacity
 ```
 
 必要な場合に限りTransport設定側で明示的な上書きを許可できますが、Action論理定義へ重複して記述することを標準にはしません。
@@ -198,10 +199,11 @@ goal_id
       -> feedback channel
 ```
 
-Goalがrejectされた場合、または受理後にterminal Resultまで完了した場合、Runtimeは対応するスロットを解放します。
+Goalがrejectされた場合、または受理後にterminal Resultまで完了した場合、Runtimeは対応する応答の配送責務が完了した後にスロットを解放します。
 
 ```text
 pending Goal rejected
+  -> Goal Response(REJECTED) delivery completed
   -> slot release
 
 accepted Goal terminal completion
@@ -215,27 +217,17 @@ accepted Goal terminal completion
 
 Action定義は、事前に予約する通信スロット数を指定します。
 
-既存Service設定との対称性から、初期実装では`maxClients`という名前を利用できます。
+通信スロット数は`slotCount`で指定します。
 
 ```json
 {
   "name": "fibonacci",
   "type": "sample_action_msgs/Fibonacci",
-  "maxClients": 4
+  "slotCount": 4
 }
 ```
 
-ただしActionでは、1 Clientが複数Goalを並行実行する可能性があります。そのため、この値の実質的な意味は「同時に使用可能な通信スロット数」です。
-
-将来的に設定名を整理する場合は、次の候補があります。
-
-```text
-slotCount
-maxConcurrentGoals
-maxChannels
-```
-
-初期実装で`maxClients`を採用する場合でも、Runtime内部ではClient数ではなくスロット数として扱うことを明記します。
+`slotCount`はRuntime／Transportが同時に保持できる通信lane数です。Client接続数でも、Applicationが業務上受理できるGoal数でもありません。共有メモリ実装では1 active Goalが1 slotを占有するため、結果的に通信上のin-flight上限になりますが、Applicationの並列実行Policyとは分離します。
 
 スロットが枯渇した場合のClient API挙動は、後続のエラー契約で定義します。少なくとも、既存Goalのチャネルを再利用して混線させてはなりません。
 
@@ -249,7 +241,7 @@ Action定義は、Action Client RuntimeおよびAction Server RuntimeをEndpoint
 {
   "name": "fibonacci",
   "type": "sample_action_msgs/Fibonacci",
-  "maxClients": 4,
+  "slotCount": 4,
   "clientEndpoint": {
     "nodeId": "fibonacci-client"
   },
@@ -273,7 +265,7 @@ Action定義は、Action Client RuntimeおよびAction Server RuntimeをEndpoint
     {
       "name": "fibonacci",
       "type": "sample_action_msgs/Fibonacci",
-      "maxClients": 4,
+      "slotCount": 4,
       "clientEndpoint": {
         "nodeId": "fibonacci-client"
       },
@@ -308,7 +300,8 @@ channel names
   Slot3Feedback
 
 shared memory only
-  generated packet sizesをRegistryから解決
+  generated base sizesをRegistryから解決
+  Transport設定のheap capacityを加算
   metadata sizeを加算
   PDU definitionsを事前登録
 ```
@@ -321,7 +314,8 @@ shared memory only
 
 - チャネルIDはAction Typeごとに0から連番
 - チャネル名は決定的な命名規則から生成
-- PDUサイズはRegistry生成情報から解決
+- base sizeはRegistry生成情報から解決
+- 可変長bodyのheap capacityはTransport設定から解決
 - Goal開始時に空きスロットを割り当て
 - terminal完了後にスロットを解放
 
@@ -369,19 +363,18 @@ ActiveSlot
 
 1. Action定義ファイルをService定義ファイルに対応する論理構成として追加する。
 2. PDUサイズはAction設定の共通必須項目にしない。
-3. 固定PDUサイズは共有メモリTransportがRegistry生成情報から解決する。
+3. 固定PDUサイズは共有メモリTransportがRegistryのbase size、Transport設定のheap capacity、metadata sizeから解決する。
 4. 同一Action Typeの並行Goalに備え、複数の通信スロットを事前予約する。
 5. 1スロットはRequest、Response、Feedbackの3論理チャネルを持つ。
 6. 論理チャネルIDはAction Typeごとに0から自動採番する。
 7. 各論理チャネルは外部から意味を識別できる決定的なチャネル名を持つ。
 8. Goal開始時に`goal_id`と空きスロットを動的に対応付ける。
-9. Goal終了後にスロットを解放する。
+9. Goal rejectまたはterminal Resultの配送責務が完了した後にスロットを解放する。
 10. スロットとチャネルはTransport routing資源であり、Protocol identityは`goal_id`のままとする。
 11. 初期実装はstatic Endpoint対応を対象とし、dynamic Endpointおよびmux routingは後続で設計する。
 
 ## 12. 未確定事項
 
-- 設定項目名を`maxClients`のままにするか、`slotCount`へ変更するか
 - チャネル名の最終的な大文字小文字および接尾辞規則
 - Action定義ファイルの正式ファイル名と配置
 - 複数Client Endpointを一つのAction定義へ記載する方式

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(HAKO_PDU_RPC_SOURCES
   rpc_services_mux_server.cpp
   rpc_client_endpoint_impl.cpp
   rpc_services_client.cpp
+  action_configuration.cpp
   action_server_endpoint_impl.cpp
   c_rpc.cpp
   c_rpc_cancel.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(HAKO_PDU_RPC_SOURCES
   rpc_services_mux_server.cpp
   rpc_client_endpoint_impl.cpp
   rpc_services_client.cpp
+  action_server_endpoint_impl.cpp
   c_rpc.cpp
   c_rpc_cancel.cpp
   c_rpc_alloc.cpp

--- a/src/action_configuration.cpp
+++ b/src/action_configuration.cpp
@@ -1,0 +1,186 @@
+#include "action_configuration.hpp"
+
+#include <fstream>
+#include <limits>
+#include <set>
+
+#include <nlohmann/json.hpp>
+
+namespace hakoniwa::pdu::action {
+namespace {
+
+bool read_required_text(const nlohmann::json& object,
+                        const char* key,
+                        std::string& value_out,
+                        std::string& error_out)
+{
+    const auto it = object.find(key);
+    if (it == object.end() || !it->is_string() || it->get_ref<const std::string&>().empty()) {
+        error_out = std::string("'") + key + "' must be a non-empty string";
+        return false;
+    }
+    value_out = it->get<std::string>();
+    return true;
+}
+
+bool read_endpoint(const nlohmann::json& action,
+                   const char* key,
+                   ActionEndpointReference& endpoint_out,
+                   std::string& error_out)
+{
+    const auto it = action.find(key);
+    if (it == action.end() || !it->is_object()) {
+        error_out = std::string("'") + key + "' must be an object";
+        return false;
+    }
+    return read_required_text(*it, "nodeId", endpoint_out.node_id, error_out);
+}
+
+std::string packet_type(const std::string& action_type, const char* suffix)
+{
+    return action_type + "Action" + suffix;
+}
+
+void append_slot_channels(ActionDefinition& definition, std::size_t slot)
+{
+    const auto base_id = static_cast<std::uint32_t>(slot * 3U);
+    const auto slot_name = std::string("Slot") + std::to_string(slot);
+    definition.channels.push_back(ActionChannelDefinition{
+        slot,
+        ActionChannelKind::REQUEST,
+        base_id,
+        slot_name + "Request",
+        packet_type(definition.type, "Request"),
+    });
+    definition.channels.push_back(ActionChannelDefinition{
+        slot,
+        ActionChannelKind::RESPONSE,
+        base_id + 1U,
+        slot_name + "Response",
+        packet_type(definition.type, "Response"),
+    });
+    definition.channels.push_back(ActionChannelDefinition{
+        slot,
+        ActionChannelKind::FEEDBACK,
+        base_id + 2U,
+        slot_name + "Feedback",
+        packet_type(definition.type, "Feedback"),
+    });
+}
+
+} // namespace
+
+bool ActionConfigurationLoader::load_file(
+    const std::string& path,
+    ActionConfiguration& configuration_out,
+    std::string& error_out)
+{
+    std::ifstream stream(path);
+    if (!stream.is_open()) {
+        error_out = "failed to open Action configuration: " + path;
+        return false;
+    }
+
+    try {
+        nlohmann::json root;
+        stream >> root;
+        return parse(root, configuration_out, error_out);
+    } catch (const nlohmann::json::exception& error) {
+        error_out = std::string("failed to parse Action configuration JSON: ") + error.what();
+        return false;
+    }
+}
+
+bool ActionConfigurationLoader::parse(
+    const nlohmann::json& root,
+    ActionConfiguration& configuration_out,
+    std::string& error_out)
+{
+    if (!root.is_object()) {
+        error_out = "Action configuration root must be an object";
+        return false;
+    }
+
+    ActionConfiguration parsed;
+    const auto actions = root.find("actions");
+    if (actions == root.end() || !actions->is_array() || actions->empty()) {
+        error_out = "'actions' must be a non-empty array";
+        return false;
+    }
+
+    std::set<std::string> names;
+    for (const auto& action : *actions) {
+        ActionDefinition definition;
+        std::string action_error;
+        if (!parse_action(action, definition, action_error)) {
+            error_out = "invalid Action definition: " + action_error;
+            return false;
+        }
+        if (!names.insert(definition.name).second) {
+            error_out = "duplicate Action name: " + definition.name;
+            return false;
+        }
+        parsed.actions.push_back(std::move(definition));
+    }
+
+    configuration_out = std::move(parsed);
+    error_out.clear();
+    return true;
+}
+
+bool ActionConfigurationLoader::parse_action(
+    const nlohmann::json& action,
+    ActionDefinition& definition_out,
+    std::string& error_out)
+{
+    if (!action.is_object()) {
+        error_out = "Action entry must be an object";
+        return false;
+    }
+
+    ActionDefinition parsed;
+    if (!read_required_text(action, "name", parsed.name, error_out)
+        || !read_required_text(action, "type", parsed.type, error_out)) {
+        return false;
+    }
+    const auto separator = parsed.type.find('/');
+    if (separator == std::string::npos || separator == 0
+        || separator + 1 == parsed.type.size()
+        || parsed.type.find('/', separator + 1) != std::string::npos) {
+        error_out = "'type' must use package/ActionName format";
+        return false;
+    }
+
+    const auto slot_count = action.find("slotCount");
+    if (slot_count == action.end() || !slot_count->is_number_unsigned()) {
+        error_out = "'slotCount' must be a positive integer";
+        return false;
+    }
+    parsed.slot_count = slot_count->get<std::size_t>();
+    if (parsed.slot_count == 0) {
+        error_out = "'slotCount' must be a positive integer";
+        return false;
+    }
+    constexpr auto max_slot_count =
+        static_cast<std::size_t>((std::numeric_limits<std::uint32_t>::max() - 2U) / 3U) + 1U;
+    if (parsed.slot_count > max_slot_count) {
+        error_out = "'slotCount' exceeds the logical channel ID range";
+        return false;
+    }
+
+    if (!read_endpoint(action, "clientEndpoint", parsed.client_endpoint, error_out)
+        || !read_endpoint(action, "serverEndpoint", parsed.server_endpoint, error_out)) {
+        return false;
+    }
+
+    parsed.channels.reserve(parsed.slot_count * 3U);
+    for (std::size_t slot = 0; slot < parsed.slot_count; ++slot) {
+        append_slot_channels(parsed, slot);
+    }
+
+    definition_out = std::move(parsed);
+    error_out.clear();
+    return true;
+}
+
+} // namespace hakoniwa::pdu::action

--- a/src/action_configuration.hpp
+++ b/src/action_configuration.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace hakoniwa::pdu::action {
+
+enum class ActionChannelKind : std::uint8_t {
+    REQUEST,
+    RESPONSE,
+    FEEDBACK,
+};
+
+struct ActionEndpointReference {
+    std::string node_id;
+};
+
+struct ActionChannelDefinition {
+    std::size_t slot_index{0};
+    ActionChannelKind kind{ActionChannelKind::REQUEST};
+    std::uint32_t channel_id{0};
+    std::string channel_name;
+    std::string packet_type;
+};
+
+struct ActionDefinition {
+    std::string name;
+    std::string type;
+    std::size_t slot_count{0};
+    ActionEndpointReference client_endpoint;
+    ActionEndpointReference server_endpoint;
+    std::vector<ActionChannelDefinition> channels;
+};
+
+struct ActionConfiguration {
+    std::vector<ActionDefinition> actions;
+};
+
+class ActionConfigurationLoader {
+public:
+    static bool load_file(const std::string& path,
+                          ActionConfiguration& configuration_out,
+                          std::string& error_out);
+
+    static bool parse(const nlohmann::json& root,
+                      ActionConfiguration& configuration_out,
+                      std::string& error_out);
+
+    static bool parse_action(const nlohmann::json& action,
+                             ActionDefinition& definition_out,
+                             std::string& error_out);
+};
+
+} // namespace hakoniwa::pdu::action

--- a/src/action_server_endpoint_impl.cpp
+++ b/src/action_server_endpoint_impl.cpp
@@ -1,0 +1,127 @@
+#include "action_server_endpoint_impl.hpp"
+
+#include <nlohmann/json.hpp>
+
+namespace hakoniwa::pdu::action {
+
+ActionServerEndpointImpl::ActionServerEndpointImpl(
+    const std::string& action_name,
+    std::uint64_t delta_time_usec,
+    std::shared_ptr<hakoniwa::pdu::Endpoint> endpoint,
+    std::shared_ptr<hakoniwa::time_source::ITimeSource> time_source)
+    : IActionServerEndpoint(action_name, delta_time_usec),
+      endpoint_(std::move(endpoint)),
+      time_source_(std::move(time_source))
+{
+}
+
+bool ActionServerEndpointImpl::initialize(
+    const nlohmann::json& action_config,
+    int pdu_meta_data_size,
+    std::optional<std::string> client_node_id)
+{
+    (void)action_config;
+    (void)pdu_meta_data_size;
+    (void)client_node_id;
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (!endpoint_ || !time_source_) {
+        initialized_ = false;
+        return false;
+    }
+
+    // TODO: validate the Action configuration and generated PDU metadata.
+    // TODO: register Goal/Cancel receive callbacks and response channels.
+    initialized_ = true;
+    return true;
+}
+
+ServerEventType ActionServerEndpointImpl::poll(ServerEvent& event_out)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    event_out = ServerEvent{};
+    if (!initialized_ || pending_events_.empty()) {
+        return ServerEventType::NONE;
+    }
+
+    event_out = std::move(pending_events_.front());
+    pending_events_.pop_front();
+    return event_out.type;
+}
+
+bool ActionServerEndpointImpl::accept_goal(
+    EventToken event_token,
+    GoalToken& goal_token_out)
+{
+    (void)event_token;
+    goal_token_out = INVALID_GOAL_TOKEN;
+
+    // TODO: consume a GOAL_REQUEST event token, create a Goal Context, allocate
+    // a non-zero GoalToken, and emit GOAL_RESPONSE(ACCEPTED).
+    return false;
+}
+
+bool ActionServerEndpointImpl::reject_goal(EventToken event_token)
+{
+    (void)event_token;
+
+    // TODO: consume a GOAL_REQUEST event token and emit
+    // GOAL_RESPONSE(REJECTED) without creating a Goal Context.
+    return false;
+}
+
+bool ActionServerEndpointImpl::accept_cancel(EventToken event_token)
+{
+    (void)event_token;
+
+    // TODO: atomically arbitrate cancel acceptance against terminal completion.
+    // Client-origin cancellation emits CANCEL_RESPONSE(ACCEPTED); Runtime-origin
+    // cancellation does not emit a Client response.
+    return false;
+}
+
+bool ActionServerEndpointImpl::reject_cancel(EventToken event_token)
+{
+    (void)event_token;
+
+    // TODO: consume the pending Cancel event. Client-origin cancellation emits
+    // CANCEL_RESPONSE(REJECTED); Runtime-origin rejection remains local.
+    return false;
+}
+
+bool ActionServerEndpointImpl::send_feedback(
+    GoalToken goal_token,
+    const PduData& feedback_pdu)
+{
+    (void)goal_token;
+    (void)feedback_pdu;
+
+    // TODO: validate EXECUTING state, assign the per-Goal feedback sequence,
+    // encode the generated Feedback PDU, and send it through endpoint_.
+    return false;
+}
+
+bool ActionServerEndpointImpl::complete(
+    GoalToken goal_token,
+    TerminalStatus status,
+    const PduData& result_pdu)
+{
+    (void)goal_token;
+    (void)status;
+    (void)result_pdu;
+
+    // TODO: validate the terminal status and commit exactly one immutable
+    // terminal Result. If Result wins over a pending Cancel, invalidate the
+    // Cancel EventToken and emit no Cancel Response.
+    return false;
+}
+
+void ActionServerEndpointImpl::clear_pending_events()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    pending_events_.clear();
+}
+
+} // namespace hakoniwa::pdu::action

--- a/src/action_server_endpoint_impl.cpp
+++ b/src/action_server_endpoint_impl.cpp
@@ -2,7 +2,76 @@
 
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
+
 namespace hakoniwa::pdu::action {
+
+bool ActionServerEndpointImpl::decode_request_header(
+    const PduData& packet,
+    HakoCpp_ActionRequestHeader& header_out)
+{
+    if (packet.empty()) {
+        return false;
+    }
+    return request_header_convertor_.pdu2cpp(
+        reinterpret_cast<char*>(const_cast<std::uint8_t*>(packet.data())),
+        header_out);
+}
+
+bool ActionServerEndpointImpl::validate_request_header(
+    const HakoCpp_ActionRequestHeader& header) const
+{
+    if (header.version != ACTION_PROTOCOL_VERSION) {
+        return false;
+    }
+    if (header.request_kind != REQUEST_KIND_GOAL
+        && header.request_kind != REQUEST_KIND_CANCEL) {
+        return false;
+    }
+    return std::any_of(
+        header.goal_id.begin(), header.goal_id.end(),
+        [](std::uint8_t value) { return value != 0; });
+}
+
+bool ActionServerEndpointImpl::write_response_header(
+    PduData& initialized_packet,
+    HakoCpp_ActionResponseHeader& header)
+{
+    if (initialized_packet.empty()) {
+        return false;
+    }
+    auto* base_ptr = static_cast<char*>(
+        hako_get_base_ptr_pdu(initialized_packet.data()));
+    if (base_ptr == nullptr) {
+        return false;
+    }
+
+    PduDynamicMemory dynamic_memory;
+    return cpp_cpp2pdu_ActionResponseHeader(
+        header,
+        *reinterpret_cast<Hako_ActionResponseHeader*>(base_ptr),
+        dynamic_memory);
+}
+
+bool ActionServerEndpointImpl::write_feedback_header(
+    PduData& initialized_packet,
+    HakoCpp_ActionFeedbackHeader& header)
+{
+    if (initialized_packet.empty()) {
+        return false;
+    }
+    auto* base_ptr = static_cast<char*>(
+        hako_get_base_ptr_pdu(initialized_packet.data()));
+    if (base_ptr == nullptr) {
+        return false;
+    }
+
+    PduDynamicMemory dynamic_memory;
+    return cpp_cpp2pdu_ActionFeedbackHeader(
+        header,
+        *reinterpret_cast<Hako_ActionFeedbackHeader*>(base_ptr),
+        dynamic_memory);
+}
 
 ActionServerEndpointImpl::ActionServerEndpointImpl(
     const std::string& action_name,

--- a/src/action_server_endpoint_impl.cpp
+++ b/src/action_server_endpoint_impl.cpp
@@ -3,6 +3,7 @@
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <iostream>
 
 namespace hakoniwa::pdu::action {
 
@@ -89,9 +90,33 @@ bool ActionServerEndpointImpl::initialize(
     int pdu_meta_data_size,
     std::optional<std::string> client_node_id)
 {
-    (void)action_config;
-    (void)pdu_meta_data_size;
-    (void)client_node_id;
+    ActionDefinition parsed_definition;
+    std::string parse_error;
+    if (!ActionConfigurationLoader::parse_action(
+            action_config, parsed_definition, parse_error)) {
+        std::cerr << "ERROR: Failed to parse Action configuration for '"
+                  << action_name_ << "': " << parse_error << std::endl;
+        return false;
+    }
+    if (parsed_definition.name != action_name_) {
+        std::cerr << "ERROR: Action configuration name mismatch: expected '"
+                  << action_name_ << "', got '" << parsed_definition.name
+                  << "'." << std::endl;
+        return false;
+    }
+    if (pdu_meta_data_size <= 0) {
+        std::cerr << "ERROR: PDU metadata size must be a positive integer."
+                  << std::endl;
+        return false;
+    }
+    if (client_node_id.has_value()
+        && parsed_definition.client_endpoint.node_id != *client_node_id) {
+        std::cerr << "ERROR: Action client endpoint mismatch for '"
+                  << action_name_ << "': expected nodeId '" << *client_node_id
+                  << "', got '" << parsed_definition.client_endpoint.node_id
+                  << "'." << std::endl;
+        return false;
+    }
 
     std::lock_guard<std::mutex> lock(mutex_);
 
@@ -100,8 +125,14 @@ bool ActionServerEndpointImpl::initialize(
         return false;
     }
 
-    // TODO: validate the Action configuration and generated PDU metadata.
-    // TODO: register Goal/Cancel receive callbacks and response channels.
+    action_definition_ = std::move(parsed_definition);
+    pdu_meta_data_size_ = pdu_meta_data_size;
+
+    // TODO(endpoint contract): resolve generated packet base sizes and
+    // transport-specific heap capacities, then register the expanded logical
+    // channels with endpoint_. The logical Action configuration is fully
+    // validated and retained here so this step does not need to reinterpret
+    // the user-facing JSON.
     initialized_ = true;
     return true;
 }

--- a/src/action_server_endpoint_impl.hpp
+++ b/src/action_server_endpoint_impl.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "hakoniwa/pdu/action/action_server_endpoint.hpp"
+#include "hakoniwa/pdu/endpoint.hpp"
+#include "hakoniwa/time_source/time_source.hpp"
+
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace hakoniwa::pdu::action {
+
+/**
+ * Initial native implementation outline for IActionServerEndpoint.
+ *
+ * This class deliberately contains only lifecycle and queue scaffolding. The
+ * generated Action PDU conversion, Goal Context state machine, token allocation,
+ * and transport callbacks are implemented in subsequent steps.
+ */
+class ActionServerEndpointImpl final : public IActionServerEndpoint {
+public:
+    ActionServerEndpointImpl(
+        const std::string& action_name,
+        std::uint64_t delta_time_usec,
+        std::shared_ptr<hakoniwa::pdu::Endpoint> endpoint,
+        std::shared_ptr<hakoniwa::time_source::ITimeSource> time_source);
+
+    ~ActionServerEndpointImpl() override = default;
+
+    bool initialize(const nlohmann::json& action_config,
+                    int pdu_meta_data_size,
+                    std::optional<std::string> client_node_id = std::nullopt) override;
+
+    ServerEventType poll(ServerEvent& event_out) override;
+
+    bool accept_goal(EventToken event_token,
+                     GoalToken& goal_token_out) override;
+    bool reject_goal(EventToken event_token) override;
+    bool accept_cancel(EventToken event_token) override;
+    bool reject_cancel(EventToken event_token) override;
+
+    bool send_feedback(GoalToken goal_token,
+                       const PduData& feedback_pdu) override;
+    bool complete(GoalToken goal_token,
+                  TerminalStatus status,
+                  const PduData& result_pdu) override;
+
+    void clear_pending_events() override;
+
+private:
+    std::shared_ptr<hakoniwa::pdu::Endpoint> endpoint_;
+    std::shared_ptr<hakoniwa::time_source::ITimeSource> time_source_;
+
+    std::mutex mutex_;
+    std::deque<ServerEvent> pending_events_;
+    bool initialized_{false};
+
+    // TODO: register generated Goal and Cancel request PDUs with endpoint_.
+    // TODO: add Goal Context map keyed by GoalId and GoalToken.
+    // TODO: add one-shot EventToken allocation and validation.
+    // TODO: centralize all Goal state changes in one locked transition function.
+    // TODO: implement atomic terminal-result versus cancel-accept arbitration.
+    // TODO: add Runtime-origin Cancel events for disconnect and shutdown.
+};
+
+} // namespace hakoniwa::pdu::action

--- a/src/action_server_endpoint_impl.hpp
+++ b/src/action_server_endpoint_impl.hpp
@@ -3,6 +3,13 @@
 #include "hakoniwa/pdu/action/action_server_endpoint.hpp"
 #include "hakoniwa/pdu/endpoint.hpp"
 #include "hakoniwa/time_source/time_source.hpp"
+#include "hako_action_msgs/pdu_cpptype_ActionFeedbackHeader.hpp"
+#include "hako_action_msgs/pdu_cpptype_ActionRequestHeader.hpp"
+#include "hako_action_msgs/pdu_cpptype_ActionResponseHeader.hpp"
+#include "hako_action_msgs/pdu_cpptype_conv_ActionFeedbackHeader.hpp"
+#include "hako_action_msgs/pdu_cpptype_conv_ActionRequestHeader.hpp"
+#include "hako_action_msgs/pdu_cpptype_conv_ActionResponseHeader.hpp"
+#include "pdu_convertor.hpp"
 
 #include <deque>
 #include <memory>
@@ -49,14 +56,45 @@ public:
     void clear_pending_events() override;
 
 private:
+    static constexpr std::uint8_t ACTION_PROTOCOL_VERSION = 1;
+    static constexpr std::uint8_t REQUEST_KIND_GOAL = 1;
+    static constexpr std::uint8_t REQUEST_KIND_CANCEL = 2;
+
     std::shared_ptr<hakoniwa::pdu::Endpoint> endpoint_;
     std::shared_ptr<hakoniwa::time_source::ITimeSource> time_source_;
+
+    // The common Header convertors deliberately operate on the prefix of an
+    // Action-specific packet. Goal/Result/Feedback bodies remain opaque
+    // PduData at this layer.
+    hako::pdu::PduConvertor<
+        HakoCpp_ActionRequestHeader,
+        hako::pdu::msgs::hako_action_msgs::ActionRequestHeader>
+        request_header_convertor_;
+    hako::pdu::PduConvertor<
+        HakoCpp_ActionResponseHeader,
+        hako::pdu::msgs::hako_action_msgs::ActionResponseHeader>
+        response_header_convertor_;
+    hako::pdu::PduConvertor<
+        HakoCpp_ActionFeedbackHeader,
+        hako::pdu::msgs::hako_action_msgs::ActionFeedbackHeader>
+        feedback_header_convertor_;
 
     std::mutex mutex_;
     std::deque<ServerEvent> pending_events_;
     bool initialized_{false};
 
-    // TODO: register generated Goal and Cancel request PDUs with endpoint_.
+    bool decode_request_header(const PduData& packet,
+                               HakoCpp_ActionRequestHeader& header_out);
+    bool validate_request_header(const HakoCpp_ActionRequestHeader& header) const;
+    bool write_response_header(PduData& initialized_packet,
+                               HakoCpp_ActionResponseHeader& header);
+    bool write_feedback_header(PduData& initialized_packet,
+                               HakoCpp_ActionFeedbackHeader& header);
+
+    // TODO(endpoint contract): resolve Action packet keys, sizes, and routing,
+    // then register Goal/Cancel receive callbacks with endpoint_.
+    // TODO(endpoint contract): create complete ActionResponse/ActionFeedback
+    // packets before write_*_header() overlays their common Header prefix.
     // TODO: add Goal Context map keyed by GoalId and GoalToken.
     // TODO: add one-shot EventToken allocation and validation.
     // TODO: centralize all Goal state changes in one locked transition function.

--- a/src/action_server_endpoint_impl.hpp
+++ b/src/action_server_endpoint_impl.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "action_configuration.hpp"
 #include "hakoniwa/pdu/action/action_server_endpoint.hpp"
 #include "hakoniwa/pdu/endpoint.hpp"
 #include "hakoniwa/time_source/time_source.hpp"
@@ -81,6 +82,8 @@ private:
 
     std::mutex mutex_;
     std::deque<ServerEvent> pending_events_;
+    std::optional<ActionDefinition> action_definition_;
+    int pdu_meta_data_size_{0};
     bool initialized_{false};
 
     bool decode_request_header(const PduData& packet,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,13 @@ endif()
 # separately by the Python CFFI integration suite.
 set(HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY hakoniwa_pdu_rpc::rpc)
 
+add_executable(hakoniwa_pdu_action_packet_codec_test
+  action_packet_codec_contract_test.cpp
+)
+target_link_libraries(hakoniwa_pdu_action_packet_codec_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
+add_test(NAME hakoniwa_pdu_action_packet_codec_test COMMAND hakoniwa_pdu_action_packet_codec_test)
+set_tests_properties(hakoniwa_pdu_action_packet_codec_test PROPERTIES TIMEOUT 30)
+
 add_executable(hakoniwa_pdu_rpc_basic_test
   rpc_basic_contract_test.cpp
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,29 @@ endif()
 # separately by the Python CFFI integration suite.
 set(HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY hakoniwa_pdu_rpc::rpc)
 
+add_executable(hakoniwa_pdu_action_configuration_test
+  action_configuration_contract_test.cpp
+)
+target_link_libraries(hakoniwa_pdu_action_configuration_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
+target_include_directories(hakoniwa_pdu_action_configuration_test PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../src"
+)
+target_compile_definitions(hakoniwa_pdu_action_configuration_test PRIVATE
+  ACTION_CONFIG_FIXTURE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/../config/sample/action.json"
+)
+add_test(NAME hakoniwa_pdu_action_configuration_test COMMAND hakoniwa_pdu_action_configuration_test)
+set_tests_properties(hakoniwa_pdu_action_configuration_test PROPERTIES TIMEOUT 30)
+
+add_executable(hakoniwa_pdu_action_server_initialization_test
+  action_server_initialization_contract_test.cpp
+)
+target_link_libraries(hakoniwa_pdu_action_server_initialization_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
+target_include_directories(hakoniwa_pdu_action_server_initialization_test PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../src"
+)
+add_test(NAME hakoniwa_pdu_action_server_initialization_test COMMAND hakoniwa_pdu_action_server_initialization_test)
+set_tests_properties(hakoniwa_pdu_action_server_initialization_test PROPERTIES TIMEOUT 30)
+
 add_executable(hakoniwa_pdu_action_packet_codec_test
   action_packet_codec_contract_test.cpp
 )

--- a/test/action_configuration_contract_test.cpp
+++ b/test/action_configuration_contract_test.cpp
@@ -1,0 +1,103 @@
+#include "action_configuration.hpp"
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace action = hakoniwa::pdu::action;
+
+TEST(ActionConfigurationContract, LoadsAndExpandsSampleConfiguration)
+{
+    action::ActionConfiguration configuration;
+    std::string error;
+
+    ASSERT_TRUE(action::ActionConfigurationLoader::load_file(
+        ACTION_CONFIG_FIXTURE_PATH, configuration, error)) << error;
+    ASSERT_EQ(configuration.actions.size(), 1U);
+
+    const auto& definition = configuration.actions.front();
+    EXPECT_EQ(definition.name, "fibonacci");
+    EXPECT_EQ(definition.type, "sample_action_msgs/Fibonacci");
+    EXPECT_EQ(definition.slot_count, 4U);
+    EXPECT_EQ(definition.client_endpoint.node_id, "fibonacci-client");
+    EXPECT_EQ(definition.server_endpoint.node_id, "fibonacci-server");
+    ASSERT_EQ(definition.channels.size(), 12U);
+
+    const auto& first = definition.channels.front();
+    EXPECT_EQ(first.slot_index, 0U);
+    EXPECT_EQ(first.kind, action::ActionChannelKind::REQUEST);
+    EXPECT_EQ(first.channel_id, 0U);
+    EXPECT_EQ(first.channel_name, "Slot0Request");
+    EXPECT_EQ(first.packet_type, "sample_action_msgs/FibonacciActionRequest");
+
+    const auto& last = definition.channels.back();
+    EXPECT_EQ(last.slot_index, 3U);
+    EXPECT_EQ(last.kind, action::ActionChannelKind::FEEDBACK);
+    EXPECT_EQ(last.channel_id, 11U);
+    EXPECT_EQ(last.channel_name, "Slot3Feedback");
+    EXPECT_EQ(last.packet_type, "sample_action_msgs/FibonacciActionFeedback");
+}
+
+TEST(ActionConfigurationContract, RejectsInvalidSlotCount)
+{
+    const auto action_json = nlohmann::json::parse(R"({
+        "name": "fibonacci",
+        "type": "sample_action_msgs/Fibonacci",
+        "slotCount": 0,
+        "clientEndpoint": {"nodeId": "client"},
+        "serverEndpoint": {"nodeId": "server"}
+    })");
+    action::ActionDefinition definition;
+    std::string error;
+
+    EXPECT_FALSE(action::ActionConfigurationLoader::parse_action(
+        action_json, definition, error));
+    EXPECT_NE(error.find("slotCount"), std::string::npos);
+}
+
+TEST(ActionConfigurationContract, RejectsMalformedActionType)
+{
+    const auto action_json = nlohmann::json::parse(R"({
+        "name": "fibonacci",
+        "type": "Fibonacci",
+        "slotCount": 1,
+        "clientEndpoint": {"nodeId": "client"},
+        "serverEndpoint": {"nodeId": "server"}
+    })");
+    action::ActionDefinition definition;
+    std::string error;
+
+    EXPECT_FALSE(action::ActionConfigurationLoader::parse_action(
+        action_json, definition, error));
+    EXPECT_NE(error.find("package/ActionName"), std::string::npos);
+}
+
+TEST(ActionConfigurationContract, RejectsDuplicateActionNames)
+{
+    const auto root = nlohmann::json::parse(R"({
+        "actions": [
+            {
+                "name": "fibonacci",
+                "type": "sample_action_msgs/Fibonacci",
+                "slotCount": 1,
+                "clientEndpoint": {"nodeId": "client-a"},
+                "serverEndpoint": {"nodeId": "server"}
+            },
+            {
+                "name": "fibonacci",
+                "type": "sample_action_msgs/Fibonacci",
+                "slotCount": 1,
+                "clientEndpoint": {"nodeId": "client-b"},
+                "serverEndpoint": {"nodeId": "server"}
+            }
+        ]
+    })");
+    action::ActionConfiguration configuration;
+    std::string error;
+
+    EXPECT_FALSE(action::ActionConfigurationLoader::parse(
+        root, configuration, error));
+    EXPECT_NE(error.find("duplicate Action name"), std::string::npos);
+}

--- a/test/action_packet_codec_contract_test.cpp
+++ b/test/action_packet_codec_contract_test.cpp
@@ -1,0 +1,100 @@
+#include <gtest/gtest.h>
+
+#include "hako_action_msgs/pdu_cpptype_ActionRequestHeader.hpp"
+#include "hako_action_msgs/pdu_cpptype_ActionResponseHeader.hpp"
+#include "hako_action_msgs/pdu_cpptype_conv_ActionRequestHeader.hpp"
+#include "hako_action_msgs/pdu_cpptype_conv_ActionResponseHeader.hpp"
+#include "pdu_convertor.hpp"
+#include "sample_action_msgs/pdu_cpptype_FibonacciActionRequest.hpp"
+#include "sample_action_msgs/pdu_cpptype_FibonacciActionResponse.hpp"
+#include "sample_action_msgs/pdu_cpptype_conv_FibonacciActionRequest.hpp"
+#include "sample_action_msgs/pdu_cpptype_conv_FibonacciActionResponse.hpp"
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+constexpr std::uint8_t kProtocolVersion = 1;
+constexpr std::uint8_t kRequestKindGoal = 1;
+constexpr std::uint8_t kResponseKindGoal = 1;
+constexpr std::uint8_t kDecisionAccepted = 1;
+
+const std::array<std::uint8_t, 16> kGoalId{
+    0x10, 0x11, 0x12, 0x13,
+    0x20, 0x21, 0x22, 0x23,
+    0x30, 0x31, 0x32, 0x33,
+    0x40, 0x41, 0x42, 0x43,
+};
+
+TEST(ActionPacketCodecContract, CommonRequestHeaderDecodesFromGeneratedPacket)
+{
+    HakoCpp_FibonacciActionRequest source{};
+    source.header.version = kProtocolVersion;
+    source.header.request_kind = kRequestKindGoal;
+    source.header.reserved = {0, 0};
+    source.header.goal_id = kGoalId;
+    source.body.order = 8;
+
+    hako::pdu::msgs::sample_action_msgs::FibonacciActionRequest packet_convertor;
+    std::vector<std::uint8_t> packet(1024, 0);
+    const int packet_size = packet_convertor.cpp2pdu(
+        source,
+        reinterpret_cast<char*>(packet.data()),
+        static_cast<int>(packet.size()));
+    ASSERT_GT(packet_size, 0);
+    packet.resize(static_cast<std::size_t>(packet_size));
+
+    hako::pdu::PduConvertor<
+        HakoCpp_ActionRequestHeader,
+        hako::pdu::msgs::hako_action_msgs::ActionRequestHeader>
+        header_convertor;
+    HakoCpp_ActionRequestHeader decoded{};
+    ASSERT_TRUE(header_convertor.pdu2cpp(
+        reinterpret_cast<char*>(packet.data()), decoded));
+
+    EXPECT_EQ(decoded.version, kProtocolVersion);
+    EXPECT_EQ(decoded.request_kind, kRequestKindGoal);
+    EXPECT_EQ(decoded.goal_id, kGoalId);
+}
+
+TEST(ActionPacketCodecContract, GeneratedResponseKeepsCommonHeaderAndDefaultBody)
+{
+    HakoCpp_FibonacciActionResponse source{};
+    source.header.version = kProtocolVersion;
+    source.header.response_kind = kResponseKindGoal;
+    source.header.status = kDecisionAccepted;
+    source.header.reserved = 0;
+    source.header.goal_id = kGoalId;
+    source.body.sequence = {};
+
+    hako::pdu::msgs::sample_action_msgs::FibonacciActionResponse packet_convertor;
+    std::vector<std::uint8_t> packet(1024, 0);
+    const int packet_size = packet_convertor.cpp2pdu(
+        source,
+        reinterpret_cast<char*>(packet.data()),
+        static_cast<int>(packet.size()));
+    ASSERT_GT(packet_size, 0);
+    packet.resize(static_cast<std::size_t>(packet_size));
+
+    hako::pdu::PduConvertor<
+        HakoCpp_ActionResponseHeader,
+        hako::pdu::msgs::hako_action_msgs::ActionResponseHeader>
+        header_convertor;
+    HakoCpp_ActionResponseHeader decoded_header{};
+    ASSERT_TRUE(header_convertor.pdu2cpp(
+        reinterpret_cast<char*>(packet.data()), decoded_header));
+
+    HakoCpp_FibonacciActionResponse decoded_packet{};
+    ASSERT_TRUE(packet_convertor.pdu2cpp(
+        reinterpret_cast<char*>(packet.data()), decoded_packet));
+
+    EXPECT_EQ(decoded_header.version, kProtocolVersion);
+    EXPECT_EQ(decoded_header.response_kind, kResponseKindGoal);
+    EXPECT_EQ(decoded_header.status, kDecisionAccepted);
+    EXPECT_EQ(decoded_header.goal_id, kGoalId);
+    EXPECT_TRUE(decoded_packet.body.sequence.empty());
+}
+
+} // namespace

--- a/test/action_server_initialization_contract_test.cpp
+++ b/test/action_server_initialization_contract_test.cpp
@@ -1,0 +1,82 @@
+#include "action_server_endpoint_impl.hpp"
+
+#include "hakoniwa/pdu/endpoint.hpp"
+#include "hakoniwa/time_source/virtual_time_source.hpp"
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <memory>
+
+namespace action = hakoniwa::pdu::action;
+
+namespace {
+
+nlohmann::json fibonacci_action()
+{
+    return nlohmann::json::parse(R"({
+        "name": "fibonacci",
+        "type": "sample_action_msgs/Fibonacci",
+        "slotCount": 4,
+        "clientEndpoint": {"nodeId": "fibonacci-client"},
+        "serverEndpoint": {"nodeId": "fibonacci-server"}
+    })");
+}
+
+std::shared_ptr<hakoniwa::pdu::Endpoint> endpoint()
+{
+    return std::make_shared<hakoniwa::pdu::Endpoint>(
+        "fibonacci-server", HAKO_PDU_ENDPOINT_DIRECTION_INOUT);
+}
+
+std::shared_ptr<hakoniwa::time_source::ITimeSource> time_source()
+{
+    return std::make_shared<hakoniwa::time_source::VirtualTimeSource>();
+}
+
+} // namespace
+
+TEST(ActionServerInitializationContract, AcceptsResolvedLogicalConfiguration)
+{
+    action::ActionServerEndpointImpl server(
+        "fibonacci", 1000, endpoint(), time_source());
+
+    EXPECT_TRUE(server.initialize(
+        fibonacci_action(), 24, std::string("fibonacci-client")));
+}
+
+TEST(ActionServerInitializationContract, RejectsActionNameMismatch)
+{
+    action::ActionServerEndpointImpl server(
+        "move_robot", 1000, endpoint(), time_source());
+
+    EXPECT_FALSE(server.initialize(fibonacci_action(), 24));
+}
+
+TEST(ActionServerInitializationContract, RejectsClientEndpointMismatch)
+{
+    action::ActionServerEndpointImpl server(
+        "fibonacci", 1000, endpoint(), time_source());
+
+    EXPECT_FALSE(server.initialize(
+        fibonacci_action(), 24, std::string("another-client")));
+}
+
+TEST(ActionServerInitializationContract, RejectsInvalidMetadataSize)
+{
+    action::ActionServerEndpointImpl server(
+        "fibonacci", 1000, endpoint(), time_source());
+
+    EXPECT_FALSE(server.initialize(fibonacci_action(), 0));
+}
+
+TEST(ActionServerInitializationContract, RequiresEndpointAndTimeSource)
+{
+    action::ActionServerEndpointImpl missing_endpoint(
+        "fibonacci", 1000, nullptr, time_source());
+    action::ActionServerEndpointImpl missing_time_source(
+        "fibonacci", 1000, endpoint(), nullptr);
+
+    EXPECT_FALSE(missing_endpoint.initialize(fibonacci_action(), 24));
+    EXPECT_FALSE(missing_time_source.initialize(fibonacci_action(), 24));
+}


### PR DESCRIPTION
## 概要

Action Server Endpoint実装の第一段階として、`IActionServerEndpoint`を満たすNative実装骨格を追加します。

## 変更内容

- `ActionServerEndpointImpl`の宣言と最小実装
- initialize／poll／accept・reject／feedback／completeの実装アウトライン
- pending event queueとライフサイクル用の最小状態
- static/shared両ライブラリのCMake source登録

## 現段階の振る舞い

- `initialize()`は依存オブジェクトを検証して初期化状態へ遷移
- `poll()`は空queueの場合`NONE`
- 未実装のGoal／Cancel／Feedback／Result操作は、誤って成功扱いしないよう`false`
- Transport登録、PDU変換、Goal Context、token allocator、Cancel／Result競合はTODOとして明示

## 今回のゴール

既存RPCライブラリへAction Server実装骨格を組み込み、Linux／macOS／Windowsのビルドが通ることを確認します。
