### PR TITLE
Fix Windows parallel link PDB collision

### DIFF
--- a/.github/workflows/rpc-cancel-race-tests.yml
+++ b/.github/workflows/rpc-cancel-race-tests.yml
@@ -67,7 +67,14 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          for attempt in 1 2 3; do
+            git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint && break
+            rm -rf endpoint
+            if [[ "$attempt" == "3" ]]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
           cmake -S endpoint -B endpoint/build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
@@ -86,7 +93,21 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+          $cloned = $false
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            git clone https://github.com/hakoniwalab/hakoniwa-pdu-endpoint.git endpoint
+            if ($LASTEXITCODE -eq 0) {
+              $cloned = $true
+              break
+            }
+            Remove-Item -Recurse -Force endpoint -ErrorAction SilentlyContinue
+            if ($attempt -lt 3) {
+              Start-Sleep -Seconds ($attempt * 10)
+            }
+          }
+          if (-not $cloned) {
+            throw "Failed to clone hakoniwa-pdu-endpoint after 3 attempts"
+          }
           cmake -S endpoint -B endpoint/build -A x64 `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=x64-windows `

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,13 +57,15 @@ add_library(hakoniwa_pdu_rpc::hakoniwa_pdu_rpc ALIAS hakoniwa_pdu_rpc)
 # Build the CFFI-loadable artifact beside the static library from the same
 # sources. The runtime file keeps the established hakoniwa_pdu_rpc name, while
 # its Windows import library uses a distinct name to avoid colliding with the
-# real static hakoniwa_pdu_rpc.lib.
+# real static hakoniwa_pdu_rpc.lib. Keep the linker PDB distinct as well:
+# multi-config Visual Studio builds may link both targets concurrently.
 add_library(hakoniwa_pdu_rpc_shared SHARED ${HAKO_PDU_RPC_SOURCES})
 hako_pdu_rpc_configure_target(hakoniwa_pdu_rpc_shared)
 set_target_properties(hakoniwa_pdu_rpc_shared PROPERTIES
   EXPORT_NAME rpc_shared
   OUTPUT_NAME hakoniwa_pdu_rpc
   ARCHIVE_OUTPUT_NAME hakoniwa_pdu_rpc_shared
+  PDB_NAME hakoniwa_pdu_rpc_shared
   WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
 


### PR DESCRIPTION
## 概要

Windows Debugの並列ビルドで、static/shared両ターゲットが同じ`hakoniwa_pdu_rpc.pdb`へ書き込もうとして`LNK1201`になる問題を修正します。

## 原因

`hakoniwa_pdu_rpc_shared`はruntime DLL名を互換性のため`hakoniwa_pdu_rpc.dll`にしています。その結果、Visual Studio multi-config buildではlinker PDBも`hakoniwa_pdu_rpc.pdb`となり、同時にビルドされるstatic target側と名前が衝突する可能性がありました。

Observed failure:

```text
LINK : fatal error LNK1201: error writing to program database ...\hakoniwa_pdu_rpc.pdb
```

## 修正

shared targetのlinker PDBだけを明示的に分離します。

```cmake
PDB_NAME hakoniwa_pdu_rpc_shared
```

DLL、static library、import libraryの既存ファイル名と公開契約は変更しません。
