### PR TITLE
Fix Windows test DLL discovery without PATH workarounds

### DIFF
--- a/.github/workflows/python-cffi-tests.yml
+++ b/.github/workflows/python-cffi-tests.yml
@@ -136,28 +136,14 @@ jobs:
           $rpc = Get-ChildItem -Path "$env:GITHUB_WORKSPACE/build" -Recurse -Filter "hakoniwa_pdu_rpc.dll" | Select-Object -First 1
           if (-not $rpc) { throw "hakoniwa_pdu_rpc.dll was not found" }
 
-          $dllDirs = @(
-            $rpc.DirectoryName,
-            "$env:GITHUB_WORKSPACE/endpoint-install/bin",
-            "$env:VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
-          ) | Where-Object { Test-Path $_ } | Select-Object -Unique
+          $endpoint = Get-ChildItem -Path "$env:GITHUB_WORKSPACE/endpoint-install" -Recurse -Filter "hakoniwa_pdu_endpoint.dll" | Select-Object -First 1
+          if (-not $endpoint) { throw "hakoniwa_pdu_endpoint.dll was not found" }
+
+          $tests = Get-ChildItem -Path "$env:GITHUB_WORKSPACE/python" -Filter "test_cffi_*.py" | Sort-Object FullName | ForEach-Object { $_.FullName }
+          if (-not $tests) { throw "Python CFFI contract tests were not found" }
 
           $env:HAKO_PDU_RPC_LIBRARY = $rpc.FullName
+          $env:HAKO_PDU_ENDPOINT_LIBRARY = $endpoint.FullName
           $env:PYTHONPATH = "$env:GITHUB_WORKSPACE/python"
-          $env:HAKO_PDU_RPC_DLL_DIRS = ($dllDirs -join [IO.Path]::PathSeparator)
-          $env:PATH = "$($dllDirs -join ';');$env:PATH"
 
-          @'
-          import os
-          from pathlib import Path
-
-          import pytest
-
-          handles = []
-          for directory in os.environ["HAKO_PDU_RPC_DLL_DIRS"].split(os.pathsep):
-              if directory:
-                  handles.append(os.add_dll_directory(directory))
-
-          tests = [str(path) for path in sorted(Path("python").glob("test_cffi_*.py"))]
-          raise SystemExit(pytest.main(["-q", *tests]))
-          '@ | python -
+          python -m pytest -q @tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,25 @@ endif()
 # separately by the Python CFFI integration suite.
 set(HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY hakoniwa_pdu_rpc::rpc)
 
+function(hako_pdu_rpc_stage_windows_test_dlls target)
+  if(NOT WIN32)
+    return()
+  endif()
+
+  # CTest does not inherit the DLL discovery performed by the Python package.
+  # Stage the runtime DLLs beside each test executable so Windows follows its
+  # normal application-directory lookup without modifying PATH globally.
+  add_custom_command(TARGET ${target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      $<TARGET_FILE:hakoniwa_pdu_rpc_shared>
+      $<TARGET_FILE_DIR:${target}>
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      $<TARGET_FILE:hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint>
+      $<TARGET_FILE_DIR:${target}>
+    VERBATIM
+  )
+endfunction()
+
 add_executable(hakoniwa_pdu_action_configuration_test
   action_configuration_contract_test.cpp
 )
@@ -126,3 +145,23 @@ add_executable(hakoniwa_pdu_rpc_c_api_cancel_race_test
 target_link_libraries(hakoniwa_pdu_rpc_c_api_cancel_race_test PRIVATE ${HAKO_PDU_RPC_NATIVE_CONTRACT_LIBRARY} GTest::gtest_main)
 add_test(NAME hakoniwa_pdu_rpc_c_api_cancel_race_test COMMAND hakoniwa_pdu_rpc_c_api_cancel_race_test)
 set_tests_properties(hakoniwa_pdu_rpc_c_api_cancel_race_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" TIMEOUT 30)
+
+set(HAKO_PDU_RPC_NATIVE_CONTRACT_TARGETS
+  hakoniwa_pdu_action_configuration_test
+  hakoniwa_pdu_action_server_initialization_test
+  hakoniwa_pdu_action_packet_codec_test
+  hakoniwa_pdu_rpc_basic_test
+  hakoniwa_pdu_rpc_mux_server_test
+  hakoniwa_pdu_rpc_c_api_mux_server_test
+  hakoniwa_pdu_rpc_c_api_basic_test
+  hakoniwa_pdu_rpc_infinite_wait_test
+  hakoniwa_pdu_rpc_c_api_infinite_wait_test
+  hakoniwa_pdu_rpc_timeout_cancel_test
+  hakoniwa_pdu_rpc_c_api_timeout_cancel_test
+  hakoniwa_pdu_rpc_cancel_race_test
+  hakoniwa_pdu_rpc_c_api_cancel_race_test
+)
+
+foreach(target IN LISTS HAKO_PDU_RPC_NATIVE_CONTRACT_TARGETS)
+  hako_pdu_rpc_stage_windows_test_dlls(${target})
+endforeach()


### PR DESCRIPTION
## 概要

Windows上のCFFIテストとnative `ctest`に残っていたDLL探索の回避処理を整理します。

This follows the original-environment verification reported in PR #63:
https://github.com/hakoniwalab/hakoniwa-pdu-rpc/pull/63#issuecomment-5163944298

## 変更内容

- Windows CFFI CIから以下の補償処理を削除
  - `PATH`へのDLL directory追加
  - `os.add_dll_directory()`を行うinline Python runner
  - vcpkg runtime directoryの明示追加
- CFFIテストは次の正式なライブラリ指定だけで実行
  - `HAKO_PDU_RPC_LIBRARY`
  - `HAKO_PDU_ENDPOINT_LIBRARY`
- Windows native contract testでは、RPC／Endpoint DLLを各test executableと同じdirectoryへpost-buildで配置
- global `PATH`を変更せず、Windows標準のapplication-directory DLL lookupを利用

## 期待する結果

- Windows CFFI 18 testsが回避処理なしで成功する
- `python tools/hako.py test`が`0xC0000135`で終了しない
- Linux／macOSのテスト挙動は変更しない
