### PR TITLE
ci: install Python dependencies before generator tests

### DIFF
--- a/.github/workflows/action-contract-tests.yml
+++ b/.github/workflows/action-contract-tests.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install Python package dependencies
+        run: python -m pip install -e .
+
       - name: Test hako.py contracts
         run: python -m unittest tools/test_hako.py tools/test_hako_operations.py -v
 

--- a/.github/workflows/package-contract.yml
+++ b/.github/workflows/package-contract.yml
@@ -83,6 +83,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install Python package dependencies
+        run: python -m pip install -e .
+
       - name: Test build manifest and operation contracts
         run: python -m unittest tools/test_hako.py tools/test_hako_operations.py -v
 


### PR DESCRIPTION
## Summary

- install the repository Python package with `python -m pip install -e .` before source-tree generator contract tests
- apply the same setup to both `package-contract` and `action-contract-tests`
- keep `pyproject.toml` as the single source of truth for Python dependencies such as `cffi` and `jsonschema`

## Root cause

The newly added configuration generator tests import `hakoniwa_pdu_rpc`, whose package initialization reaches the CFFI runtime. GitHub Actions set up Python but did not install the package dependencies first, so the jobs failed with `ModuleNotFoundError: No module named 'cffi'` before the native build steps ran.

## Impact

This should restore the generator contract tests on clean CI runners without duplicating dependency versions in workflow YAML.

## Validation

The PR itself is intended to exercise both pull-request workflows across the existing Linux, macOS, Windows, and ARM matrices. Because the prior failure happened before the remaining build/test stages, those downstream stages should also be checked after this dependency fix passes.